### PR TITLE
debezium/dbz#1550 Recover incremental snapshot schemas via SHOW CREATE TABLE

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.DefaultValueConverter;
@@ -29,6 +30,7 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.relational.TableSchemaBuilder;
+import io.debezium.relational.Tables;
 import io.debezium.relational.ValueConverterProvider;
 import io.debezium.relational.ddl.DdlChanges;
 import io.debezium.relational.ddl.DdlParser;
@@ -62,6 +64,8 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
     private final Map<Long, TableId> tableIdsByTableNumber = new ConcurrentHashMap<>();
     private final Map<Long, TableId> excludeTableIdsByTableNumber = new ConcurrentHashMap<>();
     private final BinlogConnectorConfig connectorConfig;
+    private final V valueConverter;
+    private final boolean tableIdCaseInsensitive;
 
     /**
      * Creates a binlog-connector based relational schema based on the supplied configuration. The DDL
@@ -100,6 +104,27 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         this.ddlParser = createDdlParser(connectorConfig, valueConverter);
         this.connectorConfig = connectorConfig;
         this.filters = connectorConfig.getTableFilters();
+        this.valueConverter = valueConverter;
+        this.tableIdCaseInsensitive = tableIdCaseInsensitive;
+    }
+
+    /**
+     * Parses a table definition, as returned by {@code SHOW CREATE TABLE}, into a {@link Table} without
+     * mutating the live schema state. A short-lived parser instance is used so that the shared parser
+     * used for the streaming phase is not affected by this call (debezium/dbz#1550).
+     *
+     * @param tableId the fully-qualified identifier of the table the definition belongs to; should not be null
+     * @param createTableDdl the {@code CREATE TABLE} statement text; should not be null
+     * @param systemVariables the system variables for the connection that returned the table definition; should not be null
+     * @return the parsed table definition, or {@code null} if the statement did not produce the requested table
+     */
+    Table parseTableDefinition(TableId tableId, String createTableDdl, Map<String, String> systemVariables) {
+        final DdlParser parser = createDdlParser(connectorConfig, valueConverter);
+        final Tables parsedTables = new Tables(tableIdCaseInsensitive);
+        systemVariables.forEach((name, value) -> parser.systemVariables().setVariable(BinlogSystemVariables.BinlogScope.SESSION, name, value));
+        parser.setCurrentDatabase(tableId.catalog());
+        parser.parse(createTableDdl, parsedTables);
+        return parsedTables.forTable(tableId);
     }
 
     @Override

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogIncrementalSnapshotSchemaReader.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogIncrementalSnapshotSchemaReader.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+/**
+ * Reads the current definition of a table using {@code SHOW CREATE TABLE} and parses it with the
+ * connector's DDL parser, so that the resulting {@link Table} model is identical to the one the
+ * snapshot and streaming phases would produce.
+ * <p>
+ * This is used by the incremental snapshot schema fallback for tables that are missing from the
+ * schema history. Reading the schema from JDBC {@code DatabaseMetaData} instead yields different
+ * JDBC types for binlog connectors. For example, a {@code TIMESTAMP} column is reported as
+ * {@link java.sql.Types#TIMESTAMP} with the display size (19) as its length rather than
+ * {@link java.sql.Types#TIMESTAMP_WITH_TIMEZONE} with the fractional seconds precision. This
+ * produces a drifting event schema ({@code io.debezium.time.NanoTimestamp} instead of
+ * {@code io.debezium.time.ZonedTimestamp}), loses column defaults, and subsequently fails value
+ * conversion for streamed changes (debezium/dbz#1550).
+ */
+final class BinlogIncrementalSnapshotSchemaReader {
+
+    private BinlogIncrementalSnapshotSchemaReader() {
+    }
+
+    /**
+     * Reads and parses the current definition of the given table.
+     *
+     * @param connection the JDBC connection to query the database; should not be null
+     * @param schema the connector's database schema, used to parse the definition; should not be null
+     * @param tableId the fully-qualified identifier of the table; should not be null
+     * @return the parsed table definition; never null
+     * @throws SQLException if the table definition cannot be read
+     * @throws DebeziumException if the definition cannot be parsed into the requested table
+     */
+    static Table readSchemaViaShowCreateTable(BinlogConnectorConnection connection, BinlogDatabaseSchema<?, ?, ?, ?> schema, TableId tableId)
+            throws SQLException {
+        final String createTableDdl = connection.queryAndMap(
+                "SHOW CREATE TABLE " + connection.quotedTableIdString(tableId),
+                rs -> rs.next() ? rs.getString(2) : null);
+        if (createTableDdl == null) {
+            throw new DebeziumException("SHOW CREATE TABLE returned no definition for table '" + tableId + "'");
+        }
+
+        final Map<String, String> systemVariables = new HashMap<>(connection.readCharsetSystemVariables());
+        systemVariables.putAll(connection.readSqlModeSystemVariable());
+        final Table table = schema.parseTableDefinition(tableId, createTableDdl, systemVariables);
+        if (table == null) {
+            throw new DebeziumException("Failed to parse the definition of table '" + tableId + "'");
+        }
+        return table;
+    }
+}

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.binlog.gtid.GtidSet;
 import io.debezium.connector.binlog.gtid.GtidSetFactory;
 import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
-import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalPayload;
@@ -27,7 +26,6 @@ import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
-import io.debezium.schema.DatabaseSchema;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
@@ -40,27 +38,21 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
     private static final Logger LOGGER = LoggerFactory.getLogger(BinlogReadOnlyIncrementalSnapshotChangeEventSource.class);
 
     private final GtidSetFactory gtidSetFactory;
-    private final BinlogDatabaseSchema<?, ?, ?, ?> binlogDatabaseSchema;
+    private final BinlogDatabaseSchema<P, ?, ?, ?> binlogDatabaseSchema;
     private final BinlogConnectorConnection binlogConnectorConnection;
 
     public BinlogReadOnlyIncrementalSnapshotChangeEventSource(BinlogConnectorConfig connectorConfig,
-                                                              JdbcConnection jdbcConnection,
+                                                              BinlogConnectorConnection jdbcConnection,
                                                               EventDispatcher<P, TableId> dispatcher,
-                                                              DatabaseSchema<?> databaseSchema,
+                                                              BinlogDatabaseSchema<P, ?, ?, ?> databaseSchema,
                                                               Clock clock,
                                                               SnapshotProgressListener<P> progressListener,
                                                               DataChangeEventListener<P> dataChangeEventListener,
                                                               NotificationService<P, O> notificationService) {
         super(connectorConfig, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.gtidSetFactory = connectorConfig.getGtidSetFactory();
-        if (!(databaseSchema instanceof BinlogDatabaseSchema<?, ?, ?, ?> binlogDatabaseSchema)) {
-            throw new IllegalArgumentException("Database schema must be a BinlogDatabaseSchema");
-        }
-        if (!(jdbcConnection instanceof BinlogConnectorConnection binlogConnectorConnection)) {
-            throw new IllegalArgumentException("JDBC connection must be a BinlogConnectorConnection");
-        }
-        this.binlogDatabaseSchema = binlogDatabaseSchema;
-        this.binlogConnectorConnection = binlogConnectorConnection;
+        this.binlogDatabaseSchema = databaseSchema;
+        this.binlogConnectorConnection = jdbcConnection;
     }
 
     @Override

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.binlog;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.binlog.gtid.GtidSet;
 import io.debezium.connector.binlog.gtid.GtidSetFactory;
+import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
@@ -23,6 +25,7 @@ import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnaps
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.spi.schema.DataCollectionId;
@@ -37,6 +40,8 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
     private static final Logger LOGGER = LoggerFactory.getLogger(BinlogReadOnlyIncrementalSnapshotChangeEventSource.class);
 
     private final GtidSetFactory gtidSetFactory;
+    private final BinlogDatabaseSchema<?, ?, ?, ?> binlogDatabaseSchema;
+    private final BinlogConnectorConnection binlogConnectorConnection;
 
     public BinlogReadOnlyIncrementalSnapshotChangeEventSource(BinlogConnectorConfig connectorConfig,
                                                               JdbcConnection jdbcConnection,
@@ -48,6 +53,22 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
                                                               NotificationService<P, O> notificationService) {
         super(connectorConfig, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.gtidSetFactory = connectorConfig.getGtidSetFactory();
+        if (!(databaseSchema instanceof BinlogDatabaseSchema<?, ?, ?, ?> binlogDatabaseSchema)) {
+            throw new IllegalArgumentException("Database schema must be a BinlogDatabaseSchema");
+        }
+        if (!(jdbcConnection instanceof BinlogConnectorConnection binlogConnectorConnection)) {
+            throw new IllegalArgumentException("JDBC connection must be a BinlogConnectorConnection");
+        }
+        this.binlogDatabaseSchema = binlogDatabaseSchema;
+        this.binlogConnectorConnection = binlogConnectorConnection;
+    }
+
+    @Override
+    protected Table readSchemaForTable(TableId tableId) throws SQLException {
+        // Binlog-based connectors build all table models by parsing DDL; reading the schema from JDBC
+        // DatabaseMetaData yields a diverging model (debezium/dbz#1550), so read the definition via
+        // SHOW CREATE TABLE and the connector's DDL parser instead.
+        return BinlogIncrementalSnapshotSchemaReader.readSchemaViaShowCreateTable(binlogConnectorConnection, binlogDatabaseSchema, tableId);
     }
 
     @Override

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import java.sql.SQLException;
+
+import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+/**
+ * A signal-based incremental snapshot change event source for binlog-based connectors.
+ * <p>
+ * Binlog-based connectors build all table models by parsing DDL. When the schema of a snapshotted
+ * table is missing from the schema history, the generic fallback reads it from JDBC
+ * {@code DatabaseMetaData}, which yields a diverging model (debezium/dbz#1550); this subclass reads
+ * the definition via {@code SHOW CREATE TABLE} and the connector's DDL parser instead, matching the
+ * snapshot and streaming phases.
+ */
+public class BinlogSignalBasedIncrementalSnapshotChangeEventSource<P extends BinlogPartition>
+        extends SignalBasedIncrementalSnapshotChangeEventSource<P, TableId> {
+
+    private final BinlogDatabaseSchema<P, ?, ?, ?> schema;
+    private final BinlogConnectorConnection binlogConnectorConnection;
+
+    public BinlogSignalBasedIncrementalSnapshotChangeEventSource(BinlogConnectorConfig config,
+                                                                 BinlogConnectorConnection jdbcConnection,
+                                                                 EventDispatcher<P, TableId> dispatcher,
+                                                                 BinlogDatabaseSchema<P, ?, ?, ?> databaseSchema,
+                                                                 Clock clock,
+                                                                 SnapshotProgressListener<P> progressListener,
+                                                                 DataChangeEventListener<P> dataChangeEventListener,
+                                                                 NotificationService<P, ? extends OffsetContext> notificationService) {
+        super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
+        this.schema = databaseSchema;
+        this.binlogConnectorConnection = jdbcConnection;
+    }
+
+    @Override
+    protected Table readSchemaForTable(TableId tableId) throws SQLException {
+        return BinlogIncrementalSnapshotSchemaReader.readSchemaViaShowCreateTable(binlogConnectorConnection, schema, tableId);
+    }
+}

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogIncrementalSnapshotIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogIncrementalSnapshotIT.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -48,6 +49,7 @@ import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnaps
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.SchemaHistory;
+import io.debezium.time.ZonedTimestamp;
 
 public abstract class BinlogIncrementalSnapshotIT<C extends SourceConnector>
         extends AbstractIncrementalSnapshotWithSchemaChangesSupportTest<C>
@@ -437,5 +439,90 @@ public abstract class BinlogIncrementalSnapshotIT<C extends SourceConnector>
         try (JdbcConnection connection = databaseConnection()) {
             populate4PkTable(connection, "a4");
         }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1550")
+    public void schemaOfTableMissingFromHistoryIsReadWithDdlParser() throws Exception {
+        // Phase 1: capture only table "a"; the DDL of any other table is not recorded in the history
+        final String initialTableIncludeList = DATABASE.qualifiedTableName("a") + "," + DATABASE.qualifiedTableName("debezium_signal");
+        populateTable();
+        startConnector(x -> x
+                .without(BinlogConnectorConfig.TABLE_EXCLUDE_LIST.name())
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, initialTableIncludeList)
+                .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, true)
+                .with(SchemaHistory.STORE_ONLY_CAPTURED_DATABASES_DDL, true));
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        // Create a table that is NOT captured, then move the offset past its DDL by streaming an
+        // unrelated change, so that after a restart the table's schema is missing from the history
+        // and its CREATE TABLE statement is no longer reachable from the resume position
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute(
+                    "CREATE TABLE b1550 ("
+                            + "id BIGINT PRIMARY KEY,"
+                            + "created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                            + "amount DECIMAL(10,2))",
+                    "INSERT INTO b1550 (id, amount) VALUES (1, 10.00)",
+                    "UPDATE a SET aa = 42 WHERE pk = 1");
+        }
+        assertThat(consumeRecordsForTopic(DATABASE.topicForTable("a"), 1)).hasSize(1);
+        stopConnector();
+
+        // Phase 2: expand the filter to include the new table and restart
+        final Configuration expandedConfig = config()
+                .without(BinlogConnectorConfig.TABLE_EXCLUDE_LIST.name())
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, initialTableIncludeList + "," + DATABASE.qualifiedTableName("b1550"))
+                .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, true)
+                .with(SchemaHistory.STORE_ONLY_CAPTURED_DATABASES_DDL, true)
+                .build();
+        start(connectorClass(), expandedConfig);
+        waitForConnectorToStart();
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        sendAdHocSnapshotSignal(DATABASE.qualifiedTableName("b1550"));
+
+        // The recovered schema must match the DDL-parsing paths. The previous JDBC metadata fallback
+        // reported TIMESTAMP with the display size as length, emitting an INT64
+        // io.debezium.time.NanoTimestamp field without the column default.
+        final SourceRecord read = consumeRecordsForTopic(DATABASE.topicForTable("b1550"), 1).get(0);
+        final Schema createdAtSchema = read.valueSchema().field("after").schema().field("created_at").schema();
+        assertThat(createdAtSchema.name()).isEqualTo(ZonedTimestamp.SCHEMA_NAME);
+        assertThat(createdAtSchema.defaultValue()).isNotNull();
+
+        // Streaming an update that does not touch the timestamp column must not fail the task with
+        // "Invalid value: null used for required field"
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute("UPDATE b1550 SET amount = 20.00 WHERE id = 1");
+        }
+        final SourceRecord update = consumeRecordsForTopic(DATABASE.topicForTable("b1550"), 1).get(0);
+        final Struct after = ((Struct) update.value()).getStruct("after");
+        assertThat(after.get("created_at")).isNotNull();
+
+        // The recovered table model must be persisted to schema history and survive another restart.
+        stopConnector();
+        start(connectorClass(), expandedConfig);
+        waitForConnectorToStart();
+        waitForStreamingRunning(getConnectorName(), DATABASE.getServerName());
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.execute("UPDATE b1550 SET amount = 30.00 WHERE id = 1");
+        }
+        final SourceRecord updateAfterRestart = consumeRecordsForTopic(DATABASE.topicForTable("b1550"), 1).get(0);
+        final Struct afterRestart = ((Struct) updateAfterRestart.value()).getStruct("after");
+        assertThat(afterRestart.get("created_at")).isNotNull();
+    }
+
+    private List<SourceRecord> consumeRecordsForTopic(String topicName, int expectedCount) {
+        final List<SourceRecord> records = new ArrayList<>();
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> {
+            consumeAvailableRecords(r -> {
+                if (r.topic().equals(topicName)) {
+                    records.add(r);
+                }
+            });
+            return records.size() >= expectedCount;
+        });
+        return records;
     }
 }

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbChangeEventSourceFactory.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbChangeEventSourceFactory.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 
 import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.binlog.BinlogSignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
 import io.debezium.connector.mariadb.metrics.MariaDbSnapshotChangeEventSourceMetrics;
 import io.debezium.connector.mariadb.metrics.MariaDbStreamingChangeEventSourceMetrics;
@@ -22,7 +23,6 @@ import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
-import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
@@ -138,7 +138,7 @@ public class MariaDbChangeEventSourceFactory implements ChangeEventSourceFactory
             return Optional.empty();
         }
 
-        return Optional.of(new SignalBasedIncrementalSnapshotChangeEventSource<>(
+        return Optional.of(new BinlogSignalBasedIncrementalSnapshotChangeEventSource<>(
                 configuration,
                 connectionFactory.mainConnection(),
                 dispatcher,

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -11,14 +11,13 @@ import java.util.function.Consumer;
 import io.debezium.DebeziumException;
 import io.debezium.connector.binlog.BinlogReadOnlyIncrementalSnapshotChangeEventSource;
 import io.debezium.connector.binlog.gtid.GtidSet;
+import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
 import io.debezium.connector.mariadb.gtid.MariaDbGtidSet;
-import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.relational.TableId;
-import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Clock;
 
 /**
@@ -29,9 +28,9 @@ public class MariaDbReadOnlyIncrementalSnapshotChangeEventSource
         extends BinlogReadOnlyIncrementalSnapshotChangeEventSource<MariaDbPartition, MariaDbOffsetContext> {
 
     public MariaDbReadOnlyIncrementalSnapshotChangeEventSource(MariaDbConnectorConfig connectorConfig,
-                                                               JdbcConnection jdbcConnection,
+                                                               BinlogConnectorConnection jdbcConnection,
                                                                EventDispatcher<MariaDbPartition, TableId> dispatcher,
-                                                               DatabaseSchema<?> databaseSchema,
+                                                               MariaDbDatabaseSchema databaseSchema,
                                                                Clock clock,
                                                                SnapshotProgressListener<MariaDbPartition> progressListener,
                                                                DataChangeEventListener<MariaDbPartition> dataChangeEventListener,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 
 import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.binlog.BinlogSignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.DataChangeEvent;
@@ -20,7 +21,6 @@ import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
-import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
@@ -137,7 +137,7 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
         if (configuration.getSignalingDataCollectionIds().isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(new SignalBasedIncrementalSnapshotChangeEventSource<>(
+        return Optional.of(new BinlogSignalBasedIncrementalSnapshotChangeEventSource<>(
                 configuration,
                 connectionFactory.mainConnection(),
                 dispatcher,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -18,7 +18,6 @@ import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.relational.TableId;
-import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Clock;
 
 /**
@@ -76,7 +75,7 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource extends BinlogRea
     public MySqlReadOnlyIncrementalSnapshotChangeEventSource(MySqlConnectorConfig config,
                                                              BinlogConnectorConnection jdbcConnection,
                                                              EventDispatcher<MySqlPartition, TableId> dispatcher,
-                                                             DatabaseSchema<?> databaseSchema,
+                                                             MySqlDatabaseSchema databaseSchema,
                                                              Clock clock,
                                                              SnapshotProgressListener<MySqlPartition> progressListener,
                                                              DataChangeEventListener<MySqlPartition> dataChangeEventListener,


### PR DESCRIPTION
Fixes debezium/dbz#1550

## Description

When a table is added to the capture list after its CREATE TABLE event is no longer reachable from the connector offset and is absent from schema history, incremental snapshots previously recovered its schema through JDBC metadata.

For MySQL TIMESTAMP columns, this produced a schema inconsistent with the regular snapshot and streaming DDL parsing paths, including an incorrect temporal logical type and missing column defaults.

This change:

- Retrieves missing table definitions using SHOW CREATE TABLE.
- Parses them with an isolated connector DDL parser using the current charset and SQL mode.
- Applies the same behavior to signal-based and read-only incremental snapshots for MySQL and MariaDB.
- Does not fall back to JDBC metadata when schema retrieval or parsing fails. Existing UNKNOWN_SCHEMA handling skips the affected table.
- Adds regression coverage for type fidelity, streamed updates, and schema-history recovery after restart.

## Testing

- MySQL signal-based incremental snapshot integration test
- MySQL GTID read-only incremental snapshot integration test
- MariaDB signal-based incremental snapshot integration test
- MariaDB GTID read-only incremental snapshot integration test
- Relevant module unit tests, formatting, checkstyle, and diff validation

## PR Checklist

- [x] I have read the contribution guidelines and governance document on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature/change per PR
- [x] Rebased on upstream main