### PR TITLE
debezium/dbz#2531 Resolve ambiguous partial rollbacks to the most recent transaction and prune stale deferred entries

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -189,6 +189,7 @@ Debjeet Sarkar
 Deepak Barr
 Denis Andrejew
 Denis Mikhaylov
+Deniz Ozogul
 Dennis Campagna
 Dennis Persson
 Derek Moore

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -667,13 +667,48 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
                     }
                 }
                 else {
-                    // Multiple matches - ambiguous, cannot determine which to rollback
-                    // TODO: Investigate whether this scenario is possible and if so, how to disambiguate
-                    LOGGER.warn("Unable to match partial transaction '{}' to a single transaction. Found {} transactions " +
-                            "with prefix '{}'. Cannot determine which transaction to rollback. " +
-                            "Manual investigation required. Transactions: {}",
-                            transactionId, matchingTransactions.size(), prefix,
-                            matchingTransactions.stream().map(MatchedTransaction::transactionId).collect(Collectors.joining(", ")));
+                    // Multiple candidates share the rollback's undo segment and slot prefix. Oracle
+                    // reuses an undo slot only after the transaction that previously occupied it has
+                    // ended, so of all candidates only the one with the highest start SCN can still
+                    // be in progress, and it is the one this rollback terminates.
+                    final MatchedTransaction matched = matchingTransactions.stream()
+                            .max(Comparator.comparing(MatchedTransaction::startScn))
+                            .orElseThrow();
+
+                    LOGGER.warn("Matched partial transaction '{}' to the most recent of {} transactions with prefix '{}', " +
+                            "the {} transaction '{}' (startScn={}, changeTime={}). Rolling back the matched transaction.",
+                            transactionId,
+                            matchingTransactions.size(),
+                            prefix,
+                            matched.deferred() ? "deferred" : "cached",
+                            matched.transactionId(),
+                            matched.startScn(),
+                            matched.changeTime());
+
+                    if (matched.deferred()) {
+                        removeDeferredTransaction(matched.transactionId());
+                    }
+                    else {
+                        finalizeTransaction(matched.transactionId(), event.getScn(), true);
+                        getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
+                        getMetrics().setBufferedEventCount(getTransactionCache().getTransactionEvents());
+                    }
+
+                    // Any older candidate's undo slot has since been reused, which proves that its
+                    // transaction already ended and that its terminal event was never matched. Stale
+                    // deferred entries would otherwise pin the offset SCN low watermark until the
+                    // deferred transaction retention expires; removing them is safe because a deferred
+                    // entry holds no events and a later DML event recreates the transaction. Cached
+                    // candidates are intentionally left untouched because they may carry events.
+                    for (MatchedTransaction candidate : matchingTransactions) {
+                        if (candidate != matched && candidate.deferred() && removeDeferredTransaction(candidate.transactionId())) {
+                            LOGGER.warn("Removed stale deferred transaction '{}' (startScn={}, changeTime={}) whose undo " +
+                                    "slot was reused; its terminal event was never matched.",
+                                    candidate.transactionId(),
+                                    candidate.startScn(),
+                                    candidate.changeTime());
+                        }
+                    }
                 }
             }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -436,6 +436,18 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
                 LOGGER.debug("Transaction {} was deferred with no DML events, removing on commit.", transactionId);
                 removedDeferredTransaction = true;
             }
+            else if (!Strings.isNullOrEmpty(transactionId) && transactionId.endsWith(NO_SEQUENCE_TRX_ID_SUFFIX)) {
+                // LogMiner could not resolve the commit's transaction sequence because the transaction
+                // was read in a prior mining session. There is no cached transaction to apply, but
+                // deferred entries with the same undo segment and slot prefix must still be cleaned
+                // up: the most recently started one is the transaction this commit terminates, and
+                // any older one's slot has since been reused, proving it already ended. Leaving them
+                // behind pins the offset SCN low watermark until the deferred transaction retention
+                // expires. Removal is safe because deferred entries hold no events. Cached
+                // transactions are intentionally not resolved by prefix here, since committing a
+                // guessed transaction would emit its events.
+                removedDeferredTransaction = removeDeferredTransactionsByPrefix(transactionId, "commit");
+            }
 
             if (!getOffsetContext().getCommitScn().hasEventScnBeenHandled(row)) {
                 LOGGER.debug("Transaction {} not found in cache with SCN {}, no events to commit.", transactionId, row.getScn());
@@ -725,6 +737,24 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
 
     private boolean removeDeferredTransaction(String transactionId) {
         return !Strings.isNullOrEmpty(transactionId) && deferredTransactions.remove(transactionId) != null;
+    }
+
+    private boolean removeDeferredTransactionsByPrefix(String partialTransactionId, String terminalEventName) {
+        final String prefix = partialTransactionId.substring(0, ORACLE_TRANSACTION_ID_PREFIX_LENGTH);
+        final List<DeferredTransaction> matches = deferredTransactions.values().stream()
+                .filter(t -> t.transactionId().startsWith(prefix))
+                .toList();
+        for (DeferredTransaction match : matches) {
+            deferredTransactions.remove(match.transactionId());
+            LOGGER.warn("Matched partial transaction '{}' {} to deferred transaction '{}' (startScn={}, changeTime={}); " +
+                    "removed the deferred entry.",
+                    partialTransactionId,
+                    terminalEventName,
+                    match.transactionId(),
+                    match.startScn(),
+                    match.changeTime());
+        }
+        return !matches.isEmpty();
     }
 
     private List<MatchedTransaction> getMatchingTransactionsByPrefix(String prefix) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -660,34 +660,15 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
                     LOGGER.debug("No matching transaction found for partial transaction '{}' with prefix '{}'",
                             transactionId, prefix);
                 }
-                else if (matchingTransactions.size() == 1) {
-                    final MatchedTransaction matched = matchingTransactions.get(0);
-                    LOGGER.warn("Matched partial transaction '{}' to {} transaction '{}' (startScn={}, changeTime={}). " +
-                            "Rolling back the matched transaction.",
-                            transactionId,
-                            matched.deferred() ? "deferred" : "cached",
-                            matched.transactionId(),
-                            matched.startScn(),
-                            matched.changeTime());
-                    if (matched.deferred()) {
-                        removeDeferredTransaction(matched.transactionId());
-                    }
-                    else {
-                        finalizeTransaction(matched.transactionId(), event.getScn(), true);
-                        getMetrics().setActiveTransactionCount(getTransactionCache().getTransactionCount());
-                        getMetrics().setBufferedEventCount(getTransactionCache().getTransactionEvents());
-                    }
-                }
                 else {
-                    // Multiple candidates share the rollback's undo segment and slot prefix. Oracle
-                    // reuses an undo slot only after the transaction that previously occupied it has
-                    // ended, so of all candidates only the one with the highest start SCN can still
-                    // be in progress, and it is the one this rollback terminates.
+                    // Oracle reuses an undo slot only after the transaction that previously occupied
+                    // it has ended, so of all same-prefix candidates only the one with the highest
+                    // start SCN can still be in progress, and it is the one this rollback terminates.
                     final MatchedTransaction matched = matchingTransactions.stream()
                             .max(Comparator.comparing(MatchedTransaction::startScn))
                             .orElseThrow();
 
-                    LOGGER.warn("Matched partial transaction '{}' to the most recent of {} transactions with prefix '{}', " +
+                    LOGGER.warn("Matched partial transaction '{}' to the most recent of {} transaction(s) with prefix '{}', " +
                             "the {} transaction '{}' (startScn={}, changeTime={}). Rolling back the matched transaction.",
                             transactionId,
                             matchingTransactions.size(),

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
@@ -213,6 +213,62 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    public void testPartialRollbackWithMultipleDeferredMatchesRollsBackLatestAndPrunesStale() throws Exception {
+        final String staleTransactionId = "12345678aaaaaaaa";
+        final String activeTransactionId = "12345678bbbbbbbb";
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(10, staleTransactionId));
+            source.processEvent(getStartLogMinerEventRow(20, activeTransactionId));
+
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(2);
+
+            source.processEvent(getRollbackLogMinerEventRow(30, "12345678ffffffff"));
+
+            assertThat(source.getDeferredTransactionCount()).isZero();
+            assertThat(source.getOldestDeferredTransactionStartScn()).isEqualTo(Scn.NULL);
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    public void testPartialRollbackWithCachedAndDeferredMatchesRollsBackLatestCachedAndPrunesStaleDeferred() throws Exception {
+        final String staleTransactionId = "12345678aaaaaaaa";
+        final String activeTransactionId = "12345678bbbbbbbb";
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(10, staleTransactionId));
+            source.processEvent(getStartLogMinerEventRow(20, activeTransactionId));
+            source.processEvent(getInsertLogMinerEventRow(21, activeTransactionId));
+
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(1);
+            assertThat(source.getTransactionCache().containsTransaction(activeTransactionId)).isTrue();
+
+            source.processEvent(getRollbackLogMinerEventRow(30, "12345678ffffffff"));
+
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+            assertThat(source.getDeferredTransactionCount()).isZero();
+        }
+    }
+
+    @Test
+    public void testPartialRollbackWithLatestDeferredMatchDoesNotTouchOlderCachedTransaction() throws Exception {
+        final String cachedTransactionId = "12345678aaaaaaaa";
+        final String deferredTransactionId = "12345678bbbbbbbb";
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(10, cachedTransactionId));
+            source.processEvent(getInsertLogMinerEventRow(11, cachedTransactionId));
+            source.processEvent(getStartLogMinerEventRow(20, deferredTransactionId));
+
+            source.processEvent(getRollbackLogMinerEventRow(30, "12345678ffffffff"));
+
+            assertThat(source.getDeferredTransactionCount()).isZero();
+            assertThat(source.getTransactionCache().containsTransaction(cachedTransactionId)).isTrue();
+        }
+    }
+
+    @Test
     public void testCacheIsEmptyWhenDeferredTransactionIsCommittedAfterDml() throws Exception {
         try (var source = getChangeEventSource(getConfig().build())) {
             source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
@@ -269,6 +269,55 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    public void testPartialCommitRemovesMatchingDeferredTransaction() throws Exception {
+        final String deferredTransactionId = "12345678abcdef01";
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(1, deferredTransactionId));
+
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(1);
+
+            source.processEvent(getCommitLogMinerEventRow(2, "12345678ffffffff"));
+
+            assertThat(source.getDeferredTransactionCount()).isZero();
+            assertThat(source.getTransactionCache().isEmpty()).isTrue();
+            Mockito.verify(commitScn).recordCommit(any(LogMinerEventRow.class));
+        }
+    }
+
+    @Test
+    public void testPartialCommitPrunesAllStaleDeferredMatches() throws Exception {
+        final String staleTransactionId = "12345678aaaaaaaa";
+        final String activeTransactionId = "12345678bbbbbbbb";
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(10, staleTransactionId));
+            source.processEvent(getStartLogMinerEventRow(20, activeTransactionId));
+
+            assertThat(source.getDeferredTransactionCount()).isEqualTo(2);
+
+            source.processEvent(getCommitLogMinerEventRow(30, "12345678ffffffff"));
+
+            assertThat(source.getDeferredTransactionCount()).isZero();
+            assertThat(source.getOldestDeferredTransactionStartScn()).isEqualTo(Scn.NULL);
+        }
+    }
+
+    @Test
+    public void testPartialCommitDoesNotTouchCachedTransaction() throws Exception {
+        final String cachedTransactionId = "12345678aaaaaaaa";
+
+        try (var source = getChangeEventSource(getConfig().build())) {
+            source.processEvent(getStartLogMinerEventRow(10, cachedTransactionId));
+            source.processEvent(getInsertLogMinerEventRow(11, cachedTransactionId));
+
+            source.processEvent(getCommitLogMinerEventRow(30, "12345678ffffffff"));
+
+            assertThat(source.getTransactionCache().containsTransaction(cachedTransactionId)).isTrue();
+        }
+    }
+
+    @Test
     public void testCacheIsEmptyWhenDeferredTransactionIsCommittedAfterDml() throws Exception {
         try (var source = getChangeEventSource(getConfig().build())) {
             source.processEvent(getStartLogMinerEventRow(1, TRANSACTION_ID_1));

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/buffered/DeferredMemoryStreamingChangeEventSourceTest.java
@@ -58,6 +58,7 @@ import io.debezium.connector.oracle.logminer.buffered.BufferedLogMinerStreamingC
 import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.EventDispatcher;
@@ -213,6 +214,7 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    @FixFor("debezium/dbz#2531")
     public void testPartialRollbackWithMultipleDeferredMatchesRollsBackLatestAndPrunesStale() throws Exception {
         final String staleTransactionId = "12345678aaaaaaaa";
         final String activeTransactionId = "12345678bbbbbbbb";
@@ -232,6 +234,7 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    @FixFor("debezium/dbz#2531")
     public void testPartialRollbackWithCachedAndDeferredMatchesRollsBackLatestCachedAndPrunesStaleDeferred() throws Exception {
         final String staleTransactionId = "12345678aaaaaaaa";
         final String activeTransactionId = "12345678bbbbbbbb";
@@ -252,6 +255,7 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    @FixFor("debezium/dbz#2531")
     public void testPartialRollbackWithLatestDeferredMatchDoesNotTouchOlderCachedTransaction() throws Exception {
         final String cachedTransactionId = "12345678aaaaaaaa";
         final String deferredTransactionId = "12345678bbbbbbbb";
@@ -269,6 +273,7 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    @FixFor("debezium/dbz#2531")
     public void testPartialCommitRemovesMatchingDeferredTransaction() throws Exception {
         final String deferredTransactionId = "12345678abcdef01";
 
@@ -286,6 +291,7 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    @FixFor("debezium/dbz#2531")
     public void testPartialCommitPrunesAllStaleDeferredMatches() throws Exception {
         final String staleTransactionId = "12345678aaaaaaaa";
         final String activeTransactionId = "12345678bbbbbbbb";
@@ -304,6 +310,7 @@ public class DeferredMemoryStreamingChangeEventSourceTest extends AbstractAsyncE
     }
 
     @Test
+    @FixFor("debezium/dbz#2531")
     public void testPartialCommitDoesNotTouchCachedTransaction() throws Exception {
         final String cachedTransactionId = "12345678aaaaaaaa";
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -414,3 +414,4 @@ tusharsaini18899,Tushar Saini
 tingley,Chase Tingley
 bhuvan-somisetty,bhuvan-somisetty
 akshat08,Akshat Sapra
+denizozogularas,Deniz Ozogul


### PR DESCRIPTION
Fixes debezium/dbz#2531

## Description

The `ffffffff` partial-transaction fallback currently exists only for rollbacks, and its ambiguous branch removes nothing. Both gaps leak deferred (START-only) entries, which then pin the offset SCN low watermark for the full `log.mining.buffer.deferred.transaction.retention.ms` (default 24h) — invisibly, since in deferred mode the mining window keeps sliding and the stale-offset warning only prints transaction cache ids. In our production case (details in the issue) a restart then had to re-mine ~10 hours of redo.

Two changes, one per commit:

**1. Ambiguous partial rollbacks are resolved instead of dropped.** Oracle reuses an undo slot only after the transaction that previously occupied it has ended, so of all same-prefix candidates only the one with the highest start SCN can still be in progress — the rollback is applied to that candidate (same semantics as the existing single-match branch). Every older *deferred* candidate's slot has provably been reused, so those stale entries are pruned; older *cached* candidates are left untouched since they may carry events.

**2. Partial commits now clean up deferred entries too.** `handleCommitEvent` had no prefix fallback at all: a COMMIT arriving from a later mining session with an unresolved sequence missed the deferred map on the exact key and logged only at DEBUG, leaking the entry silently (this is the path our production case actually hit — the day's WARN logs contain no ambiguous-match warning). A partial commit now removes matching deferred entries by prefix, with a WARN. Cached transactions are deliberately not resolved by prefix on the commit side, because committing a guessed transaction would emit its events.

Removing a deferred entry is lossless: it holds no events, and if a DML for it ever arrived, `enqueueEvent` recreates the transaction from the DML row.

Unit tests cover both terminal event types: multiple deferred matches, cached-latest + stale-deferred, deferred-latest + older cached (untouched), and the three partial-commit shapes.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
