### PR TITLE
debezium/dbz#2490 retry timescaledb transform on transient connection errors

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
@@ -6,11 +6,15 @@
 package io.debezium.connector.postgresql.transforms.timescaledb;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLTransientException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.kafka.connect.errors.RetriableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,7 +100,37 @@ public class QueryInformationSchemaMetadata extends AbstractTimescaleDbMetadata 
             });
         }
         catch (SQLException e) {
+            if (isRetriable(e)) {
+                try {
+                    connection.close();
+                }
+                catch (Exception closeError) {
+                    LOGGER.debug("Failed to close broken connection before reconnect", closeError);
+                }
+                try {
+                    connection.reconnect();
+                }
+                catch (SQLException reconnectError) {
+                    LOGGER.debug("Failed to reconnect after a retriable TimescaleDB metadata error", reconnectError);
+                }
+                throw new RetriableException("Failed to read TimescaleDB metadata", e);
+            }
             throw new DebeziumException("Failed to read TimescaleDB metadata", e);
         }
+    }
+
+    static boolean isRetriable(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLTransientException
+                    || current instanceof SQLRecoverableException) {
+                return true;
+            }
+            if (current instanceof SocketException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadataTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadataTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.transforms.timescaledb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLSyntaxErrorException;
+import java.sql.SQLTransientException;
+
+import org.junit.jupiter.api.Test;
+
+class QueryInformationSchemaMetadataTest {
+
+    @Test
+    void sqlTransientExceptionIsRetriable() {
+        assertThat(QueryInformationSchemaMetadata.isRetriable(new SQLTransientException("temporary"))).isTrue();
+    }
+
+    @Test
+    void sqlRecoverableExceptionIsRetriable() {
+        assertThat(QueryInformationSchemaMetadata.isRetriable(new SQLRecoverableException("recoverable"))).isTrue();
+    }
+
+    @Test
+    void socketResetWrappedInSqlExceptionIsRetriable() {
+        var psqlException = new SQLException("An I/O error occurred while sending to the backend");
+        psqlException.initCause(new SocketException("Connection reset by peer"));
+
+        assertThat(QueryInformationSchemaMetadata.isRetriable(psqlException)).isTrue();
+    }
+
+    @Test
+    void nestedSocketExceptionDeepInChainIsRetriable() {
+        var cause = new SocketException("Broken pipe");
+        var intermediate = new RuntimeException("wrapper", cause);
+        var outer = new SQLException("outer", intermediate);
+
+        assertThat(QueryInformationSchemaMetadata.isRetriable(outer)).isTrue();
+    }
+
+    @Test
+    void sqlSyntaxErrorIsNotRetriable() {
+        assertThat(QueryInformationSchemaMetadata.isRetriable(new SQLSyntaxErrorException("syntax error"))).isFalse();
+    }
+
+    @Test
+    void plainExceptionWithoutTransientCauseIsNotRetriable() {
+        assertThat(QueryInformationSchemaMetadata.isRetriable(new SQLException("some other failure"))).isFalse();
+        assertThat(QueryInformationSchemaMetadata.isRetriable(new RuntimeException("unexpected", new IOException("disk full")))).isFalse();
+    }
+
+    @Test
+    void nullThrowableIsNotRetriable() {
+        assertThat(QueryInformationSchemaMetadata.isRetriable(null)).isFalse();
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2490

## Description
<!-- Briefly describe your changes here. -->
JDBC socket failures raised by the Timescale metadata gathering step were raised as a plain non-retriable `DebeziumException`.
This PR adds a condition that checks for retriabiliity of individual exceptions related to network issues and similar retriable issues and reconnects to the database.
It tries to close the old connection first, in case there is still anything not cleanup up that would stay open with a simple `connection.reconnect()`. In the end, the old connection object is overwritten with a new one regardless and a `RetriableException` is thrown.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
