### PR TITLE
debezium/dbz#2379 Add pluggable claim-check storage

### DIFF
--- a/debezium-connect-plugins/pom.xml
+++ b/debezium-connect-plugins/pom.xml
@@ -18,6 +18,10 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-storage-api</artifactId>
+        </dependency>
 
         <!-- Kafka Connect API -->
         <dependency>

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/ClaimCheckRecordSerializer.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/ClaimCheckRecordSerializer.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.debezium.DebeziumException;
+import io.debezium.util.HexConverter;
 import io.debezium.util.Strings;
 
 final class ClaimCheckRecordSerializer {
@@ -164,11 +165,7 @@ final class ClaimCheckRecordSerializer {
     static String sha256Hex(byte[] data) {
         try {
             byte[] digest = MessageDigest.getInstance("SHA-256").digest(data);
-            StringBuilder hex = new StringBuilder(digest.length * 2);
-            for (byte value : digest) {
-                hex.append(String.format("%02x", value));
-            }
-            return hex.toString();
+            return HexConverter.convertToHexString(digest);
         }
         catch (NoSuchAlgorithmException e) {
             throw new DebeziumException("SHA-256 is not available", e);

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/ClaimCheckRecordSerializer.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/ClaimCheckRecordSerializer.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.DebeziumException;
+
+final class ClaimCheckRecordSerializer {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private ClaimCheckRecordSerializer() {
+    }
+
+    static SerializedRecord serialize(SourceRecord record) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("version", 1);
+        payload.put("topic", record.topic());
+        payload.put("sourcePartition", canonicalMap(record.sourcePartition()));
+        payload.put("sourceOffset", canonicalMap(record.sourceOffset()));
+        payload.put("key", connectValue(record.keySchema(), record.key()));
+        payload.put("value", connectValue(record.valueSchema(), record.value()));
+
+        try {
+            byte[] bytes = OBJECT_MAPPER.writeValueAsBytes(payload);
+            String payloadHash = sha256Hex(bytes);
+            Map<String, Object> sourcePosition = new LinkedHashMap<>();
+            sourcePosition.put("sourcePartition", canonicalMap(record.sourcePartition()));
+            sourcePosition.put("sourceOffset", canonicalMap(record.sourceOffset()));
+            String offsetHash = sha256Hex(OBJECT_MAPPER.writeValueAsBytes(sourcePosition));
+            String key = sanitize(record.topic()) + "/offset-" + offsetHash.substring(0, 16)
+                    + "-sha256-" + payloadHash + ".json";
+            return new SerializedRecord(key, bytes, payloadHash);
+        }
+        catch (JsonProcessingException e) {
+            throw new DebeziumException("Failed to serialize oversized record to JSON", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object connectValue(Schema schema, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (schema == null) {
+            return canonicalValue(value);
+        }
+
+        return switch (schema.type()) {
+            case STRUCT -> {
+                Struct struct = (Struct) value;
+                Map<String, Object> object = new LinkedHashMap<>();
+                for (org.apache.kafka.connect.data.Field field : schema.fields()) {
+                    object.put(field.name(), connectValue(field.schema(), struct.getWithoutDefault(field.name())));
+                }
+                yield object;
+            }
+            case ARRAY -> {
+                List<Object> values = new ArrayList<>();
+                for (Object element : (List<Object>) value) {
+                    values.add(connectValue(schema.valueSchema(), element));
+                }
+                yield values;
+            }
+            case MAP -> {
+                Map<Object, Object> map = (Map<Object, Object>) value;
+                Map<String, Object> mapped = new TreeMap<>();
+                for (Map.Entry<Object, Object> entry : map.entrySet()) {
+                    mapped.put(String.valueOf(entry.getKey()), connectValue(schema.valueSchema(), entry.getValue()));
+                }
+                yield mapped;
+            }
+            case BYTES -> Base64.getEncoder().encodeToString(bytes(value));
+            case STRING -> value.toString();
+            default -> value instanceof BigDecimal ? value.toString() : value;
+        };
+    }
+
+    private static Map<String, Object> canonicalMap(Map<String, ?> value) {
+        if (value == null || value.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> canonical = new TreeMap<>();
+        value.forEach((key, item) -> canonical.put(key, canonicalValue(item)));
+        return canonical;
+    }
+
+    private static Object canonicalValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> canonical = new TreeMap<>();
+            map.entrySet().stream()
+                    .sorted(Comparator.comparing(entry -> String.valueOf(entry.getKey())))
+                    .forEach(entry -> canonical.put(String.valueOf(entry.getKey()), canonicalValue(entry.getValue())));
+            return canonical;
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(ClaimCheckRecordSerializer::canonicalValue).toList();
+        }
+        if (value instanceof byte[] bytes) {
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+        if (value instanceof ByteBuffer buffer) {
+            return Base64.getEncoder().encodeToString(bytes(buffer));
+        }
+        return value;
+    }
+
+    private static byte[] bytes(Object value) {
+        if (value instanceof byte[] bytes) {
+            return bytes;
+        }
+        if (value instanceof ByteBuffer buffer) {
+            ByteBuffer copy = buffer.duplicate();
+            byte[] data = new byte[copy.remaining()];
+            copy.get(data);
+            return data;
+        }
+        if (value instanceof BigDecimal decimal) {
+            return decimal.unscaledValue().toByteArray();
+        }
+        throw new DebeziumException("Unsupported BYTES value type: " + value.getClass().getName());
+    }
+
+    private static String sanitize(String value) {
+        String candidate = value == null || value.isBlank() ? "unknown-topic" : value;
+        return candidate.replaceAll("[^A-Za-z0-9_.=-]", "_");
+    }
+
+    static String sha256Hex(byte[] data) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(data);
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte value : digest) {
+                hex.append(String.format("%02x", value));
+            }
+            return hex.toString();
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new DebeziumException("SHA-256 is not available", e);
+        }
+    }
+
+    record SerializedRecord(String key, byte[] payload, String sha256) {
+    }
+}

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/ClaimCheckRecordSerializer.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/ClaimCheckRecordSerializer.java
@@ -19,12 +19,14 @@ import java.util.TreeMap;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.debezium.DebeziumException;
+import io.debezium.util.Strings;
 
 final class ClaimCheckRecordSerializer {
 
@@ -39,6 +41,7 @@ final class ClaimCheckRecordSerializer {
         payload.put("topic", record.topic());
         payload.put("sourcePartition", canonicalMap(record.sourcePartition()));
         payload.put("sourceOffset", canonicalMap(record.sourceOffset()));
+        payload.put("headers", serializeHeaders(record));
         payload.put("key", connectValue(record.keySchema(), record.key()));
         payload.put("value", connectValue(record.valueSchema(), record.value()));
 
@@ -56,6 +59,17 @@ final class ClaimCheckRecordSerializer {
         catch (JsonProcessingException e) {
             throw new DebeziumException("Failed to serialize oversized record to JSON", e);
         }
+    }
+
+    private static List<Map<String, Object>> serializeHeaders(SourceRecord record) {
+        List<Map<String, Object>> headers = new ArrayList<>();
+        for (Header header : record.headers()) {
+            Map<String, Object> serializedHeader = new LinkedHashMap<>();
+            serializedHeader.put("key", header.key());
+            serializedHeader.put("value", connectValue(header.schema(), header.value()));
+            headers.add(serializedHeader);
+        }
+        return headers;
     }
 
     @SuppressWarnings("unchecked")
@@ -143,7 +157,7 @@ final class ClaimCheckRecordSerializer {
     }
 
     private static String sanitize(String value) {
-        String candidate = value == null || value.isBlank() ? "unknown-topic" : value;
+        String candidate = Strings.isNullOrBlank(value) ? "unknown-topic" : value;
         return candidate.replaceAll("[^A-Za-z0-9_.=-]", "_");
     }
 

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
@@ -6,9 +6,14 @@
 package io.debezium.transforms;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -17,12 +22,23 @@ import org.apache.kafka.connect.components.Versioned;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.DebeziumException;
 import io.debezium.Module;
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
+import io.debezium.config.Instantiator;
 import io.debezium.metadata.ConfigDescriptor;
+import io.debezium.spi.storage.OversizedRecord;
+import io.debezium.spi.storage.OversizedRecordReference;
+import io.debezium.spi.storage.OversizedRecordStorage;
 import io.debezium.util.ApproximateStructSizeCalculator;
 
 /**
@@ -37,6 +53,8 @@ import io.debezium.util.ApproximateStructSizeCalculator;
  *   <li>Proportional column truncation: truncates string/bytes columns proportionally
  *       (larger columns are truncated more). Columns at or below the configured
  *       minimum field size are excluded from truncation.</li>
+ *   <li>Claim check: writes the complete source record through a configured storage
+ *       implementation and replaces selected columns with a durable reference.</li>
  * </ul>
  *
  * String size is estimated using str.length() as a constant-time approximation.
@@ -47,9 +65,40 @@ import io.debezium.util.ApproximateStructSizeCalculator;
  */
 public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transformation<R>, Versioned, ConfigDescriptor {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     public static final String MAX_BYTES_CONF = "max.bytes";
     public static final String COMPRESSION_RATIO_CONF = "compression.ratio";
     public static final String MIN_FIELD_SIZE_CONF = "min.field.size";
+    public static final String STRATEGY_CONF = "strategy";
+    public static final String CLAIM_CHECK_STORAGE_CLASS_CONF = "claim.check.storage.class";
+    public static final String CLAIM_CHECK_COLUMNS_CONF = "claim.check.columns.include.list";
+    public static final String CLAIM_CHECK_STORAGE_CONFIG_PREFIX = "claim.check.storage.";
+
+    public enum Strategy implements EnumeratedValue {
+        TRUNCATE("truncate"),
+        CLAIM_CHECK("claim_check");
+
+        private final String value;
+
+        Strategy(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        static Strategy parse(String value) {
+            for (Strategy strategy : values()) {
+                if (strategy.value.equalsIgnoreCase(value)) {
+                    return strategy;
+                }
+            }
+            return null;
+        }
+    }
 
     private static final Field MAX_BYTES_FIELD = Field.create(MAX_BYTES_CONF)
             .withDisplayName("Maximum record size")
@@ -81,6 +130,28 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
                     "Only fields larger than this threshold are eligible for proportional truncation. " +
                     "Default is 25000 (25KB).");
 
+    private static final Field STRATEGY_FIELD = Field.create(STRATEGY_CONF)
+            .withDisplayName("Record size enforcement strategy")
+            .withEnum(Strategy.class, Strategy.TRUNCATE)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Strategy used for records that exceed 'max.bytes'. The default 'truncate' strategy " +
+                    "retains the existing proportional truncation behavior. The 'claim_check' strategy stores the " +
+                    "complete record externally and emits durable references in configured columns.");
+
+    private static final Field CLAIM_CHECK_STORAGE_CLASS_FIELD = Field.create(CLAIM_CHECK_STORAGE_CLASS_CONF)
+            .withDisplayName("Claim-check storage class")
+            .withType(ConfigDef.Type.STRING)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Fully-qualified OversizedRecordStorage implementation class. Required when strategy is 'claim_check'.");
+
+    private static final Field CLAIM_CHECK_COLUMNS_FIELD = Field.create(CLAIM_CHECK_COLUMNS_CONF)
+            .withDisplayName("Claim-check columns include list")
+            .withType(ConfigDef.Type.LIST)
+            .withDefault("")
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Comma-separated columns to replace with claim-check markers. Qualified column names are accepted; " +
+                    "matching uses the final column-name segment. Required when strategy is 'claim_check'.");
+
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(MAX_BYTES_CONF,
                     ConfigDef.Type.INT,
@@ -96,11 +167,30 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
                     ConfigDef.Type.INT,
                     25000,
                     ConfigDef.Importance.MEDIUM,
-                    MIN_FIELD_SIZE_FIELD.description());
+                    MIN_FIELD_SIZE_FIELD.description())
+            .define(STRATEGY_CONF,
+                    ConfigDef.Type.STRING,
+                    Strategy.TRUNCATE.getValue(),
+                    ConfigDef.ValidString.in(Strategy.TRUNCATE.getValue(), Strategy.CLAIM_CHECK.getValue()),
+                    ConfigDef.Importance.HIGH,
+                    STRATEGY_FIELD.description())
+            .define(CLAIM_CHECK_STORAGE_CLASS_CONF,
+                    ConfigDef.Type.STRING,
+                    null,
+                    ConfigDef.Importance.HIGH,
+                    CLAIM_CHECK_STORAGE_CLASS_FIELD.description())
+            .define(CLAIM_CHECK_COLUMNS_CONF,
+                    ConfigDef.Type.LIST,
+                    "",
+                    ConfigDef.Importance.HIGH,
+                    CLAIM_CHECK_COLUMNS_FIELD.description());
 
     private int maxBytes;
     private double compressionRatio;
     private int minFieldSize;
+    private Strategy strategy = Strategy.TRUNCATE;
+    private Set<String> claimCheckColumns = Set.of();
+    private OversizedRecordStorage claimCheckStorage;
 
     @Override
     public R apply(R record) {
@@ -120,6 +210,10 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
         long currentSize = (long) Math.ceil(rawEstimate * compressionRatio);
         if (currentSize <= maxBytes) {
             return record;
+        }
+
+        if (strategy == Strategy.CLAIM_CHECK) {
+            return applyClaimCheck(record);
         }
 
         Struct value = (Struct) record.value();
@@ -149,7 +243,153 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
                 record.key(),
                 record.valueSchema(),
                 value,
-                record.timestamp());
+                record.timestamp(),
+                record.headers());
+    }
+
+    private R applyClaimCheck(R record) {
+        SourceRecord sourceRecord = (SourceRecord) record;
+        Struct value = (Struct) sourceRecord.value();
+        List<ClaimCheckField> fields = findClaimCheckFields(value);
+
+        validateClaimCheckFields(value, fields, sourceRecord.topic());
+
+        ClaimCheckRecordSerializer.SerializedRecord serialized = ClaimCheckRecordSerializer.serialize(sourceRecord);
+        OversizedRecordReference reference;
+        try {
+            reference = claimCheckStorage.write(new OversizedRecord(
+                    serialized.key(),
+                    serialized.payload(),
+                    "application/json"));
+        }
+        catch (RuntimeException e) {
+            throw new ConnectException("Failed to store oversized record for topic " + sourceRecord.topic(), e);
+        }
+        if (reference == null) {
+            throw new ConnectException("Claim-check storage returned no reference for topic " + sourceRecord.topic());
+        }
+
+        Struct replacementValue = copyStruct(value);
+        for (ClaimCheckField field : fields) {
+            Struct section = replacementValue.getStruct(field.sectionName);
+            section.put(field.fieldName, claimCheckMarker(reference, serialized.sha256(), field));
+        }
+
+        R replacement = record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                record.valueSchema(),
+                replacementValue,
+                record.timestamp(),
+                record.headers());
+
+        long replacementSize = (long) Math.ceil(
+                ApproximateStructSizeCalculator.getApproximateRecordSize((SourceRecord) replacement) * compressionRatio);
+        if (replacementSize > maxBytes) {
+            throw new ConnectException("Claim-check replacement for topic " + sourceRecord.topic()
+                    + " still exceeds max.bytes: " + replacementSize + " > " + maxBytes);
+        }
+        return replacement;
+    }
+
+    private List<ClaimCheckField> findClaimCheckFields(Struct envelope) {
+        List<ClaimCheckField> fields = new ArrayList<>();
+        collectClaimCheckFields(envelope, "before", fields);
+        collectClaimCheckFields(envelope, "after", fields);
+        return fields;
+    }
+
+    private void collectClaimCheckFields(Struct envelope, String sectionName, List<ClaimCheckField> fields) {
+        org.apache.kafka.connect.data.Field sectionField = envelope.schema().field(sectionName);
+        if (sectionField == null) {
+            return;
+        }
+        Object sectionValue = envelope.getWithoutDefault(sectionName);
+        if (!(sectionValue instanceof Struct section)) {
+            return;
+        }
+
+        for (org.apache.kafka.connect.data.Field field : section.schema().fields()) {
+            if (!claimCheckColumns.contains(field.name())) {
+                continue;
+            }
+            Object fieldValue = section.getWithoutDefault(field.name());
+            if (fieldValue != null) {
+                fields.add(new ClaimCheckField(sectionName, field.name(), field.schema().type()));
+            }
+        }
+    }
+
+    private void validateClaimCheckFields(Struct envelope, List<ClaimCheckField> fields, String topic) {
+        Set<String> availableColumns = new LinkedHashSet<>();
+        collectSectionColumns(envelope, "before", availableColumns);
+        collectSectionColumns(envelope, "after", availableColumns);
+
+        Set<String> missingColumns = claimCheckColumns.stream()
+                .filter(column -> !availableColumns.contains(column))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        if (!missingColumns.isEmpty()) {
+            throw new ConnectException("Claim-check columns " + missingColumns + " were not found in record for topic " + topic);
+        }
+        if (fields.isEmpty()) {
+            throw new ConnectException("Claim-check columns are present but null in record for topic " + topic);
+        }
+
+        validateClaimCheckColumnSchemas(envelope, "before");
+        validateClaimCheckColumnSchemas(envelope, "after");
+    }
+
+    private void validateClaimCheckColumnSchemas(Struct envelope, String sectionName) {
+        org.apache.kafka.connect.data.Field sectionField = envelope.schema().field(sectionName);
+        if (sectionField == null || sectionField.schema().type() != Schema.Type.STRUCT) {
+            return;
+        }
+        for (org.apache.kafka.connect.data.Field field : sectionField.schema().fields()) {
+            if (claimCheckColumns.contains(field.name())
+                    && field.schema().type() != Schema.Type.STRING
+                    && field.schema().type() != Schema.Type.BYTES) {
+                throw new ConnectException("Claim-check column '" + field.name() + "' has schema type "
+                        + field.schema().type() + "; only STRING and BYTES columns are supported");
+            }
+        }
+    }
+
+    private static void collectSectionColumns(Struct envelope, String sectionName, Set<String> columns) {
+        org.apache.kafka.connect.data.Field sectionField = envelope.schema().field(sectionName);
+        if (sectionField == null || sectionField.schema().type() != Schema.Type.STRUCT) {
+            return;
+        }
+        sectionField.schema().fields().forEach(field -> columns.add(field.name()));
+    }
+
+    private static Struct copyStruct(Struct value) {
+        Struct copy = new Struct(value.schema());
+        for (org.apache.kafka.connect.data.Field field : value.schema().fields()) {
+            Object fieldValue = value.getWithoutDefault(field.name());
+            copy.put(field.name(), fieldValue instanceof Struct struct ? copyStruct(struct) : fieldValue);
+        }
+        return copy;
+    }
+
+    private static Object claimCheckMarker(OversizedRecordReference reference, String sha256, ClaimCheckField field) {
+        Map<String, Object> marker = new LinkedHashMap<>();
+        marker.put("__debezium_claim_check", true);
+        marker.put("version", 1);
+        marker.put("storage", reference.storage());
+        marker.put("uri", reference.uri().toString());
+        marker.put("column", field.fieldName);
+        marker.put("size_bytes", reference.sizeBytes());
+        marker.put("sha256", sha256);
+
+        try {
+            String json = OBJECT_MAPPER.writeValueAsString(marker);
+            return field.schemaType == Schema.Type.BYTES ? json.getBytes(StandardCharsets.UTF_8) : json;
+        }
+        catch (JsonProcessingException e) {
+            throw new DebeziumException("Failed to serialize claim-check marker", e);
+        }
     }
 
     private List<TruncatableField> getTruncatableFields(Struct envelope, String fieldName) {
@@ -259,10 +499,15 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
 
     @Override
     public void close() {
+        if (claimCheckStorage != null) {
+            claimCheckStorage.close();
+            claimCheckStorage = null;
+        }
     }
 
     @Override
     public void configure(Map<String, ?> props) {
+        close();
         AbstractConfig config = new AbstractConfig(CONFIG_DEF, props);
 
         int maxSize = config.getInt(MAX_BYTES_CONF);
@@ -282,11 +527,77 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             throw new ConfigException(MIN_FIELD_SIZE_CONF, minField, "Must be non-negative");
         }
         this.minFieldSize = minField;
+
+        this.strategy = Strategy.parse(config.getString(STRATEGY_CONF));
+        if (strategy == Strategy.CLAIM_CHECK) {
+            configureClaimCheck(config, props);
+        }
+        else {
+            this.claimCheckColumns = Set.of();
+        }
+    }
+
+    private void configureClaimCheck(AbstractConfig config, Map<String, ?> props) {
+        String storageClass = config.getString(CLAIM_CHECK_STORAGE_CLASS_CONF);
+        if (storageClass == null || storageClass.isBlank()) {
+            throw new ConfigException(CLAIM_CHECK_STORAGE_CLASS_CONF, storageClass,
+                    "Must be set when strategy is 'claim_check'");
+        }
+
+        List<String> configuredColumns = config.getList(CLAIM_CHECK_COLUMNS_CONF);
+        this.claimCheckColumns = configuredColumns.stream()
+                .map(String::trim)
+                .filter(column -> !column.isEmpty())
+                .map(EnforceRecordSize::unqualifiedColumnName)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        if (claimCheckColumns.isEmpty()) {
+            throw new ConfigException(CLAIM_CHECK_COLUMNS_CONF, configuredColumns,
+                    "Must contain at least one column when strategy is 'claim_check'");
+        }
+
+        Object storage;
+        try {
+            storage = Instantiator.getInstance(storageClass);
+        }
+        catch (IllegalArgumentException e) {
+            throw new ConfigException("Unable to instantiate claim-check storage class " + storageClass, e);
+        }
+        if (!(storage instanceof OversizedRecordStorage oversizedRecordStorage)) {
+            throw new ConfigException(CLAIM_CHECK_STORAGE_CLASS_CONF, storageClass,
+                    "Class must implement " + OversizedRecordStorage.class.getName());
+        }
+
+        Map<String, Object> storageProperties = new LinkedHashMap<>();
+        props.forEach((name, value) -> {
+            if (name.startsWith(CLAIM_CHECK_STORAGE_CONFIG_PREFIX)
+                    && !name.equals(CLAIM_CHECK_STORAGE_CLASS_CONF)) {
+                storageProperties.put(name.substring(CLAIM_CHECK_STORAGE_CONFIG_PREFIX.length()), value);
+            }
+        });
+        try {
+            oversizedRecordStorage.configure(Configuration.from(storageProperties));
+            this.claimCheckStorage = oversizedRecordStorage;
+        }
+        catch (RuntimeException e) {
+            oversizedRecordStorage.close();
+            throw new ConfigException("Unable to configure claim-check storage class " + storageClass, e);
+        }
+    }
+
+    private static String unqualifiedColumnName(String columnName) {
+        int lastDot = columnName.lastIndexOf('.');
+        return lastDot == -1 ? columnName : columnName.substring(lastDot + 1);
     }
 
     @Override
     public Field.Set getConfigFields() {
-        return Field.setOf(MAX_BYTES_FIELD, COMPRESSION_RATIO_FIELD, MIN_FIELD_SIZE_FIELD);
+        return Field.setOf(
+                MAX_BYTES_FIELD,
+                COMPRESSION_RATIO_FIELD,
+                MIN_FIELD_SIZE_FIELD,
+                STRATEGY_FIELD,
+                CLAIM_CHECK_STORAGE_CLASS_FIELD,
+                CLAIM_CHECK_COLUMNS_FIELD);
     }
 
     private static class TruncatableField {
@@ -299,5 +610,8 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             this.value = value;
             this.sizeBytes = sizeBytes;
         }
+    }
+
+    private record ClaimCheckField(String sectionName, String fieldName, Schema.Type schemaType) {
     }
 }

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
@@ -40,6 +40,7 @@ import io.debezium.spi.storage.OversizedRecord;
 import io.debezium.spi.storage.OversizedRecordReference;
 import io.debezium.spi.storage.OversizedRecordStorage;
 import io.debezium.util.ApproximateStructSizeCalculator;
+import io.debezium.util.Strings;
 
 /**
  * A Single Message Transform that enforces a maximum record size.
@@ -347,13 +348,16 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             return;
         }
         for (org.apache.kafka.connect.data.Field field : sectionField.schema().fields()) {
-            if (claimCheckColumns.contains(field.name())
-                    && field.schema().type() != Schema.Type.STRING
-                    && field.schema().type() != Schema.Type.BYTES) {
+            if (claimCheckColumns.contains(field.name()) && !isSupportedClaimCheckSchema(field.schema())) {
                 throw new ConnectException("Claim-check column '" + field.name() + "' has schema type "
-                        + field.schema().type() + "; only STRING and BYTES columns are supported");
+                        + field.schema().type() + "; only STRING and unnamed BYTES columns are supported");
             }
         }
+    }
+
+    private static boolean isSupportedClaimCheckSchema(Schema schema) {
+        return schema.type() == Schema.Type.STRING
+                || (schema.type() == Schema.Type.BYTES && schema.name() == null);
     }
 
     private static void collectSectionColumns(Struct envelope, String sectionName, Set<String> columns) {
@@ -539,15 +543,15 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
 
     private void configureClaimCheck(AbstractConfig config, Map<String, ?> props) {
         String storageClass = config.getString(CLAIM_CHECK_STORAGE_CLASS_CONF);
-        if (storageClass == null || storageClass.isBlank()) {
+        if (Strings.isNullOrBlank(storageClass)) {
             throw new ConfigException(CLAIM_CHECK_STORAGE_CLASS_CONF, storageClass,
                     "Must be set when strategy is 'claim_check'");
         }
 
         List<String> configuredColumns = config.getList(CLAIM_CHECK_COLUMNS_CONF);
         this.claimCheckColumns = configuredColumns.stream()
+                .filter(column -> !Strings.isNullOrBlank(column))
                 .map(String::trim)
-                .filter(column -> !column.isEmpty())
                 .map(EnforceRecordSize::unqualifiedColumnName)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         if (claimCheckColumns.isEmpty()) {

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
@@ -13,6 +13,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -35,6 +37,7 @@ import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Instantiator;
+import io.debezium.function.Predicates;
 import io.debezium.metadata.ConfigDescriptor;
 import io.debezium.spi.storage.OversizedRecord;
 import io.debezium.spi.storage.OversizedRecordReference;
@@ -150,8 +153,9 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             .withType(ConfigDef.Type.LIST)
             .withDefault("")
             .withImportance(ConfigDef.Importance.HIGH)
-            .withDescription("Comma-separated columns to replace with claim-check markers. Qualified column names are accepted; " +
-                    "matching uses the final column-name segment. Required when strategy is 'claim_check'.");
+            .withDescription("Comma-separated regular expressions that match columns to replace with claim-check markers. " +
+                    "Each expression is evaluated against the column name and the topic-qualified column name. " +
+                    "Required when strategy is 'claim_check'.");
 
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(MAX_BYTES_CONF,
@@ -190,7 +194,8 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
     private double compressionRatio;
     private int minFieldSize;
     private Strategy strategy = Strategy.TRUNCATE;
-    private Set<String> claimCheckColumns = Set.of();
+    private List<String> claimCheckColumns = List.of();
+    private List<Predicate<String>> claimCheckColumnSelectors = List.of();
     private OversizedRecordStorage claimCheckStorage;
 
     @Override
@@ -251,7 +256,7 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
     private R applyClaimCheck(R record) {
         SourceRecord sourceRecord = (SourceRecord) record;
         Struct value = (Struct) sourceRecord.value();
-        List<ClaimCheckField> fields = findClaimCheckFields(value);
+        List<ClaimCheckField> fields = findClaimCheckFields(value, sourceRecord.topic());
 
         validateClaimCheckFields(value, fields, sourceRecord.topic());
 
@@ -295,14 +300,14 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
         return replacement;
     }
 
-    private List<ClaimCheckField> findClaimCheckFields(Struct envelope) {
+    private List<ClaimCheckField> findClaimCheckFields(Struct envelope, String topic) {
         List<ClaimCheckField> fields = new ArrayList<>();
-        collectClaimCheckFields(envelope, "before", fields);
-        collectClaimCheckFields(envelope, "after", fields);
+        collectClaimCheckFields(envelope, "before", topic, fields);
+        collectClaimCheckFields(envelope, "after", topic, fields);
         return fields;
     }
 
-    private void collectClaimCheckFields(Struct envelope, String sectionName, List<ClaimCheckField> fields) {
+    private void collectClaimCheckFields(Struct envelope, String sectionName, String topic, List<ClaimCheckField> fields) {
         org.apache.kafka.connect.data.Field sectionField = envelope.schema().field(sectionName);
         if (sectionField == null) {
             return;
@@ -313,7 +318,7 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
         }
 
         for (org.apache.kafka.connect.data.Field field : section.schema().fields()) {
-            if (!claimCheckColumns.contains(field.name())) {
+            if (!isClaimCheckColumn(topic, field.name())) {
                 continue;
             }
             Object fieldValue = section.getWithoutDefault(field.name());
@@ -328,9 +333,15 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
         collectSectionColumns(envelope, "before", availableColumns);
         collectSectionColumns(envelope, "after", availableColumns);
 
-        Set<String> missingColumns = claimCheckColumns.stream()
-                .filter(column -> !availableColumns.contains(column))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<String> missingColumns = new LinkedHashSet<>();
+        for (int index = 0; index < claimCheckColumns.size(); index++) {
+            Predicate<String> selector = claimCheckColumnSelectors.get(index);
+            boolean matched = availableColumns.stream()
+                    .anyMatch(availableColumn -> matchesClaimCheckColumn(selector, topic, availableColumn));
+            if (!matched) {
+                missingColumns.add(claimCheckColumns.get(index));
+            }
+        }
         if (!missingColumns.isEmpty()) {
             throw new ConnectException("Claim-check columns " + missingColumns + " were not found in record for topic " + topic);
         }
@@ -338,17 +349,17 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             throw new ConnectException("Claim-check columns are present but null in record for topic " + topic);
         }
 
-        validateClaimCheckColumnSchemas(envelope, "before");
-        validateClaimCheckColumnSchemas(envelope, "after");
+        validateClaimCheckColumnSchemas(envelope, "before", topic);
+        validateClaimCheckColumnSchemas(envelope, "after", topic);
     }
 
-    private void validateClaimCheckColumnSchemas(Struct envelope, String sectionName) {
+    private void validateClaimCheckColumnSchemas(Struct envelope, String sectionName, String topic) {
         org.apache.kafka.connect.data.Field sectionField = envelope.schema().field(sectionName);
         if (sectionField == null || sectionField.schema().type() != Schema.Type.STRUCT) {
             return;
         }
         for (org.apache.kafka.connect.data.Field field : sectionField.schema().fields()) {
-            if (claimCheckColumns.contains(field.name()) && !isSupportedClaimCheckSchema(field.schema())) {
+            if (isClaimCheckColumn(topic, field.name()) && !isSupportedClaimCheckSchema(field.schema())) {
                 throw new ConnectException("Claim-check column '" + field.name() + "' has schema type "
                         + field.schema().type() + "; only STRING and unnamed BYTES columns are supported");
             }
@@ -366,6 +377,16 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             return;
         }
         sectionField.schema().fields().forEach(field -> columns.add(field.name()));
+    }
+
+    private boolean isClaimCheckColumn(String topic, String fieldName) {
+        return claimCheckColumnSelectors.stream()
+                .anyMatch(selector -> matchesClaimCheckColumn(selector, topic, fieldName));
+    }
+
+    private static boolean matchesClaimCheckColumn(Predicate<String> selector, String topic, String fieldName) {
+        return selector.test(fieldName)
+                || (!Strings.isNullOrBlank(topic) && selector.test(topic + "." + fieldName));
     }
 
     private static Struct copyStruct(Struct value) {
@@ -537,7 +558,8 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             configureClaimCheck(config, props);
         }
         else {
-            this.claimCheckColumns = Set.of();
+            this.claimCheckColumns = List.of();
+            this.claimCheckColumnSelectors = List.of();
         }
     }
 
@@ -552,12 +574,14 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
         this.claimCheckColumns = configuredColumns.stream()
                 .filter(column -> !Strings.isNullOrBlank(column))
                 .map(String::trim)
-                .map(EnforceRecordSize::unqualifiedColumnName)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toList());
         if (claimCheckColumns.isEmpty()) {
             throw new ConfigException(CLAIM_CHECK_COLUMNS_CONF, configuredColumns,
                     "Must contain at least one column when strategy is 'claim_check'");
         }
+        this.claimCheckColumnSelectors = claimCheckColumns.stream()
+                .map(column -> Predicates.includes(column, Pattern.CASE_INSENSITIVE))
+                .collect(Collectors.toList());
 
         Object storage;
         try {
@@ -586,11 +610,6 @@ public class EnforceRecordSize<R extends ConnectRecord<R>> implements Transforma
             oversizedRecordStorage.close();
             throw new ConfigException("Unable to configure claim-check storage class " + storageClass, e);
         }
-    }
-
-    private static String unqualifiedColumnName(String columnName) {
-        int lastDot = columnName.lastIndexOf('.');
-        return lastDot == -1 ? columnName : columnName.substring(lastDot + 1);
     }
 
     @Override

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/EnforceRecordSize.java
@@ -42,6 +42,7 @@ import io.debezium.metadata.ConfigDescriptor;
 import io.debezium.spi.storage.OversizedRecord;
 import io.debezium.spi.storage.OversizedRecordReference;
 import io.debezium.spi.storage.OversizedRecordStorage;
+import io.debezium.transforms.claimcheck.ClaimCheckRecordSerializer;
 import io.debezium.util.ApproximateStructSizeCalculator;
 import io.debezium.util.Strings;
 

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/claimcheck/ClaimCheckRecordSerializer.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/claimcheck/ClaimCheckRecordSerializer.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.transforms;
+package io.debezium.transforms.claimcheck;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -29,14 +29,14 @@ import io.debezium.DebeziumException;
 import io.debezium.util.HexConverter;
 import io.debezium.util.Strings;
 
-final class ClaimCheckRecordSerializer {
+public final class ClaimCheckRecordSerializer {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private ClaimCheckRecordSerializer() {
     }
 
-    static SerializedRecord serialize(SourceRecord record) {
+    public static SerializedRecord serialize(SourceRecord record) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("version", 1);
         payload.put("topic", record.topic());
@@ -162,7 +162,7 @@ final class ClaimCheckRecordSerializer {
         return candidate.replaceAll("[^A-Za-z0-9_.=-]", "_");
     }
 
-    static String sha256Hex(byte[] data) {
+    private static String sha256Hex(byte[] data) {
         try {
             byte[] digest = MessageDigest.getInstance("SHA-256").digest(data);
             return HexConverter.convertToHexString(digest);
@@ -172,6 +172,6 @@ final class ClaimCheckRecordSerializer {
         }
     }
 
-    record SerializedRecord(String key, byte[] payload, String sha256) {
+    public record SerializedRecord(String key, byte[] payload, String sha256) {
     }
 }

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.config.Configuration;
+import io.debezium.spi.storage.OversizedRecord;
+import io.debezium.spi.storage.OversizedRecordReference;
+import io.debezium.spi.storage.OversizedRecordStorage;
+
+class EnforceRecordSizeClaimCheckTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Schema SOURCE_SCHEMA = SchemaBuilder.struct()
+            .field("db", Schema.STRING_SCHEMA)
+            .build();
+    private static final Schema KEY_SCHEMA = SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .build();
+
+    private EnforceRecordSize<SourceRecord> transform;
+
+    @BeforeEach
+    void setUp() {
+        RecordingStorage.reset();
+        transform = new EnforceRecordSize<>();
+    }
+
+    @AfterEach
+    void tearDown() {
+        transform.close();
+    }
+
+    @Test
+    void shouldStoreCompleteRecordBeforeReplacingConfiguredColumn() throws Exception {
+        transform.configure(claimCheckConfig("inventory.customers.payload"));
+        String payload = "complete-value-" + "x".repeat(5_000);
+        SourceRecord sourceRecord = createStringRecord(payload, sourceOffset(100L));
+
+        SourceRecord result = transform.apply(sourceRecord);
+
+        assertThat(RecordingStorage.records).hasSize(1);
+        OversizedRecord stored = RecordingStorage.records.get(0);
+        JsonNode storedJson = OBJECT_MAPPER.readTree(stored.payload());
+        assertThat(storedJson.path("version").asInt()).isEqualTo(1);
+        assertThat(storedJson.path("topic").asText()).isEqualTo("inventory.customers");
+        assertThat(storedJson.at("/sourcePartition/server").asText()).isEqualTo("inventory");
+        assertThat(storedJson.at("/sourceOffset/lsn").asLong()).isEqualTo(100L);
+        assertThat(storedJson.at("/key/id").asInt()).isEqualTo(1);
+        assertThat(storedJson.at("/value/after/payload").asText()).isEqualTo(payload);
+        assertThat(stored.contentType()).isEqualTo("application/json");
+
+        JsonNode marker = marker(result, "payload");
+        assertThat(marker.path("__debezium_claim_check").asBoolean()).isTrue();
+        assertThat(marker.path("version").asInt()).isEqualTo(1);
+        assertThat(marker.path("storage").asText()).isEqualTo("test");
+        assertThat(marker.path("uri").asText()).isEqualTo("test://claim-check/" + stored.key());
+        assertThat(marker.path("column").asText()).isEqualTo("payload");
+        assertThat(marker.path("size_bytes").asLong()).isEqualTo(stored.payload().length);
+        assertThat(marker.path("sha256").asText()).isEqualTo(ClaimCheckRecordSerializer.sha256Hex(stored.payload()));
+
+        assertThat(after(sourceRecord).getString("payload")).isEqualTo(payload);
+        assertThat(RecordingStorage.configuredBasePath).isEqualTo("test://claim-check");
+    }
+
+    @Test
+    void shouldUseTheSameKeyForAnIdenticalRetry() {
+        transform.configure(claimCheckConfig("payload"));
+        SourceRecord sourceRecord = createStringRecord("x".repeat(5_000), sourceOffset(100L));
+
+        transform.apply(sourceRecord);
+        transform.apply(sourceRecord);
+
+        assertThat(RecordingStorage.records).hasSize(2);
+        assertThat(RecordingStorage.records.get(0).key()).isEqualTo(RecordingStorage.records.get(1).key());
+        assertThat(RecordingStorage.records.get(0).payload()).isEqualTo(RecordingStorage.records.get(1).payload());
+    }
+
+    @Test
+    void shouldUseDifferentKeysForDifferentSourceOffsets() {
+        transform.configure(claimCheckConfig("payload"));
+
+        transform.apply(createStringRecord("x".repeat(5_000), sourceOffset(100L)));
+        transform.apply(createStringRecord("x".repeat(5_000), sourceOffset(101L)));
+
+        assertThat(RecordingStorage.records).hasSize(2);
+        assertThat(RecordingStorage.records.get(0).key()).isNotEqualTo(RecordingStorage.records.get(1).key());
+    }
+
+    @Test
+    void shouldCanonicalizeSourcePositionWhenBuildingTheKey() {
+        transform.configure(claimCheckConfig("payload"));
+        Map<String, Object> firstOffset = new LinkedHashMap<>();
+        firstOffset.put("lsn", 100L);
+        firstOffset.put("tx", 7L);
+        Map<String, Object> secondOffset = new LinkedHashMap<>();
+        secondOffset.put("tx", 7L);
+        secondOffset.put("lsn", 100L);
+
+        transform.apply(createStringRecord("x".repeat(5_000), firstOffset));
+        transform.apply(createStringRecord("x".repeat(5_000), secondOffset));
+
+        assertThat(RecordingStorage.records.get(0).key()).isEqualTo(RecordingStorage.records.get(1).key());
+    }
+
+    @Test
+    void shouldFailClosedWithoutMutatingTheOriginalRecord() {
+        transform.configure(claimCheckConfig("payload"));
+        RecordingStorage.failWrites = true;
+        String payload = "x".repeat(5_000);
+        SourceRecord sourceRecord = createStringRecord(payload, sourceOffset(100L));
+
+        assertThatThrownBy(() -> transform.apply(sourceRecord))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Failed to store oversized record");
+
+        assertThat(after(sourceRecord).getString("payload")).isEqualTo(payload);
+    }
+
+    @Test
+    void shouldValidateConfiguredColumnsBeforeWriting() {
+        transform.configure(claimCheckConfig("missing_column"));
+        SourceRecord sourceRecord = createStringRecord("x".repeat(5_000), sourceOffset(100L));
+
+        assertThatThrownBy(() -> transform.apply(sourceRecord))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("missing_column")
+                .hasMessageContaining("not found");
+        assertThat(RecordingStorage.records).isEmpty();
+    }
+
+    @Test
+    void shouldRejectUnsupportedColumnTypesBeforeWriting() {
+        transform.configure(claimCheckConfig("payload"));
+        Schema recordSchema = SchemaBuilder.struct()
+                .field("payload", Schema.OPTIONAL_INT32_SCHEMA)
+                .field("large", Schema.OPTIONAL_STRING_SCHEMA)
+                .optional()
+                .build();
+        Struct after = new Struct(recordSchema)
+                .put("payload", 42)
+                .put("large", "x".repeat(5_000));
+        SourceRecord sourceRecord = createRecord(recordSchema, after, sourceOffset(100L));
+
+        assertThatThrownBy(() -> transform.apply(sourceRecord))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("payload")
+                .hasMessageContaining("only STRING and BYTES");
+        assertThat(RecordingStorage.records).isEmpty();
+    }
+
+    @Test
+    void shouldFailClosedWhenStorageReturnsNoReference() {
+        transform.configure(claimCheckConfig("payload"));
+        RecordingStorage.returnNullReference = true;
+        String payload = "x".repeat(5_000);
+        SourceRecord sourceRecord = createStringRecord(payload, sourceOffset(100L));
+
+        assertThatThrownBy(() -> transform.apply(sourceRecord))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("returned no reference");
+        assertThat(after(sourceRecord).getString("payload")).isEqualTo(payload);
+    }
+
+    @Test
+    void shouldNotWriteRecordsWithinTheConfiguredLimit() {
+        Map<String, Object> config = claimCheckConfig("payload");
+        config.put(EnforceRecordSize.MAX_BYTES_CONF, "10000");
+        transform.configure(config);
+        SourceRecord sourceRecord = createStringRecord("small", sourceOffset(100L));
+
+        SourceRecord result = transform.apply(sourceRecord);
+
+        assertThat(result).isSameAs(sourceRecord);
+        assertThat(RecordingStorage.records).isEmpty();
+    }
+
+    @Test
+    void shouldEmitABytesMarkerForBytesColumns() throws Exception {
+        transform.configure(claimCheckConfig("payload"));
+        SourceRecord sourceRecord = createBytesRecord(new byte[5_000], sourceOffset(100L));
+
+        SourceRecord result = transform.apply(sourceRecord);
+
+        byte[] markerBytes = after(result).getBytes("payload");
+        JsonNode marker = OBJECT_MAPPER.readTree(new String(markerBytes, StandardCharsets.UTF_8));
+        assertThat(marker.path("__debezium_claim_check").asBoolean()).isTrue();
+        assertThat(OBJECT_MAPPER.readTree(RecordingStorage.records.get(0).payload())
+                .at("/value/after/payload").asText()).isNotBlank();
+    }
+
+    @Test
+    void shouldCloseConfiguredStorage() {
+        transform.configure(claimCheckConfig("payload"));
+
+        transform.close();
+
+        assertThat(RecordingStorage.closed).isTrue();
+    }
+
+    private static Map<String, Object> claimCheckConfig(String columns) {
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(EnforceRecordSize.MAX_BYTES_CONF, "1200");
+        config.put(EnforceRecordSize.STRATEGY_CONF, "claim_check");
+        config.put(EnforceRecordSize.CLAIM_CHECK_STORAGE_CLASS_CONF, RecordingStorage.class.getName());
+        config.put(EnforceRecordSize.CLAIM_CHECK_COLUMNS_CONF, columns);
+        config.put(EnforceRecordSize.CLAIM_CHECK_STORAGE_CONFIG_PREFIX + "base.path", "test://claim-check");
+        return config;
+    }
+
+    private static SourceRecord createStringRecord(String value, Map<String, ?> offset) {
+        Schema recordSchema = SchemaBuilder.struct()
+                .field("payload", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("id", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+        Struct after = new Struct(recordSchema)
+                .put("payload", value)
+                .put("id", 1);
+        return createRecord(recordSchema, after, offset);
+    }
+
+    private static SourceRecord createBytesRecord(byte[] value, Map<String, ?> offset) {
+        Schema recordSchema = SchemaBuilder.struct()
+                .field("payload", Schema.OPTIONAL_BYTES_SCHEMA)
+                .field("id", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+        Struct after = new Struct(recordSchema)
+                .put("payload", ByteBuffer.wrap(value))
+                .put("id", 1);
+        return createRecord(recordSchema, after, offset);
+    }
+
+    private static SourceRecord createRecord(Schema recordSchema, Struct after, Map<String, ?> offset) {
+        Schema envelopeSchema = SchemaBuilder.struct()
+                .field("before", recordSchema)
+                .field("after", recordSchema)
+                .field("op", Schema.STRING_SCHEMA)
+                .field("source", SOURCE_SCHEMA)
+                .build();
+        Struct envelope = new Struct(envelopeSchema)
+                .put("after", after)
+                .put("op", "c")
+                .put("source", new Struct(SOURCE_SCHEMA).put("db", "inventory"));
+        return new SourceRecord(
+                Map.of("server", "inventory"),
+                offset,
+                "inventory.customers",
+                0,
+                KEY_SCHEMA,
+                new Struct(KEY_SCHEMA).put("id", 1),
+                envelopeSchema,
+                envelope);
+    }
+
+    private static Map<String, Object> sourceOffset(long lsn) {
+        return Map.of("lsn", lsn);
+    }
+
+    private static Struct after(SourceRecord record) {
+        return ((Struct) record.value()).getStruct("after");
+    }
+
+    private static JsonNode marker(SourceRecord record, String field) throws Exception {
+        return OBJECT_MAPPER.readTree(after(record).getString(field));
+    }
+
+    public static class RecordingStorage implements OversizedRecordStorage {
+
+        private static final List<OversizedRecord> records = new ArrayList<>();
+        private static boolean failWrites;
+        private static boolean returnNullReference;
+        private static boolean closed;
+        private static String configuredBasePath;
+
+        static void reset() {
+            records.clear();
+            failWrites = false;
+            returnNullReference = false;
+            closed = false;
+            configuredBasePath = null;
+        }
+
+        @Override
+        public void configure(Configuration config) {
+            configuredBasePath = config.getString("base.path");
+        }
+
+        @Override
+        public OversizedRecordReference write(OversizedRecord record) {
+            if (failWrites) {
+                throw new IllegalStateException("storage unavailable");
+            }
+            records.add(record);
+            if (returnNullReference) {
+                return null;
+            }
+            return new OversizedRecordReference(
+                    "test",
+                    URI.create("test://claim-check/" + record.key()),
+                    record.payload().length);
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
@@ -92,7 +92,9 @@ class EnforceRecordSizeClaimCheckTest {
 
     @Test
     void shouldSerializeHeadersInOrder() throws Exception {
-        transform.configure(claimCheckConfig("payload"));
+        Map<String, Object> config = claimCheckConfig("payload");
+        config.put(EnforceRecordSize.MAX_BYTES_CONF, "2000");
+        transform.configure(config);
         SourceRecord sourceRecord = createStringRecord("x".repeat(5_000), sourceOffset(100L));
         sourceRecord.headers().addString("trace-id", "first");
         sourceRecord.headers().addBytes("trace-id", new byte[]{ 1, 2, 3 });

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
@@ -91,6 +91,37 @@ class EnforceRecordSizeClaimCheckTest {
     }
 
     @Test
+    void shouldScopeQualifiedClaimCheckColumnsToTheConfiguredTopic() throws Exception {
+        transform.configure(claimCheckConfig("inventory[.]customers[.]payload"));
+
+        SourceRecord matchingRecord = createStringRecord("x".repeat(5_000), sourceOffset(100L));
+        SourceRecord matchingResult = transform.apply(matchingRecord);
+
+        assertThat(marker(matchingResult, "payload").path("__debezium_claim_check").asBoolean()).isTrue();
+        assertThat(RecordingStorage.records).hasSize(1);
+
+        SourceRecord nonMatchingRecord = createStringRecord("x".repeat(5_000), sourceOffset(101L), "inventory.orders");
+
+        assertThatThrownBy(() -> transform.apply(nonMatchingRecord))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("inventory[.]customers[.]payload")
+                .hasMessageContaining("not found");
+        assertThat(RecordingStorage.records).hasSize(1);
+    }
+
+    @Test
+    void shouldSerializeNullKeys() throws Exception {
+        transform.configure(claimCheckConfig("payload"));
+        SourceRecord sourceRecord = createStringRecord("x".repeat(5_000), sourceOffset(100L), "inventory.customers", null);
+
+        SourceRecord result = transform.apply(sourceRecord);
+
+        JsonNode storedJson = OBJECT_MAPPER.readTree(RecordingStorage.records.get(0).payload());
+        assertThat(storedJson.path("key").isNull()).isTrue();
+        assertThat(result.key()).isNull();
+    }
+
+    @Test
     void shouldSerializeHeadersInOrder() throws Exception {
         Map<String, Object> config = claimCheckConfig("payload");
         config.put(EnforceRecordSize.MAX_BYTES_CONF, "2000");
@@ -275,6 +306,14 @@ class EnforceRecordSizeClaimCheckTest {
     }
 
     private static SourceRecord createStringRecord(String value, Map<String, ?> offset) {
+        return createStringRecord(value, offset, "inventory.customers");
+    }
+
+    private static SourceRecord createStringRecord(String value, Map<String, ?> offset, String topic) {
+        return createStringRecord(value, offset, topic, new Struct(KEY_SCHEMA).put("id", 1));
+    }
+
+    private static SourceRecord createStringRecord(String value, Map<String, ?> offset, String topic, Object key) {
         Schema recordSchema = SchemaBuilder.struct()
                 .field("payload", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("id", Schema.INT32_SCHEMA)
@@ -283,7 +322,7 @@ class EnforceRecordSizeClaimCheckTest {
         Struct after = new Struct(recordSchema)
                 .put("payload", value)
                 .put("id", 1);
-        return createRecord(recordSchema, after, offset);
+        return createRecord(recordSchema, after, offset, topic, key);
     }
 
     private static SourceRecord createBytesRecord(byte[] value, Map<String, ?> offset) {
@@ -299,6 +338,10 @@ class EnforceRecordSizeClaimCheckTest {
     }
 
     private static SourceRecord createRecord(Schema recordSchema, Struct after, Map<String, ?> offset) {
+        return createRecord(recordSchema, after, offset, "inventory.customers", new Struct(KEY_SCHEMA).put("id", 1));
+    }
+
+    private static SourceRecord createRecord(Schema recordSchema, Struct after, Map<String, ?> offset, String topic, Object key) {
         Schema envelopeSchema = SchemaBuilder.struct()
                 .field("before", recordSchema)
                 .field("after", recordSchema)
@@ -312,10 +355,10 @@ class EnforceRecordSizeClaimCheckTest {
         return new SourceRecord(
                 Map.of("server", "inventory"),
                 offset,
-                "inventory.customers",
+                topic,
                 0,
                 KEY_SCHEMA,
-                new Struct(KEY_SCHEMA).put("id", 1),
+                key,
                 envelopeSchema,
                 envelope);
     }

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
@@ -8,6 +8,7 @@ package io.debezium.transforms;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -16,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -86,6 +88,23 @@ class EnforceRecordSizeClaimCheckTest {
 
         assertThat(after(sourceRecord).getString("payload")).isEqualTo(payload);
         assertThat(RecordingStorage.configuredBasePath).isEqualTo("test://claim-check");
+    }
+
+    @Test
+    void shouldSerializeHeadersInOrder() throws Exception {
+        transform.configure(claimCheckConfig("payload"));
+        SourceRecord sourceRecord = createStringRecord("x".repeat(5_000), sourceOffset(100L));
+        sourceRecord.headers().addString("trace-id", "first");
+        sourceRecord.headers().addBytes("trace-id", new byte[]{ 1, 2, 3 });
+
+        transform.apply(sourceRecord);
+
+        JsonNode headers = OBJECT_MAPPER.readTree(RecordingStorage.records.get(0).payload()).path("headers");
+        assertThat(headers.size()).isEqualTo(2);
+        assertThat(headers.get(0).path("key").asText()).isEqualTo("trace-id");
+        assertThat(headers.get(0).path("value").asText()).isEqualTo("first");
+        assertThat(headers.get(1).path("key").asText()).isEqualTo("trace-id");
+        assertThat(headers.get(1).path("value").asText()).isEqualTo("AQID");
     }
 
     @Test
@@ -170,7 +189,27 @@ class EnforceRecordSizeClaimCheckTest {
         assertThatThrownBy(() -> transform.apply(sourceRecord))
                 .isInstanceOf(ConnectException.class)
                 .hasMessageContaining("payload")
-                .hasMessageContaining("only STRING and BYTES");
+                .hasMessageContaining("only STRING and unnamed BYTES");
+        assertThat(RecordingStorage.records).isEmpty();
+    }
+
+    @Test
+    void shouldRejectNamedBytesColumnsBeforeWriting() {
+        transform.configure(claimCheckConfig("amount"));
+        Schema recordSchema = SchemaBuilder.struct()
+                .field("amount", Decimal.builder(2).optional().build())
+                .field("large", Schema.OPTIONAL_STRING_SCHEMA)
+                .optional()
+                .build();
+        Struct after = new Struct(recordSchema)
+                .put("amount", new BigDecimal("42.00"))
+                .put("large", "x".repeat(5_000));
+        SourceRecord sourceRecord = createRecord(recordSchema, after, sourceOffset(100L));
+
+        assertThatThrownBy(() -> transform.apply(sourceRecord))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("amount")
+                .hasMessageContaining("unnamed BYTES");
         assertThat(RecordingStorage.records).isEmpty();
     }
 

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/EnforceRecordSizeClaimCheckTest.java
@@ -12,7 +12,9 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +86,8 @@ class EnforceRecordSizeClaimCheckTest {
         assertThat(marker.path("uri").asText()).isEqualTo("test://claim-check/" + stored.key());
         assertThat(marker.path("column").asText()).isEqualTo("payload");
         assertThat(marker.path("size_bytes").asLong()).isEqualTo(stored.payload().length);
-        assertThat(marker.path("sha256").asText()).isEqualTo(ClaimCheckRecordSerializer.sha256Hex(stored.payload()));
+        assertThat(marker.path("sha256").asText()).isEqualTo(HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(stored.payload())));
 
         assertThat(after(sourceRecord).getString("payload")).isEqualTo(payload);
         assertThat(RecordingStorage.configuredBasePath).isEqualTo("test://claim-check");

--- a/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecord.java
+++ b/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.spi.storage;
+
+import java.util.Objects;
+
+import io.debezium.common.annotation.Incubating;
+
+/**
+ * A serialized source record that exceeds the configured inline message size.
+ *
+ * @param key deterministic storage key; retries of the same source record must use the same key
+ * @param payload complete serialized source record
+ * @param contentType media type of the serialized payload
+ *
+ * @author Debezium Authors
+ */
+@Incubating
+public record OversizedRecord(String key, byte[] payload, String contentType) {
+
+    public OversizedRecord {
+        if (Objects.requireNonNull(key, "key must not be null").isBlank()) {
+            throw new IllegalArgumentException("key must not be blank");
+        }
+        payload = Objects.requireNonNull(payload, "payload must not be null").clone();
+        if (payload.length == 0) {
+            throw new IllegalArgumentException("payload must not be empty");
+        }
+        if (Objects.requireNonNull(contentType, "contentType must not be null").isBlank()) {
+            throw new IllegalArgumentException("contentType must not be blank");
+        }
+    }
+
+    @Override
+    public byte[] payload() {
+        return payload.clone();
+    }
+}

--- a/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecord.java
+++ b/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecord.java
@@ -8,6 +8,7 @@ package io.debezium.spi.storage;
 import java.util.Objects;
 
 import io.debezium.common.annotation.Incubating;
+import io.debezium.util.Strings;
 
 /**
  * A serialized source record that exceeds the configured inline message size.
@@ -22,14 +23,16 @@ import io.debezium.common.annotation.Incubating;
 public record OversizedRecord(String key, byte[] payload, String contentType) {
 
     public OversizedRecord {
-        if (Objects.requireNonNull(key, "key must not be null").isBlank()) {
+        Objects.requireNonNull(key, "key must not be null");
+        if (Strings.isNullOrBlank(key)) {
             throw new IllegalArgumentException("key must not be blank");
         }
         payload = Objects.requireNonNull(payload, "payload must not be null").clone();
         if (payload.length == 0) {
             throw new IllegalArgumentException("payload must not be empty");
         }
-        if (Objects.requireNonNull(contentType, "contentType must not be null").isBlank()) {
+        Objects.requireNonNull(contentType, "contentType must not be null");
+        if (Strings.isNullOrBlank(contentType)) {
             throw new IllegalArgumentException("contentType must not be blank");
         }
     }

--- a/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecordReference.java
+++ b/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecordReference.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.util.Objects;
 
 import io.debezium.common.annotation.Incubating;
+import io.debezium.util.Strings;
 
 /**
  * Durable reference returned after an oversized record is stored.
@@ -23,7 +24,8 @@ import io.debezium.common.annotation.Incubating;
 public record OversizedRecordReference(String storage, URI uri, long sizeBytes) {
 
     public OversizedRecordReference {
-        if (Objects.requireNonNull(storage, "storage must not be null").isBlank()) {
+        Objects.requireNonNull(storage, "storage must not be null");
+        if (Strings.isNullOrBlank(storage)) {
             throw new IllegalArgumentException("storage must not be blank");
         }
         Objects.requireNonNull(uri, "uri must not be null");

--- a/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecordReference.java
+++ b/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecordReference.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.spi.storage;
+
+import java.net.URI;
+import java.util.Objects;
+
+import io.debezium.common.annotation.Incubating;
+
+/**
+ * Durable reference returned after an oversized record is stored.
+ *
+ * @param storage stable identifier for the storage implementation
+ * @param uri absolute URI from which the complete record can be recovered
+ * @param sizeBytes number of bytes stored
+ *
+ * @author Debezium Authors
+ */
+@Incubating
+public record OversizedRecordReference(String storage, URI uri, long sizeBytes) {
+
+    public OversizedRecordReference {
+        if (Objects.requireNonNull(storage, "storage must not be null").isBlank()) {
+            throw new IllegalArgumentException("storage must not be blank");
+        }
+        Objects.requireNonNull(uri, "uri must not be null");
+        if (!uri.isAbsolute()) {
+            throw new IllegalArgumentException("uri must be absolute");
+        }
+        if (sizeBytes < 0) {
+            throw new IllegalArgumentException("sizeBytes must be non-negative");
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecordStorage.java
+++ b/debezium-storage/debezium-storage-api/src/main/java/io/debezium/spi/storage/OversizedRecordStorage.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.spi.storage;
+
+import io.debezium.common.annotation.Incubating;
+import io.debezium.config.Configuration;
+
+/**
+ * Storage contract used by record-size enforcement to externalize complete records.
+ * <p>
+ * Implementations must return from {@link #write(OversizedRecord)} only after the
+ * payload is durably acknowledged. A write failure must be propagated to the caller
+ * so that no claim-check marker is emitted for a missing payload.
+ * Implementations must also treat {@link OversizedRecord#key()} as idempotent: writing
+ * the same key and payload more than once must be safe.
+ *
+ * @author Debezium Authors
+ */
+@Incubating
+public interface OversizedRecordStorage extends AutoCloseable {
+
+    /**
+     * Configures the storage implementation.
+     *
+     * @param properties implementation-specific configuration
+     */
+    void configure(Configuration properties);
+
+    /**
+     * Writes an oversized record and returns its durable external reference.
+     *
+     * @param record serialized record and deterministic key
+     * @return durable external reference
+     */
+    OversizedRecordReference write(OversizedRecord record);
+
+    @Override
+    default void close() {
+    }
+}

--- a/debezium-storage/debezium-storage-s3/pom.xml
+++ b/debezium-storage/debezium-storage-s3/pom.xml
@@ -23,6 +23,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-storage-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
@@ -114,4 +119,3 @@
         </profile>
     </profiles>
 </project>
-

--- a/debezium-storage/debezium-storage-s3/src/main/java/io/debezium/storage/s3/S3OversizedRecordStorage.java
+++ b/debezium-storage/debezium-storage-s3/src/main/java/io/debezium/storage/s3/S3OversizedRecordStorage.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.s3;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import io.debezium.DebeziumException;
+import io.debezium.common.annotation.Incubating;
+import io.debezium.config.Configuration;
+import io.debezium.spi.storage.OversizedRecord;
+import io.debezium.spi.storage.OversizedRecordReference;
+import io.debezium.spi.storage.OversizedRecordStorage;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Stores complete oversized records in Amazon S3.
+ *
+ * @author Debezium Authors
+ */
+@Incubating
+public class S3OversizedRecordStorage implements OversizedRecordStorage {
+
+    public static final String BASE_PATH_CONFIG = "base.path";
+    public static final String REGION_CONFIG = "region";
+    public static final String ENDPOINT_CONFIG = "endpoint";
+    public static final String FORCE_PATH_STYLE_CONFIG = "force.path.style";
+
+    private static final String STORAGE_NAME = "s3";
+
+    private String bucket;
+    private String prefix;
+    private S3Client s3Client;
+
+    @Override
+    public void configure(Configuration config) {
+        close();
+
+        URI basePath = parseBasePath(config.getString(BASE_PATH_CONFIG));
+        String regionName = config.getString(REGION_CONFIG);
+        if (regionName == null || regionName.isBlank()) {
+            throw new DebeziumException("Configuration '" + REGION_CONFIG + "' is required for " + getClass().getSimpleName());
+        }
+
+        String configuredBucket = basePath.getHost();
+        String configuredPrefix = normalizePrefix(basePath.getPath());
+        S3Client configuredClient = createS3Client(
+                config,
+                Region.of(regionName),
+                DefaultCredentialsProvider.create());
+
+        bucket = configuredBucket;
+        prefix = configuredPrefix;
+        s3Client = configuredClient;
+    }
+
+    protected S3Client createS3Client(Configuration config, Region region, AwsCredentialsProvider credentialsProvider) {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .forcePathStyle(config.getBoolean(FORCE_PATH_STYLE_CONFIG, false));
+
+        String endpoint = config.getString(ENDPOINT_CONFIG);
+        if (endpoint != null && !endpoint.isBlank()) {
+            builder.endpointOverride(parseAbsoluteUri(ENDPOINT_CONFIG, endpoint));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public OversizedRecordReference write(OversizedRecord record) {
+        if (s3Client == null) {
+            throw new DebeziumException(getClass().getSimpleName() + " is not configured");
+        }
+
+        byte[] payload = record.payload();
+        String objectKey = prefix + record.key();
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .contentType(record.contentType())
+                .contentLength((long) payload.length)
+                .build();
+
+        try {
+            s3Client.putObject(request, RequestBody.fromBytes(payload));
+        }
+        catch (RuntimeException e) {
+            throw new DebeziumException("Failed to store oversized record at s3://" + bucket + "/" + objectKey, e);
+        }
+
+        return new OversizedRecordReference(STORAGE_NAME, objectUri(objectKey), payload.length);
+    }
+
+    @Override
+    public void close() {
+        if (s3Client != null) {
+            s3Client.close();
+            s3Client = null;
+        }
+    }
+
+    private static URI parseBasePath(String value) {
+        if (value == null || value.isBlank()) {
+            throw new DebeziumException("Configuration '" + BASE_PATH_CONFIG + "' is required for "
+                    + S3OversizedRecordStorage.class.getSimpleName());
+        }
+
+        URI uri = parseAbsoluteUri(BASE_PATH_CONFIG, value);
+        if (!STORAGE_NAME.equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null || uri.getHost().isBlank()
+                || uri.getUserInfo() != null || uri.getPort() != -1 || uri.getQuery() != null || uri.getFragment() != null) {
+            throw new DebeziumException("Configuration '" + BASE_PATH_CONFIG
+                    + "' must be an S3 URI in the form s3://bucket/optional-prefix");
+        }
+        return uri;
+    }
+
+    private static URI parseAbsoluteUri(String property, String value) {
+        try {
+            URI uri = URI.create(value);
+            if (!uri.isAbsolute()) {
+                throw new IllegalArgumentException("URI is not absolute");
+            }
+            return uri;
+        }
+        catch (IllegalArgumentException e) {
+            throw new DebeziumException("Configuration '" + property + "' must be a valid absolute URI", e);
+        }
+    }
+
+    private static String normalizePrefix(String path) {
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            return "";
+        }
+        String normalized = path;
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized.endsWith("/") ? normalized : normalized + "/";
+    }
+
+    private URI objectUri(String objectKey) {
+        try {
+            return new URI(STORAGE_NAME, bucket, "/" + objectKey, null);
+        }
+        catch (URISyntaxException e) {
+            throw new DebeziumException("Failed to create S3 reference for object key " + objectKey, e);
+        }
+    }
+}

--- a/debezium-storage/debezium-storage-s3/src/main/java/io/debezium/storage/s3/S3OversizedRecordStorage.java
+++ b/debezium-storage/debezium-storage-s3/src/main/java/io/debezium/storage/s3/S3OversizedRecordStorage.java
@@ -48,7 +48,7 @@ public class S3OversizedRecordStorage implements OversizedRecordStorage {
 
         URI basePath = parseBasePath(config.getString(BASE_PATH_CONFIG));
         String regionName = config.getString(REGION_CONFIG);
-        if (regionName == null || regionName.isBlank()) {
+        if (Strings.isNullOrBlank(regionName)) {
             throw new DebeziumException("Configuration '" + REGION_CONFIG + "' is required for " + getClass().getSimpleName());
         }
 

--- a/debezium-storage/debezium-storage-s3/src/main/java/io/debezium/storage/s3/S3OversizedRecordStorage.java
+++ b/debezium-storage/debezium-storage-s3/src/main/java/io/debezium/storage/s3/S3OversizedRecordStorage.java
@@ -14,9 +14,12 @@ import io.debezium.config.Configuration;
 import io.debezium.spi.storage.OversizedRecord;
 import io.debezium.spi.storage.OversizedRecordReference;
 import io.debezium.spi.storage.OversizedRecordStorage;
+import io.debezium.util.Strings;
 
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -35,6 +38,8 @@ public class S3OversizedRecordStorage implements OversizedRecordStorage {
     public static final String REGION_CONFIG = "region";
     public static final String ENDPOINT_CONFIG = "endpoint";
     public static final String FORCE_PATH_STYLE_CONFIG = "force.path.style";
+    public static final String ACCESS_KEY_ID_CONFIG = "access.key.id";
+    public static final String SECRET_ACCESS_KEY_CONFIG = "secret.access.key";
 
     private static final String STORAGE_NAME = "s3";
 
@@ -57,7 +62,7 @@ public class S3OversizedRecordStorage implements OversizedRecordStorage {
         S3Client configuredClient = createS3Client(
                 config,
                 Region.of(regionName),
-                DefaultCredentialsProvider.create());
+                createCredentialsProvider(config));
 
         bucket = configuredBucket;
         prefix = configuredPrefix;
@@ -71,10 +76,19 @@ public class S3OversizedRecordStorage implements OversizedRecordStorage {
                 .forcePathStyle(config.getBoolean(FORCE_PATH_STYLE_CONFIG, false));
 
         String endpoint = config.getString(ENDPOINT_CONFIG);
-        if (endpoint != null && !endpoint.isBlank()) {
+        if (!Strings.isNullOrBlank(endpoint)) {
             builder.endpointOverride(parseAbsoluteUri(ENDPOINT_CONFIG, endpoint));
         }
         return builder.build();
+    }
+
+    private static AwsCredentialsProvider createCredentialsProvider(Configuration config) {
+        String accessKeyId = config.getString(ACCESS_KEY_ID_CONFIG);
+        String secretAccessKey = config.getString(SECRET_ACCESS_KEY_CONFIG);
+        if (!Strings.isNullOrBlank(accessKeyId) && !Strings.isNullOrBlank(secretAccessKey)) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey));
+        }
+        return DefaultCredentialsProvider.create();
     }
 
     @Override
@@ -111,13 +125,13 @@ public class S3OversizedRecordStorage implements OversizedRecordStorage {
     }
 
     private static URI parseBasePath(String value) {
-        if (value == null || value.isBlank()) {
+        if (Strings.isNullOrBlank(value)) {
             throw new DebeziumException("Configuration '" + BASE_PATH_CONFIG + "' is required for "
                     + S3OversizedRecordStorage.class.getSimpleName());
         }
 
         URI uri = parseAbsoluteUri(BASE_PATH_CONFIG, value);
-        if (!STORAGE_NAME.equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null || uri.getHost().isBlank()
+        if (!STORAGE_NAME.equalsIgnoreCase(uri.getScheme()) || Strings.isNullOrBlank(uri.getHost())
                 || uri.getUserInfo() != null || uri.getPort() != -1 || uri.getQuery() != null || uri.getFragment() != null) {
             throw new DebeziumException("Configuration '" + BASE_PATH_CONFIG
                     + "' must be an S3 URI in the form s3://bucket/optional-prefix");
@@ -139,7 +153,7 @@ public class S3OversizedRecordStorage implements OversizedRecordStorage {
     }
 
     private static String normalizePrefix(String path) {
-        if (path == null || path.isBlank() || "/".equals(path)) {
+        if (Strings.isNullOrBlank(path) || "/".equals(path)) {
             return "";
         }
         String normalized = path;

--- a/debezium-storage/debezium-storage-s3/src/test/java/io/debezium/storage/s3/S3OversizedRecordStorageTest.java
+++ b/debezium-storage/debezium-storage-s3/src/test/java/io/debezium/storage/s3/S3OversizedRecordStorageTest.java
@@ -189,6 +189,6 @@ class S3OversizedRecordStorageTest {
     private static Map<String, Object> configurationProperties() {
         return Map.of(
                 S3OversizedRecordStorage.BASE_PATH_CONFIG, "s3://claim-check-bucket/debezium/oversized",
-                S3OversizedRecordStorage.REGION_CONFIG, "us-west-1"));
+                S3OversizedRecordStorage.REGION_CONFIG, "us-west-1");
     }
 }

--- a/debezium-storage/debezium-storage-s3/src/test/java/io/debezium/storage/s3/S3OversizedRecordStorageTest.java
+++ b/debezium-storage/debezium-storage-s3/src/test/java/io/debezium/storage/s3/S3OversizedRecordStorageTest.java
@@ -31,6 +31,9 @@ import io.debezium.config.Configuration;
 import io.debezium.spi.storage.OversizedRecord;
 import io.debezium.spi.storage.OversizedRecordReference;
 
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -82,7 +85,36 @@ class S3OversizedRecordStorageTest {
                 URI.create("s3://claim-check-bucket/debezium/oversized/inventory.customers/offset-123-sha256-abc.json"),
                 reference.uri());
         assertEquals(payload.length, reference.sizeBytes());
-        verify(storage).createS3Client(any(), org.mockito.ArgumentMatchers.eq(Region.US_WEST_1), any());
+        ArgumentCaptor<AwsCredentialsProvider> credentialsProviderCaptor = ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+        verify(storage).createS3Client(any(), org.mockito.ArgumentMatchers.eq(Region.US_WEST_1), credentialsProviderCaptor.capture());
+        assertTrue(credentialsProviderCaptor.getValue() instanceof DefaultCredentialsProvider);
+    }
+
+    @Test
+    void shouldUseConfiguredStaticCredentials() {
+        Map<String, Object> properties = new LinkedHashMap<>(configurationProperties());
+        properties.put(S3OversizedRecordStorage.ACCESS_KEY_ID_CONFIG, "access-key-id");
+        properties.put(S3OversizedRecordStorage.SECRET_ACCESS_KEY_CONFIG, "secret-access-key");
+
+        storage.configure(Configuration.from(properties));
+
+        ArgumentCaptor<AwsCredentialsProvider> credentialsProviderCaptor = ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+        verify(storage).createS3Client(any(), org.mockito.ArgumentMatchers.eq(Region.US_WEST_1), credentialsProviderCaptor.capture());
+        assertTrue(credentialsProviderCaptor.getValue() instanceof StaticCredentialsProvider);
+        assertEquals("access-key-id", credentialsProviderCaptor.getValue().resolveCredentials().accessKeyId());
+        assertEquals("secret-access-key", credentialsProviderCaptor.getValue().resolveCredentials().secretAccessKey());
+    }
+
+    @Test
+    void shouldUseDefaultCredentialsWhenStaticCredentialsAreIncomplete() {
+        Map<String, Object> properties = new LinkedHashMap<>(configurationProperties());
+        properties.put(S3OversizedRecordStorage.ACCESS_KEY_ID_CONFIG, "access-key-id");
+
+        storage.configure(Configuration.from(properties));
+
+        ArgumentCaptor<AwsCredentialsProvider> credentialsProviderCaptor = ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+        verify(storage).createS3Client(any(), org.mockito.ArgumentMatchers.eq(Region.US_WEST_1), credentialsProviderCaptor.capture());
+        assertTrue(credentialsProviderCaptor.getValue() instanceof DefaultCredentialsProvider);
     }
 
     @Test
@@ -151,7 +183,11 @@ class S3OversizedRecordStorageTest {
     }
 
     private static Configuration configuration() {
-        return Configuration.from(Map.of(
+        return Configuration.from(configurationProperties());
+    }
+
+    private static Map<String, Object> configurationProperties() {
+        return Map.of(
                 S3OversizedRecordStorage.BASE_PATH_CONFIG, "s3://claim-check-bucket/debezium/oversized",
                 S3OversizedRecordStorage.REGION_CONFIG, "us-west-1"));
     }

--- a/debezium-storage/debezium-storage-s3/src/test/java/io/debezium/storage/s3/S3OversizedRecordStorageTest.java
+++ b/debezium-storage/debezium-storage-s3/src/test/java/io/debezium/storage/s3/S3OversizedRecordStorageTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.spi.storage.OversizedRecord;
+import io.debezium.spi.storage.OversizedRecordReference;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+class S3OversizedRecordStorageTest {
+
+    private S3Client s3Client;
+    private S3OversizedRecordStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        s3Client = mock(S3Client.class);
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+        storage = spy(new S3OversizedRecordStorage());
+        doReturn(s3Client).when(storage).createS3Client(any(), any(), any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        storage.close();
+    }
+
+    @Test
+    void shouldSynchronouslyStoreThePayloadAtTheConfiguredBasePath() throws Exception {
+        storage.configure(configuration());
+        byte[] payload = "complete source record".getBytes(StandardCharsets.UTF_8);
+        OversizedRecord record = new OversizedRecord(
+                "inventory.customers/offset-123-sha256-abc.json",
+                payload,
+                "application/json");
+
+        OversizedRecordReference reference = storage.write(record);
+
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        ArgumentCaptor<RequestBody> bodyCaptor = ArgumentCaptor.forClass(RequestBody.class);
+        verify(s3Client).putObject(requestCaptor.capture(), bodyCaptor.capture());
+        PutObjectRequest request = requestCaptor.getValue();
+        assertEquals("claim-check-bucket", request.bucket());
+        assertEquals("debezium/oversized/inventory.customers/offset-123-sha256-abc.json", request.key());
+        assertEquals("application/json", request.contentType());
+        assertEquals(payload.length, request.contentLength());
+        assertArrayEquals(payload, bodyCaptor.getValue().contentStreamProvider().newStream().readAllBytes());
+
+        assertEquals("s3", reference.storage());
+        assertEquals(
+                URI.create("s3://claim-check-bucket/debezium/oversized/inventory.customers/offset-123-sha256-abc.json"),
+                reference.uri());
+        assertEquals(payload.length, reference.sizeBytes());
+        verify(storage).createS3Client(any(), org.mockito.ArgumentMatchers.eq(Region.US_WEST_1), any());
+    }
+
+    @Test
+    void shouldPropagateUploadFailureWithoutReturningAReference() {
+        storage.configure(configuration());
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(new IllegalStateException("S3 unavailable"));
+        OversizedRecord record = new OversizedRecord("record.json", new byte[]{ 1 }, "application/json");
+
+        DebeziumException exception = assertThrows(DebeziumException.class, () -> storage.write(record));
+        assertTrue(exception.getMessage().contains("Failed to store oversized record"));
+        assertTrue(exception.getMessage().contains("s3://claim-check-bucket/debezium/oversized/record.json"));
+        assertEquals("S3 unavailable", exception.getCause().getMessage());
+    }
+
+    @Test
+    void shouldRequireAnS3BasePath() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(S3OversizedRecordStorage.BASE_PATH_CONFIG, "https://claim-check-bucket/prefix");
+        properties.put(S3OversizedRecordStorage.REGION_CONFIG, "us-west-1");
+
+        DebeziumException exception = assertThrows(
+                DebeziumException.class,
+                () -> storage.configure(Configuration.from(properties)));
+        assertTrue(exception.getMessage().contains("must be an S3 URI"));
+    }
+
+    @Test
+    void shouldRejectCredentialsInTheBasePath() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(S3OversizedRecordStorage.BASE_PATH_CONFIG, "s3://user@claim-check-bucket/prefix");
+        properties.put(S3OversizedRecordStorage.REGION_CONFIG, "us-west-1");
+
+        DebeziumException exception = assertThrows(
+                DebeziumException.class,
+                () -> storage.configure(Configuration.from(properties)));
+        assertTrue(exception.getMessage().contains("must be an S3 URI"));
+    }
+
+    @Test
+    void shouldRequireARegion() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(S3OversizedRecordStorage.BASE_PATH_CONFIG, "s3://claim-check-bucket/prefix");
+
+        DebeziumException exception = assertThrows(
+                DebeziumException.class,
+                () -> storage.configure(Configuration.from(properties)));
+        assertTrue(exception.getMessage().contains(S3OversizedRecordStorage.REGION_CONFIG));
+    }
+
+    @Test
+    void shouldRejectWritesBeforeConfiguration() {
+        OversizedRecord record = new OversizedRecord("record.json", new byte[]{ 1 }, "application/json");
+
+        DebeziumException exception = assertThrows(DebeziumException.class, () -> storage.write(record));
+        assertTrue(exception.getMessage().contains("not configured"));
+    }
+
+    @Test
+    void shouldCloseTheClient() {
+        storage.configure(configuration());
+
+        storage.close();
+
+        verify(s3Client).close();
+    }
+
+    private static Configuration configuration() {
+        return Configuration.from(Map.of(
+                S3OversizedRecordStorage.BASE_PATH_CONFIG, "s3://claim-check-bucket/debezium/oversized",
+                S3OversizedRecordStorage.REGION_CONFIG, "us-west-1"));
+    }
+}

--- a/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
+++ b/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
@@ -13,13 +13,15 @@
 
 toc::[]
 
-The `EnforceRecordSize` SMT estimates the serialized size of each record and, if it exceeds the configured maximum, truncates eligible string and bytes columns proportionally to bring the record within the size limit.
+The `EnforceRecordSize` SMT estimates the serialized size of each record and applies a configured strategy if the record exceeds the maximum size.
+By default, the SMT truncates eligible string and bytes columns proportionally.
+Alternatively, the SMT can store the complete record externally and replace selected columns with claim-check markers.
 
 Some downstream systems, such as Apache Kafka brokers or sink connectors, impose a maximum message size limit.
 When {prodname} captures a change event for a row that contains large string or bytes columns, the serialized record can exceed that limit, causing the connector to fail.
 
-The SMT truncates larger columns aggressively to comply with the threshold.
-If does not modify columns if their sizes are at or below the configured threshold.
+With the default strategy, the SMT truncates larger columns aggressively to comply with the threshold.
+It does not modify columns if their sizes are at or below the configured threshold.
 
 // Type: concept
 // Title: Example: Basic configuration of the {prodname} enforce record size SMT
@@ -40,6 +42,55 @@ transforms.EnforceRecordSize.max.bytes=1048576
 When this configuration is active, if the estimated serialized size of a record exceeds 1,048,576 bytes (1 MB), its large string and bytes fields are truncated proportionally until the record conforms to the configured limit.
 
 // Type: concept
+// Title: Storing oversized records by using the claim-check strategy
+// ModuleID: storing-oversized-records-by-using-the-enforce-record-size-claim-check-strategy
+[[enforce-record-size-claim-check]]
+== Storing oversized records by using the claim-check strategy
+
+Use the `claim_check` strategy when downstream consumers require the complete value and truncation would cause data loss.
+When an event exceeds `max.bytes`, the SMT serializes the complete source record, including its source partition and offset, key, and value, and writes it through an `OversizedRecordStorage` implementation.
+After the storage implementation acknowledges the write, the SMT copies the event and replaces each configured non-null string or bytes column in its `before` and `after` sections with a claim-check marker.
+
+The following example stores oversized records in Amazon S3:
+
+[source]
+----
+transforms=EnforceRecordSize
+transforms.EnforceRecordSize.type=io.debezium.transforms.EnforceRecordSize
+transforms.EnforceRecordSize.max.bytes=1048576
+transforms.EnforceRecordSize.strategy=claim_check
+transforms.EnforceRecordSize.claim.check.columns.include.list=inventory.customers.payload
+transforms.EnforceRecordSize.claim.check.storage.class=io.debezium.storage.s3.S3OversizedRecordStorage
+transforms.EnforceRecordSize.claim.check.storage.base.path=s3://my-bucket/debezium/oversized
+transforms.EnforceRecordSize.claim.check.storage.region=us-west-1
+----
+
+The S3 implementation uses the AWS default credentials provider chain.
+To use it, make the `debezium-storage-s3` artifact and its dependencies available on the same Kafka Connect plugin path as the connector.
+
+The marker is a JSON value that retains the column's original string or bytes schema.
+For example:
+
+[source,json]
+----
+{
+  "__debezium_claim_check": true,
+  "version": 1,
+  "storage": "s3",
+  "uri": "s3://my-bucket/debezium/oversized/inventory.customers/offset-a1b2c3d4-sha256-e5f6.json",
+  "column": "payload",
+  "size_bytes": 2097152,
+  "sha256": "e5f6..."
+}
+----
+
+A downstream consumer must recognize the marker, read the complete record from `uri`, verify it as needed by using `sha256`, and recover the value identified by `column`.
+
+The storage key is derived from the source partition and offset and from the serialized payload hash.
+As a result, a retry of the same source event writes the same key and does not create duplicate objects.
+The write is synchronous and fail-closed: if storage does not acknowledge the write, the SMT throws an exception and does not emit a marker record.
+
+// Type: concept
 // Title: How the enforce record size SMT estimates record size
 // ModuleID: how-the-enforce-record-size-smt-estimates-record-size
 [[enforce-record-size-how-it-works]]
@@ -51,6 +102,7 @@ The string size calculation assumes one byte per character, which understates mu
 
 When the estimated size (adjusted by the optional `compression.ratio`) exceeds `max.bytes`, the SMT identifies all string and bytes fields in the `before` and `after` sections of the envelope that are larger than `min.field.size`.
 It then distributes the excess bytes proportionally across those fields, truncating larger fields more than smaller fields.
+This truncation behavior applies when `strategy` is set to its default value, `truncate`.
 
 // Type: concept
 // ModuleID: enforce-record-size-smt-configuration-with-compression-ratio
@@ -116,6 +168,12 @@ It passes non-envelope records, such as schema change events or tombstones, unch
 * The SMT does not guarantee that the final serialized record is exactly at or below `max.bytes`, because it estimates size approximately and the actual serialized size depends on the converter (JSON, Avro, or Protobuf) and its associated overhead.
 To provide a safety margin, configure a conservative `max.bytes` value or adjust the `compression.ratio` setting.
 
+* With the `claim_check` strategy, the SMT supports only string and bytes columns.
+It validates all configured column names before writing the record to storage.
+
+* The `claim_check` strategy leaves the input record unchanged and returns a copied envelope that contains the markers.
+It emits that copy only after external storage acknowledges the complete record.
+
 // Type: reference
 // ModuleID: options-for-configuring-the-enforce-record-size-transformation
 // Title: Options for configuring the enforce record size transformation
@@ -134,7 +192,7 @@ The following table lists the configuration options that you can set for the enf
 |[[enforce-record-size-max-bytes]]<<enforce-record-size-max-bytes, `max.bytes`>>
 |No default  value.
 |(Required) The maximum record size in bytes.
-If the estimated serialized size of a record (adjusted by `compression.ratio`) exceeds the specified limit, the transformation proportionally truncates values in string and bytes columns to conform to the limit
+If the estimated serialized size of a record (adjusted by `compression.ratio`) exceeds the specified limit, the transformation applies the configured `strategy`.
 
 |[[enforce-record-size-compression-ratio]]<<enforce-record-size-compression-ratio, `compression.ratio`>>
 |`1.0`
@@ -147,5 +205,40 @@ For example, if serialization compresses raw record size by 50%, set this to `0.
 |A non-negative number that specifies the maximum size of fields that are subject to truncation.
 The transformation does not truncate fields if their size is less than or equal to this value (in bytes).
 Only fields larger than this threshold are eligible for proportional truncation.
+This option does not apply to the `claim_check` strategy.
+
+|[[enforce-record-size-strategy]]<<enforce-record-size-strategy, `strategy`>>
+|`truncate`
+|Specifies the action to take when an event exceeds `max.bytes`.
+Set the value to `truncate` to proportionally truncate eligible columns.
+Set the value to `claim_check` to store the complete record externally and replace configured columns with durable references.
+
+|[[enforce-record-size-claim-check-storage-class]]<<enforce-record-size-claim-check-storage-class, `claim.check.storage.class`>>
+|No default value.
+|The fully qualified name of an `OversizedRecordStorage` implementation.
+Required when `strategy` is set to `claim_check`.
+For S3, set the value to `io.debezium.storage.s3.S3OversizedRecordStorage`.
+
+|[[enforce-record-size-claim-check-columns]]<<enforce-record-size-claim-check-columns, `claim.check.columns.include.list`>>
+|No default value.
+|A comma-separated list of string or bytes columns to replace with claim-check markers.
+You can specify an unqualified column name, such as `payload`, or a qualified name, such as `inventory.customers.payload`.
+Required when `strategy` is set to `claim_check`.
+
+|[[enforce-record-size-claim-check-s3-base-path]]<<enforce-record-size-claim-check-s3-base-path, `claim.check.storage.base.path`>>
+|No default value.
+|For `S3OversizedRecordStorage`, the S3 bucket and optional object prefix, in the form `s3://bucket/optional-prefix`.
+
+|[[enforce-record-size-claim-check-s3-region]]<<enforce-record-size-claim-check-s3-region, `claim.check.storage.region`>>
+|No default value.
+|For `S3OversizedRecordStorage`, the AWS region in which the bucket is located.
+
+|[[enforce-record-size-claim-check-s3-endpoint]]<<enforce-record-size-claim-check-s3-endpoint, `claim.check.storage.endpoint`>>
+|No default value.
+|For `S3OversizedRecordStorage`, an optional absolute URI for a custom S3-compatible endpoint.
+
+|[[enforce-record-size-claim-check-s3-force-path-style]]<<enforce-record-size-claim-check-s3-force-path-style, `claim.check.storage.force.path.style`>>
+|`false`
+|For `S3OversizedRecordStorage`, specifies whether the S3 client uses path-style access.
 
 |===

--- a/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
+++ b/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
@@ -48,8 +48,8 @@ When this configuration is active, if the estimated serialized size of a record 
 == Storing oversized records by using the claim-check strategy
 
 Use the `claim_check` strategy when downstream consumers require the complete value and truncation would cause data loss.
-When an event exceeds `max.bytes`, the SMT serializes the complete source record, including its source partition and offset, key, and value, and writes it through an `OversizedRecordStorage` implementation.
-After the storage implementation acknowledges the write, the SMT copies the event and replaces each configured non-null string or bytes column in its `before` and `after` sections with a claim-check marker.
+When an event exceeds `max.bytes`, the SMT serializes the complete source record, including its source partition and offset, headers, key, and value, and writes it through an `OversizedRecordStorage` implementation.
+After the storage implementation acknowledges the write, the SMT copies the event and replaces each configured non-null string or unnamed bytes column in its `before` and `after` sections with a claim-check marker.
 
 The following example stores oversized records in Amazon S3:
 
@@ -65,10 +65,12 @@ transforms.EnforceRecordSize.claim.check.storage.base.path=s3://my-bucket/debezi
 transforms.EnforceRecordSize.claim.check.storage.region=us-west-1
 ----
 
-The S3 implementation uses the AWS default credentials provider chain.
+By default, the S3 implementation uses the AWS default credentials provider chain, including web identity credentials for IAM roles for service accounts (IRSA).
+To use static credentials for local development, set both `claim.check.storage.access.key.id` and `claim.check.storage.secret.access.key`.
+When both properties are present, the S3 implementation uses them instead of the default provider chain.
 To use it, make the `debezium-storage-s3` artifact and its dependencies available on the same Kafka Connect plugin path as the connector.
 
-The marker is a JSON value that retains the column's original string or bytes schema.
+The marker is a JSON value that retains the column's original string or unnamed bytes schema.
 For example:
 
 [source,json]
@@ -221,7 +223,7 @@ For S3, set the value to `io.debezium.storage.s3.S3OversizedRecordStorage`.
 
 |[[enforce-record-size-claim-check-columns]]<<enforce-record-size-claim-check-columns, `claim.check.columns.include.list`>>
 |No default value.
-|A comma-separated list of string or bytes columns to replace with claim-check markers.
+|A comma-separated list of string or unnamed bytes columns to replace with claim-check markers.
 You can specify an unqualified column name, such as `payload`, or a qualified name, such as `inventory.customers.payload`.
 Required when `strategy` is set to `claim_check`.
 
@@ -232,6 +234,16 @@ Required when `strategy` is set to `claim_check`.
 |[[enforce-record-size-claim-check-s3-region]]<<enforce-record-size-claim-check-s3-region, `claim.check.storage.region`>>
 |No default value.
 |For `S3OversizedRecordStorage`, the AWS region in which the bucket is located.
+
+|[[enforce-record-size-claim-check-s3-access-key-id]]<<enforce-record-size-claim-check-s3-access-key-id, `claim.check.storage.access.key.id`>>
+|No default value.
+|Optional access key ID for `S3OversizedRecordStorage`.
+When this property and `claim.check.storage.secret.access.key` are both set, the S3 implementation uses static credentials.
+
+|[[enforce-record-size-claim-check-s3-secret-access-key]]<<enforce-record-size-claim-check-s3-secret-access-key, `claim.check.storage.secret.access.key`>>
+|No default value.
+|Optional secret access key for `S3OversizedRecordStorage`.
+When this property and `claim.check.storage.access.key.id` are both set, the S3 implementation uses static credentials.
 
 |[[enforce-record-size-claim-check-s3-endpoint]]<<enforce-record-size-claim-check-s3-endpoint, `claim.check.storage.endpoint`>>
 |No default value.

--- a/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
+++ b/documentation/modules/ROOT/pages/transformations/enforce-record-size.adoc
@@ -50,6 +50,8 @@ When this configuration is active, if the estimated serialized size of a record 
 Use the `claim_check` strategy when downstream consumers require the complete value and truncation would cause data loss.
 When an event exceeds `max.bytes`, the SMT serializes the complete source record, including its source partition and offset, headers, key, and value, and writes it through an `OversizedRecordStorage` implementation.
 After the storage implementation acknowledges the write, the SMT copies the event and replaces each configured non-null string or unnamed bytes column in its `before` and `after` sections with a claim-check marker.
+The `claim.check.columns.include.list` entries are case-insensitive regular expressions that match either an unqualified column name, such as `payload`, or a topic-qualified name, such as `inventory.customers.payload`.
+Use a topic-qualified expression to scope claim-check replacement to a single topic.
 
 The following example stores oversized records in Amazon S3:
 
@@ -59,7 +61,7 @@ transforms=EnforceRecordSize
 transforms.EnforceRecordSize.type=io.debezium.transforms.EnforceRecordSize
 transforms.EnforceRecordSize.max.bytes=1048576
 transforms.EnforceRecordSize.strategy=claim_check
-transforms.EnforceRecordSize.claim.check.columns.include.list=inventory.customers.payload
+transforms.EnforceRecordSize.claim.check.columns.include.list=inventory[.]customers[.]payload
 transforms.EnforceRecordSize.claim.check.storage.class=io.debezium.storage.s3.S3OversizedRecordStorage
 transforms.EnforceRecordSize.claim.check.storage.base.path=s3://my-bucket/debezium/oversized
 transforms.EnforceRecordSize.claim.check.storage.region=us-west-1
@@ -223,8 +225,9 @@ For S3, set the value to `io.debezium.storage.s3.S3OversizedRecordStorage`.
 
 |[[enforce-record-size-claim-check-columns]]<<enforce-record-size-claim-check-columns, `claim.check.columns.include.list`>>
 |No default value.
-|A comma-separated list of string or unnamed bytes columns to replace with claim-check markers.
-You can specify an unqualified column name, such as `payload`, or a qualified name, such as `inventory.customers.payload`.
+|A comma-separated list of case-insensitive regular expressions that match string or unnamed bytes columns to replace with claim-check markers.
+Each expression is evaluated against the unqualified column name, such as `payload`, and the topic-qualified column name, such as `inventory.customers.payload`.
+To scope a column to a topic, use an expression such as `inventory[.]customers[.]payload`.
 Required when `strategy` is set to `claim_check`.
 
 |[[enforce-record-size-claim-check-s3-base-path]]<<enforce-record-size-claim-check-s3-base-path, `claim.check.storage.base.path`>>


### PR DESCRIPTION
Fixes debezium/dbz#2379

## Description

This change adds an opt-in `claim_check` strategy to the `EnforceRecordSize` SMT while preserving proportional truncation as the default behavior.

- Adds a storage-neutral `OversizedRecordStorage` SPI in `debezium-storage-api`.
- Adds `S3OversizedRecordStorage` in `debezium-storage-s3`, using the AWS default credentials provider chain.
- Serializes and synchronously stores the complete source record before emitting a versioned marker.
- Uses deterministic source-position and payload hashes so retries reuse the same object key.
- Fails the transformation without mutating the input record when storage fails or the replacement still exceeds `max.bytes`.
- Documents configuration, marker recovery, S3 setup, and fail-closed behavior.

## Verification

- Focused `EnforceRecordSize` suites: 29 tests passed.
- Focused S3 adapter suite: 7 tests passed.
- Affected reactor `verify`: all 20 modules passed, including 397 connect-plugin tests, 34 S3 tests, formatting, checkstyle, architecture checks, and API compatibility.

## AI assistance disclosure

I used OpenAI Codex assistively to review contribution hygiene, run tests, and resolve a documentation conflict while rebasing onto current `main`. I reviewed the resulting changes and take responsibility for this contribution.

## PR Checklist

- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to this change.
- [ ] One feature/change per PR unless tightly coupled.
- [ ] Rebased on upstream `main`.
