### PR TITLE
debezium/dbz#2495 Declare the unavailable value placeholder on the column schema

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/data/UnavailableValuePlaceholderParameter.java
+++ b/debezium-connector-common/src/main/java/io/debezium/data/UnavailableValuePlaceholderParameter.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * Schema parameter that declares the exact unavailable value placeholder representation a connector
+ * emits for a column, so that consumers such as the {@code ReselectColumnsPostProcessor} can recognize
+ * placeholder values by comparing against the declared representation instead of inferring it from the
+ * value shape.
+ *
+ * <p>The parameter value is the {@link #serialize(Schema, Object) canonical serialization} of the
+ * placeholder value as it appears in emitted change events. Producers attach the parameter with the
+ * serialization of the placeholder they emit; consumers compare a field value against it with
+ * {@link #matches(Schema, Object, String)}.
+ *
+ * @author Sundong Kim
+ */
+public class UnavailableValuePlaceholderParameter {
+
+    /**
+     * Key of the schema parameter carrying the serialized placeholder representation.
+     */
+    public static final String SCHEMA_PARAMETER_KEY = "__debezium.unavailable.value.placeholder";
+
+    private UnavailableValuePlaceholderParameter() {
+    }
+
+    /**
+     * Determines whether the given value is the placeholder declared by the given canonical
+     * representation. The comparison work is bounded by the length of the declared representation,
+     * so values much larger than the placeholder are rejected without being serialized in full.
+     *
+     * @param schema the schema of the field holding the value; may be null
+     * @param value the value to compare; may be null
+     * @param declared the declared canonical placeholder representation; must not be null
+     * @return {@code true} if the value is the declared placeholder
+     */
+    public static boolean matches(Schema schema, Object value, String declared) {
+        return declared.equals(serialize(schema, value, declared.length()));
+    }
+
+    /**
+     * Serializes the given value to the canonical string representation used by the
+     * {@link #SCHEMA_PARAMETER_KEY} parameter.
+     *
+     * @param schema the schema of the field holding the value; may be null
+     * @param value the value to serialize; may be null
+     * @return the canonical representation, or {@code null} if the value cannot be represented
+     */
+    public static String serialize(Schema schema, Object value) {
+        return serialize(schema, value, Integer.MAX_VALUE);
+    }
+
+    /**
+     * A value whose representation would exceed {@code maxLength} is rejected with {@code null} rather
+     * than truncated, so comparing against a shorter declared placeholder never serializes it in full.
+     */
+    private static String serialize(Schema schema, Object value, int maxLength) {
+        if (schema == null || value == null) {
+            return null;
+        }
+        switch (schema.type()) {
+            case STRING:
+                return value instanceof String string && string.length() <= maxLength ? string : null;
+            case BYTES:
+                return serializeBytes(value, maxLength);
+            case INT32:
+            case INT64:
+                return value instanceof Number ? value.toString() : null;
+            case ARRAY:
+                return serializeArray(schema, value, maxLength);
+            case MAP:
+                return serializeMap(schema, value, maxLength);
+            default:
+                return null;
+        }
+    }
+
+    private static String serializeBytes(Object value, int maxLength) {
+        byte[] bytes;
+        if (value instanceof byte[] byteArray) {
+            bytes = byteArray;
+        }
+        else if (value instanceof ByteBuffer byteBuffer) {
+            final ByteBuffer buffer = byteBuffer.duplicate();
+            if (base64Length(buffer.remaining()) > maxLength) {
+                return null;
+            }
+            bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+        }
+        else {
+            return null;
+        }
+        return base64Length(bytes.length) <= maxLength ? Base64.getEncoder().encodeToString(bytes) : null;
+    }
+
+    private static long base64Length(int byteCount) {
+        return 4L * ((byteCount + 2L) / 3L);
+    }
+
+    private static String serializeArray(Schema schema, Object value, int maxLength) {
+        if (!(value instanceof Collection)) {
+            return null;
+        }
+        final StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (Object element : (Collection<?>) value) {
+            if (sb.length() > maxLength) {
+                return null;
+            }
+            final String serialized = serializeElement(schema.valueSchema(), element, maxLength);
+            if (serialized == null) {
+                return null;
+            }
+            if (!first) {
+                sb.append(',');
+            }
+            sb.append(serialized);
+            first = false;
+        }
+        return sb.length() + 1 <= maxLength ? sb.append(']').toString() : null;
+    }
+
+    private static String serializeMap(Schema schema, Object value, int maxLength) {
+        if (!(value instanceof Map)) {
+            return null;
+        }
+        final StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+            if (sb.length() > maxLength) {
+                return null;
+            }
+            final String key = serializeElement(schema.keySchema(), entry.getKey(), maxLength);
+            final String entryValue = serializeElement(schema.valueSchema(), entry.getValue(), maxLength);
+            if (key == null || entryValue == null) {
+                return null;
+            }
+            if (!first) {
+                sb.append(',');
+            }
+            sb.append(key).append(':').append(entryValue);
+            first = false;
+        }
+        return sb.length() + 1 <= maxLength ? sb.append('}').toString() : null;
+    }
+
+    /**
+     * Serializes a nested value: strings and binary values are quoted and escaped so that
+     * representations of composite values are unambiguous. Quoting only lengthens a value, so
+     * bounding the unquoted length never rejects an element that would have fit.
+     */
+    private static String serializeElement(Schema schema, Object value, int maxLength) {
+        if (schema == null || value == null) {
+            return null;
+        }
+        switch (schema.type()) {
+            case STRING:
+                return value instanceof String string && string.length() <= maxLength ? quote(string) : null;
+            case BYTES:
+                final String bytes = serializeBytes(value, maxLength);
+                return bytes != null ? quote(bytes) : null;
+            default:
+                return serialize(schema, value, maxLength);
+        }
+    }
+
+    private static String quote(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/processors/reselect/ReselectColumnsPostProcessor.java
@@ -37,7 +37,9 @@ import io.debezium.config.Instantiator;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.data.Json;
+import io.debezium.data.SchemaUtil;
 import io.debezium.data.SpecialValueDecimal;
+import io.debezium.data.UnavailableValuePlaceholderParameter;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.function.Predicates;
 import io.debezium.jdbc.JdbcConnection;
@@ -441,6 +443,12 @@ public class ReselectColumnsPostProcessor implements PostProcessor, BeanRegistry
     }
 
     private boolean isUnavailableValueHolder(org.apache.kafka.connect.data.Field field, Object value) {
+        final Optional<String> declaredPlaceholder = SchemaUtil.getSchemaParameter(field.schema(), UnavailableValuePlaceholderParameter.SCHEMA_PARAMETER_KEY);
+        if (declaredPlaceholder.isPresent()) {
+            // The connector declared the exact placeholder representation this column carries, so
+            // compare against the declaration instead of inferring the placeholder by value shape.
+            return UnavailableValuePlaceholderParameter.matches(field.schema(), value, declaredPlaceholder.get());
+        }
         if (unavailableValuePlaceholder != null) {
             if (field.schema().type() == Schema.Type.ARRAY && value != null) {
                 // Special use case to inspect by element

--- a/debezium-connector-common/src/test/java/io/debezium/data/UnavailableValuePlaceholderParameterTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/data/UnavailableValuePlaceholderParameterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link UnavailableValuePlaceholderParameter}.
+ *
+ * @author Sundong Kim
+ */
+public class UnavailableValuePlaceholderParameterTest {
+
+    private static final String PLACEHOLDER = "__debezium_unavailable_value";
+    private static final byte[] PLACEHOLDER_BYTES = PLACEHOLDER.getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    public void shouldSerializeString() {
+        assertThat(UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_STRING_SCHEMA, PLACEHOLDER)).isEqualTo(PLACEHOLDER);
+    }
+
+    @Test
+    public void shouldSerializeBytesAndByteBufferIdentically() {
+        final String expected = Base64.getEncoder().encodeToString(PLACEHOLDER_BYTES);
+        assertThat(UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_BYTES_SCHEMA, PLACEHOLDER_BYTES)).isEqualTo(expected);
+        final ByteBuffer buffer = ByteBuffer.wrap(PLACEHOLDER_BYTES);
+        assertThat(UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_BYTES_SCHEMA, buffer)).isEqualTo(expected);
+        // serializing must not consume the buffer
+        assertThat(buffer.remaining()).isEqualTo(PLACEHOLDER_BYTES.length);
+    }
+
+    @Test
+    public void shouldSerializeIntegers() {
+        assertThat(UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_INT32_SCHEMA, 95)).isEqualTo("95");
+        assertThat(UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_INT64_SCHEMA, 95L)).isEqualTo("95");
+    }
+
+    @Test
+    public void shouldSerializeArrays() {
+        final Schema strings = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build();
+        assertThat(UnavailableValuePlaceholderParameter.serialize(strings, List.of(PLACEHOLDER)))
+                .isEqualTo("[\"" + PLACEHOLDER + "\"]");
+        final Schema ints = SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).build();
+        assertThat(UnavailableValuePlaceholderParameter.serialize(ints, List.of(9, 5))).isEqualTo("[9,5]");
+    }
+
+    @Test
+    public void shouldDistinguishElementBoundariesInStringArrays() {
+        final Schema strings = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build();
+        final String joined = UnavailableValuePlaceholderParameter.serialize(strings, List.of("a,b"));
+        final String split = UnavailableValuePlaceholderParameter.serialize(strings, List.of("a", "b"));
+        assertThat(joined).isNotEqualTo(split);
+        final String quoted = UnavailableValuePlaceholderParameter.serialize(strings, List.of("a\"b\\c"));
+        assertThat(quoted).isEqualTo("[\"a\\\"b\\\\c\"]");
+    }
+
+    @Test
+    public void shouldSerializeMaps() {
+        final Schema map = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).build();
+        assertThat(UnavailableValuePlaceholderParameter.serialize(map, Map.of(PLACEHOLDER, PLACEHOLDER)))
+                .isEqualTo("{\"" + PLACEHOLDER + "\":\"" + PLACEHOLDER + "\"}");
+    }
+
+    @Test
+    public void shouldMatchOnlyTheDeclaredPlaceholder() {
+        final String declared = UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_STRING_SCHEMA, PLACEHOLDER);
+        assertThat(UnavailableValuePlaceholderParameter.matches(Schema.OPTIONAL_STRING_SCHEMA, PLACEHOLDER, declared)).isTrue();
+        assertThat(UnavailableValuePlaceholderParameter.matches(Schema.OPTIONAL_STRING_SCHEMA, "other", declared)).isFalse();
+    }
+
+    @Test
+    public void shouldMatchEveryTypeItCanSerialize() {
+        final Schema strings = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build();
+        final Schema map = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).build();
+        final Map<Schema, Object> placeholders = new LinkedHashMap<>();
+        placeholders.put(Schema.OPTIONAL_STRING_SCHEMA, PLACEHOLDER);
+        placeholders.put(Schema.OPTIONAL_BYTES_SCHEMA, PLACEHOLDER_BYTES);
+        placeholders.put(SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).build(), List.of(9, 5));
+        placeholders.put(strings, List.of(PLACEHOLDER));
+        placeholders.put(map, Map.of(PLACEHOLDER, PLACEHOLDER));
+
+        placeholders.forEach((schema, placeholder) -> {
+            final String declared = UnavailableValuePlaceholderParameter.serialize(schema, placeholder);
+            assertThat(declared).isNotNull();
+            assertThat(UnavailableValuePlaceholderParameter.matches(schema, placeholder, declared)).isTrue();
+        });
+
+        // A map that holds more than the declared single entry is not the placeholder
+        final String declaredMap = UnavailableValuePlaceholderParameter.serialize(map, Map.of(PLACEHOLDER, PLACEHOLDER));
+        assertThat(UnavailableValuePlaceholderParameter.matches(map, Map.of(PLACEHOLDER, PLACEHOLDER, "k", "v"), declaredMap)).isFalse();
+    }
+
+    @Test
+    public void shouldRejectOversizedValuesWithoutSerializingThemInFull() {
+        final Schema bytes = Schema.OPTIONAL_BYTES_SCHEMA;
+        final String declared = UnavailableValuePlaceholderParameter.serialize(bytes, PLACEHOLDER_BYTES);
+        final ByteBuffer oversized = ByteBuffer.wrap(new byte[10 * 1024 * 1024]);
+        assertThat(UnavailableValuePlaceholderParameter.matches(bytes, oversized, declared)).isFalse();
+        // the value was rejected on length alone, so it was never read
+        assertThat(oversized.position()).isZero();
+
+        final Schema strings = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build();
+        final String declaredArray = UnavailableValuePlaceholderParameter.serialize(strings, List.of(PLACEHOLDER));
+        assertThat(UnavailableValuePlaceholderParameter.matches(strings, List.of(PLACEHOLDER, PLACEHOLDER), declaredArray)).isFalse();
+        assertThat(UnavailableValuePlaceholderParameter.matches(strings, List.of("x".repeat(10 * 1024 * 1024)), declaredArray)).isFalse();
+
+        final Schema map = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).build();
+        final String declaredMap = UnavailableValuePlaceholderParameter.serialize(map, Map.of(PLACEHOLDER, PLACEHOLDER));
+        assertThat(UnavailableValuePlaceholderParameter.matches(map, Map.of("x".repeat(10 * 1024 * 1024), "v"), declaredMap)).isFalse();
+    }
+
+    @Test
+    public void shouldNotSerializeUnsupportedOrMismatchedValues() {
+        assertThat(UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_STRING_SCHEMA, null)).isNull();
+        // Java type not matching the schema type
+        assertThat(UnavailableValuePlaceholderParameter.serialize(SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).build(), PLACEHOLDER)).isNull();
+        assertThat(UnavailableValuePlaceholderParameter.serialize(Schema.OPTIONAL_INT32_SCHEMA, PLACEHOLDER)).isNull();
+        // structs are not supported
+        final Schema struct = SchemaBuilder.struct().field("f", Schema.OPTIONAL_STRING_SCHEMA).build();
+        assertThat(UnavailableValuePlaceholderParameter.serialize(struct, new org.apache.kafka.connect.data.Struct(struct))).isNull();
+        // an array containing a null element has no canonical representation
+        final Schema strings = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build();
+        assertThat(UnavailableValuePlaceholderParameter.serialize(strings, Arrays.asList("a", null))).isNull();
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1149,6 +1149,18 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     "the original value is a toasted value not provided by the database. " +
                     "If starts with 'hex:' prefix it is expected that the rest of the string represents hexadecimal encoded octets.");
 
+    public static final Field PROPAGATE_COLUMN_UNAVAILABLE_VALUE_PLACEHOLDER = Field.create("column.propagate.unavailable.value.placeholder")
+            .withDisplayName("Propagate unavailable value placeholders by columns")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(false)
+            .withDescription("Declare the exact unavailable value placeholder representation each column carries "
+                    + "as the '__debezium.unavailable.value.placeholder' schema parameter, so consumers such as the "
+                    + "reselect columns post processor can recognize placeholder values without inferring them from the value shape. "
+                    + "Enabling the parameter changes the registered schemas of captured tables.");
+
     public static final Field MONEY_FRACTION_DIGITS = Field.create("money.fraction.digits")
             .withDisplayName("Money fraction digits")
             .withType(Type.SHORT)
@@ -1528,6 +1540,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return publishViaPartitionRoot;
     }
 
+    public boolean isUnavailableValuePlaceholderPropagated() {
+        return getConfig().getBoolean(PROPAGATE_COLUMN_UNAVAILABLE_VALUE_PLACEHOLDER);
+    }
+
     @Override
     public byte[] getUnavailableValuePlaceholder() {
         String placeholder = getConfig().getString(UNAVAILABLE_VALUE_PLACEHOLDER);
@@ -1582,7 +1598,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     LSN_FLUSH_TIMEOUT_ACTION, XMIN_FETCH_INTERVAL)
             .group(Field.Group.CONNECTOR, HSTORE_HANDLING_MODE, BINARY_HANDLING_MODE, SCHEMA_NAME_ADJUSTMENT_MODE, INTERVAL_HANDLING_MODE,
                     LOGICAL_DECODING_MESSAGE_PREFIX_INCLUDE_LIST, LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST, PUBLISH_VIA_PARTITION_ROOT, LSN_FLUSH_MODE,
-                    SHOULD_FLUSH_LSN_IN_SOURCE_DB, UNAVAILABLE_VALUE_PLACEHOLDER, SKIPPED_OPERATIONS)
+                    SHOULD_FLUSH_LSN_IN_SOURCE_DB, UNAVAILABLE_VALUE_PLACEHOLDER, PROPAGATE_COLUMN_UNAVAILABLE_VALUE_PLACEHOLDER, SKIPPED_OPERATIONS)
             .group(Field.Group.CONNECTOR_ADVANCED, SCHEMA_REFRESH_MODE, INCLUDE_UNKNOWN_DATATYPES, SOURCE_INFO_STRUCT_MAKER)
             .group(Field.Group.CONNECTOR_SNAPSHOT, SNAPSHOT_MODE, SNAPSHOT_ISOLATION_MODE, SNAPSHOT_QUERY_MODE, SNAPSHOT_QUERY_MODE_CUSTOM_NAME, SNAPSHOT_LOCKING_MODE,
                     SNAPSHOT_LOCKING_MODE_CUSTOM_NAME, INCREMENTAL_SNAPSHOT_CHUNK_SIZE)

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -74,6 +74,7 @@ import io.debezium.data.Bits;
 import io.debezium.data.Json;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.TsVector;
+import io.debezium.data.UnavailableValuePlaceholderParameter;
 import io.debezium.data.Uuid;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.geometry.Circle;
@@ -187,6 +188,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
 
     private final UnchangedToastedPlaceholder unchangedToastedPlaceholder;
     private final int moneyFractionDigits;
+    private final boolean declareUnavailableValuePlaceholderParameter;
 
     public static PostgresValueConverter of(PostgresConnectorConfig connectorConfig, Charset databaseCharset, TypeRegistry typeRegistry) {
         return new PostgresValueConverter(
@@ -201,14 +203,16 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 connectorConfig.binaryHandlingMode(),
                 connectorConfig.intervalHandlingMode(),
                 new UnchangedToastedPlaceholder(connectorConfig),
-                connectorConfig.moneyFractionDigits());
+                connectorConfig.moneyFractionDigits(),
+                connectorConfig.isUnavailableValuePlaceholderPropagated());
     }
 
     protected PostgresValueConverter(Charset databaseCharset, DecimalMode decimalMode,
                                      TemporalPrecisionMode temporalPrecisionMode, ZoneOffset defaultOffset,
                                      BigIntUnsignedMode bigIntUnsignedMode, boolean includeUnknownDatatypes, TypeRegistry typeRegistry,
                                      HStoreHandlingMode hStoreMode, BinaryHandlingMode binaryMode, IntervalHandlingMode intervalMode,
-                                     UnchangedToastedPlaceholder unchangedToastedPlaceholder, int moneyFractionDigits) {
+                                     UnchangedToastedPlaceholder unchangedToastedPlaceholder, int moneyFractionDigits,
+                                     boolean declareUnavailableValuePlaceholderParameter) {
         super(decimalMode, temporalPrecisionMode, defaultOffset, null, bigIntUnsignedMode, binaryMode);
         this.databaseCharset = databaseCharset;
         this.jsonFactory = new JsonFactory();
@@ -218,10 +222,49 @@ public class PostgresValueConverter extends JdbcValueConverters {
         this.intervalMode = intervalMode;
         this.moneyFractionDigits = moneyFractionDigits;
         this.unchangedToastedPlaceholder = unchangedToastedPlaceholder;
+        this.declareUnavailableValuePlaceholderParameter = declareUnavailableValuePlaceholderParameter;
     }
 
     @Override
     public SchemaBuilder schemaBuilder(Column column) {
+        final SchemaBuilder builder = columnSchemaBuilder(column);
+        if (builder == null || !declareUnavailableValuePlaceholderParameter) {
+            return builder;
+        }
+        return declareUnavailableValuePlaceholder(column, builder);
+    }
+
+    /**
+     * Declares the unavailable value placeholder representation of the column as a schema parameter.
+     *
+     * <p>The representation is computed by running the column's own value converter over the unchanged
+     * toast marker the streaming source would supply, so the declared representation is by construction
+     * the value the connector emits at runtime. Columns whose placeholder conversion does not yield a
+     * value valid for the column's schema (e.g. fixed-width types that can never be toasted) get no
+     * parameter.
+     */
+    private SchemaBuilder declareUnavailableValuePlaceholder(Column column, SchemaBuilder builder) {
+        try {
+            final Field field = new Field(column.name(), 0, builder.build());
+            final ValueConverter converter = converter(column, field);
+            if (converter == null) {
+                return builder;
+            }
+            final Object placeholder = converter.convert(UnchangedToastedReplicationMessageColumn.markerForType(column.typeName()));
+            final String serialized = UnavailableValuePlaceholderParameter.serialize(field.schema(), placeholder);
+            if (serialized != null) {
+                builder.parameter(UnavailableValuePlaceholderParameter.SCHEMA_PARAMETER_KEY, serialized);
+            }
+        }
+        catch (RuntimeException e) {
+            // Expected for a non-optional column whose type cannot hold the marker, i.e. one that is never
+            // toasted; declaring no parameter is always safe, so this must not fail schema construction
+            logger.debug("Column {} cannot carry an unavailable value placeholder: {}", column.name(), e.getMessage());
+        }
+        return builder;
+    }
+
+    private SchemaBuilder columnSchemaBuilder(Column column) {
         int oidValue = column.nativeType();
         switch (oidValue) {
             case PgOid.BIT:
@@ -474,7 +517,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 .length(column.length())
                 .create();
 
-        return schemaBuilder(elementColumn);
+        // The placeholder parameter is declared on the field schema only, never on element schemas
+        return columnSchemaBuilder(elementColumn);
     }
 
     @Override
@@ -649,7 +693,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 .length(column.length())
                 .create();
 
-        SchemaBuilder elementSchemaBuilder = schemaBuilder(elementColumn);
+        SchemaBuilder elementSchemaBuilder = columnSchemaBuilder(elementColumn);
         if (elementSchemaBuilder == null) {
             return null;
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedPlaceholder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedPlaceholder.java
@@ -31,7 +31,8 @@ public class UnchangedToastedPlaceholder {
     /**
      * Provides different representations of a placeholder value.<br>
      *
-     * <b>NOTE:</b> Adding new types might require an update in {@link io.debezium.processors.reselect.ReselectColumnsPostProcessor}.
+     * <b>NOTE:</b> Adding new types might require an update in {@link io.debezium.processors.reselect.ReselectColumnsPostProcessor},
+     * unless the placeholder is declared as a schema parameter via {@code column.propagate.unavailable.value.placeholder}.
      *
      * @param connectorConfig
      */

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
@@ -43,7 +43,7 @@ public class UnchangedToastedReplicationMessageColumn extends AbstractReplicatio
 
     public UnchangedToastedReplicationMessageColumn(String columnName, PostgresType type, String typeWithModifiers, boolean optional) {
         super(columnName, type, typeWithModifiers, optional);
-        setUnchangedToastValue(typeWithModifiers);
+        unchangedToastValue = markerForType(typeWithModifiers);
     }
 
     @Override
@@ -69,7 +69,10 @@ public class UnchangedToastedReplicationMessageColumn extends AbstractReplicatio
         return unchangedToastValue;
     }
 
-    private void setUnchangedToastValue(String typeWithModifiers) {
+    /**
+     * Returns the marker object used for an unchanged toasted column of the given type.
+     */
+    public static Object markerForType(String typeWithModifiers) {
         typeWithModifiers = removeSizeModifierFromArrayTypes(typeWithModifiers);
         switch (typeWithModifiers) {
             case "text[]":
@@ -82,39 +85,33 @@ public class UnchangedToastedReplicationMessageColumn extends AbstractReplicatio
             case "_json":
             case "jsonb[]":
             case "_jsonb":
-                unchangedToastValue = UNCHANGED_TEXT_ARRAY_TOAST_VALUE;
-                break;
+                return UNCHANGED_TEXT_ARRAY_TOAST_VALUE;
             case "bytea[]":
             case "_bytea":
-                unchangedToastValue = UNCHANGED_BINARY_ARRAY_TOAST_VALUE;
-                break;
+                return UNCHANGED_BINARY_ARRAY_TOAST_VALUE;
             case "integer[]":
             case "_int4":
             case "date[]":
             case "_date":
-                unchangedToastValue = UNCHANGED_INT_ARRAY_TOAST_VALUE;
-                break;
+                return UNCHANGED_INT_ARRAY_TOAST_VALUE;
             case "bigint[]":
             case "_int8":
-                unchangedToastValue = UNCHANGED_BIGINT_ARRAY_TOAST_VALUE;
-                break;
+                return UNCHANGED_BIGINT_ARRAY_TOAST_VALUE;
             case "hstore":
-                unchangedToastValue = UNCHANGED_HSTORE_TOAST_VALUE;
-                break;
+                return UNCHANGED_HSTORE_TOAST_VALUE;
             case "uuid[]":
             case "_uuid":
-                unchangedToastValue = UNCHANGED_UUID_TOAST_VALUE;
-                break;
+                return UNCHANGED_UUID_TOAST_VALUE;
             default:
-                unchangedToastValue = UNCHANGED_TOAST_VALUE;
+                return UNCHANGED_TOAST_VALUE;
         }
     }
 
-    private boolean isArrayType(String typeWithModifiers) {
+    private static boolean isArrayType(String typeWithModifiers) {
         return typeWithModifiers.startsWith(TYPE_ARRAY_PREFIX) || typeWithModifiers.endsWith(TYPE_ARRAY_SUFFIX);
     }
 
-    protected String removeSizeModifierFromArrayTypes(String typeWithModifiers) {
+    protected static String removeSizeModifierFromArrayTypes(String typeWithModifiers) {
         // Removing the size for type like _varchar(2000, 0)
         if (isArrayType(typeWithModifiers)) {
             final int leftParenthesis = typeWithModifiers.indexOf("(");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -25,12 +26,14 @@ import org.junit.jupiter.api.Test;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.data.Envelope;
+import io.debezium.data.UnavailableValuePlaceholderParameter;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.processors.AbstractReselectProcessorTest;
 import io.debezium.processors.reselect.ReselectColumnsPostProcessor;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 /**
  * Postgres' integration tests for {@link ReselectColumnsPostProcessor}.
@@ -380,6 +383,134 @@ public class PostgresReselectColumnsProcessorIT extends AbstractReselectProcesso
         assertThat(after.get("data2")).isEqualTo(2);
 
         assertColumnReselectedForUnavailableValue(logInterceptor, "s1.dbz8212_toast", "data");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2495")
+    public void testToastColumnUuidArrayReselectedWhenPlaceholderDeclaredAsSchemaParameter() throws Exception {
+        TestHelper.execute("CREATE TABLE s1.dbz2495_toast (id int primary key, data uuid[], data2 int);");
+
+        final LogInterceptor logInterceptor = getReselectLogInterceptor();
+
+        Configuration config = getConfigurationBuilder()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1\\.dbz2495_toast")
+                .with(PostgresConnectorConfig.PROPAGATE_COLUMN_UNAVAILABLE_VALUE_PLACEHOLDER, "true")
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingStarted();
+
+        TestHelper.execute(
+                "INSERT INTO s1.dbz2495_toast (id,data,data2) values (1,(SELECT array_agg(gen_random_uuid()) FROM generate_series(1,1000)), 1);",
+                "UPDATE s1.dbz2495_toast SET data2 = 2 where id = 1;");
+
+        final SourceRecords sourceRecords = consumeRecordsByTopic(2);
+        final List<SourceRecord> tableRecords = sourceRecords.recordsForTopic("test_server.s1.dbz2495_toast");
+
+        // Check insert
+        SourceRecord record = tableRecords.get(0);
+        Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidInsert(record, "id", 1);
+        final Object uuidValues = after.get("data");
+        assertThat((List<?>) uuidValues).hasSize(1000);
+
+        // The connector declares the exact placeholder representation of the column as a schema parameter
+        final String declared = after.schema().field("data").schema().parameters()
+                .get(UnavailableValuePlaceholderParameter.SCHEMA_PARAMETER_KEY);
+        final String placeholderUuid = UUID.nameUUIDFromBytes(
+                RelationalDatabaseConnectorConfig.DEFAULT_UNAVAILABLE_VALUE_PLACEHOLDER.getBytes()).toString();
+        assertThat(declared).isEqualTo("[\"" + placeholderUuid + "\"]");
+
+        // Check update: uuid[] placeholders are not recognized by the value-shape heuristics, so the
+        // re-selection can only have happened through the declared schema parameter
+        record = tableRecords.get(1);
+        after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidUpdate(record, "id", 1);
+        assertThat(after.get("id")).isEqualTo(1);
+        assertThat(after.get("data")).isEqualTo(uuidValues);
+        assertThat(after.get("data2")).isEqualTo(2);
+
+        assertColumnReselectedForUnavailableValue(logInterceptor, "s1.dbz2495_toast", "data");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2495")
+    public void testGenuineArrayValueContainingThePlaceholderIsNotReselectedWhenDeclared() throws Exception {
+        TestHelper.execute("CREATE TABLE s1.dbz2495_collision (id int primary key, data text[], data2 int);");
+
+        final LogInterceptor logInterceptor = getReselectLogInterceptor();
+
+        Configuration config = getConfigurationBuilder()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1\\.dbz2495_collision")
+                .with(PostgresConnectorConfig.PROPAGATE_COLUMN_UNAVAILABLE_VALUE_PLACEHOLDER, "true")
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingStarted();
+
+        // A short array, so it is never toasted, that genuinely holds the sentinel as one of its elements.
+        // The value-shape heuristics match an array as unavailable as soon as any single element equals the
+        // sentinel, so without the declared representation this row is reselected on every update.
+        final List<String> textValues = List.of("a", RelationalDatabaseConnectorConfig.DEFAULT_UNAVAILABLE_VALUE_PLACEHOLDER, "b");
+        final String data = textValues.stream().map(v -> "\"" + v + "\"").collect(Collectors.joining(", "));
+
+        TestHelper.execute(
+                "INSERT INTO s1.dbz2495_collision (id,data,data2) values (1,'{" + data + "}', 1);",
+                "UPDATE s1.dbz2495_collision SET data2 = 2 where id = 1;");
+
+        final SourceRecords sourceRecords = consumeRecordsByTopic(2);
+        final List<SourceRecord> tableRecords = sourceRecords.recordsForTopic("test_server.s1.dbz2495_collision");
+
+        SourceRecord record = tableRecords.get(1);
+        Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidUpdate(record, "id", 1);
+        assertThat(after.get("data")).isEqualTo(textValues);
+        assertThat(after.get("data2")).isEqualTo(2);
+
+        // The declared representation holds a single element, so the three-element value cannot be the placeholder
+        final String declared = after.schema().field("data").schema().parameters()
+                .get(UnavailableValuePlaceholderParameter.SCHEMA_PARAMETER_KEY);
+        assertThat(declared).isEqualTo("[\"" + RelationalDatabaseConnectorConfig.DEFAULT_UNAVAILABLE_VALUE_PLACEHOLDER + "\"]");
+        assertThat(logInterceptor.containsMessage(
+                "Adding column data for table s1.dbz2495_collision to re-select list due to unavailable value placeholder.")).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2495")
+    public void testToastColumnTextArrayReselectedWhenPlaceholderDeclaredAsSchemaParameter() throws Exception {
+        TestHelper.execute("CREATE TABLE s1.dbz2495_text_array (id int primary key, data text[], data2 int);");
+
+        final LogInterceptor logInterceptor = getReselectLogInterceptor();
+
+        final List<String> textValues = new ArrayList<>();
+        textValues.add(RandomStringUtils.randomAlphanumeric(8192));
+        textValues.add(RandomStringUtils.randomAlphanumeric(8192));
+
+        final String data = textValues.stream().map(v -> "\"" + v + "\"").collect(Collectors.joining(", "));
+
+        Configuration config = getConfigurationBuilder()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1\\.dbz2495_text_array")
+                .with(PostgresConnectorConfig.PROPAGATE_COLUMN_UNAVAILABLE_VALUE_PLACEHOLDER, "true")
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingStarted();
+
+        TestHelper.execute(
+                "INSERT INTO s1.dbz2495_text_array (id,data,data2) values (1,'{" + data + "}', 1);",
+                "UPDATE s1.dbz2495_text_array SET data2 = 2 where id = 1;");
+
+        final SourceRecords sourceRecords = consumeRecordsByTopic(2);
+        final List<SourceRecord> tableRecords = sourceRecords.recordsForTopic("test_server.s1.dbz2495_text_array");
+
+        // A type the heuristics already recognize keeps working through the declared representation
+        SourceRecord record = tableRecords.get(1);
+        Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        VerifyRecord.isValidUpdate(record, "id", 1);
+        assertThat(after.get("data")).isEqualTo(textValues);
+        assertThat(after.get("data2")).isEqualTo(2);
+
+        assertColumnReselectedForUnavailableValue(logInterceptor, "s1.dbz2495_text_array", "data");
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -561,6 +561,7 @@ public final class TestHelper {
                 config.binaryHandlingMode(),
                 config.intervalHandlingMode(),
                 new UnchangedToastedPlaceholder(config),
-                config.moneyFractionDigits());
+                config.moneyFractionDigits(),
+                config.isUnavailableValuePlaceholderPropagated());
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -4654,6 +4654,12 @@ For example to request the publisher to send all changes, that is, changes that 
 If the setting of `unavailable.value.placeholder` starts with the `hex:` prefix it is expected that the rest of the string represents hexadecimally encoded octets.
 For more information, see xref:postgresql-toasted-values[toasted values].
 
+|[[postgresql-property-column-propagate-unavailable-value-placeholder]]<<postgresql-property-column-propagate-unavailable-value-placeholder, `+column.propagate.unavailable.value.placeholder+`>>
+|`false`
+|Specifies whether the connector declares the exact placeholder representation that each column carries in the `__debezium.unavailable.value.placeholder` schema parameter of the column's field schema.
+Consumers such as the reselect columns post processor use the declared representation to recognize placeholder values without inferring them from the value shape.
+Enabling this option changes the registered schemas of captured tables.
+
 |[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata.

--- a/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
+++ b/documentation/modules/ROOT/pages/post-processors/reselect-columns.adoc
@@ -36,6 +36,11 @@ You can configure the post processor to reselect the following column types:
  * `null` columns.
  * Columns that contain the `unavailable.value.placeholder` sentinel value.
 
+By default, the post processor recognizes sentinel values by inferring them from the shape of the column value.
+A connector can instead declare the exact placeholder representation of a column in the `__debezium.unavailable.value.placeholder` schema parameter.
+The PostgreSQL connector declares it when `column.propagate.unavailable.value.placeholder` is set to `true`.
+For a column that carries the parameter, the post processor compares the value against the declared representation, which works for any column type.
+
 
 NOTE: You can use the `ReselectColumnsPostProcessor` post processor only with {prodname} source connectors.
 The post processor is not designed to work with the {prodname} JDBC sink connector.


### PR DESCRIPTION
Part of debezium/dbz#2495

## Description

Following the direction agreed on the issue, this stops the reselect columns post processor from inferring an unavailable value placeholder from the shape of a value, for columns where the connector can state the answer instead.

A connector may declare the exact placeholder representation of a column in the new `__debezium.unavailable.value.placeholder` schema parameter. When a field carries it, the post processor compares the value against the declaration and ignores the shape inference for that column. Two consequences:

- Any column type is recognized, including ones the inference never covered. `uuid[]` placeholders have been built since DBZ-6720 but were never recognized, so those columns were silently never reselected.
- A genuine value that merely resembles a placeholder no longer triggers a re-select. The inference marks an array as unavailable as soon as any single element equals the sentinel, so a real `text[]` holding the sentinel among other elements is reselected on every update today.

PostgreSQL declares the parameter when `column.propagate.unavailable.value.placeholder` is set; it is off by default. The declared representation is produced by running the column's own `ValueConverter` over the unchanged toast marker, so it is by construction the value the connector emits at runtime rather than a second hand-maintained mapping. A column whose conversion does not yield a representable value gets no parameter and keeps using the existing inference, as do events from connectors that do not declare it.

This is deliberately the first of three steps, so the format can be reviewed before it becomes a compatibility commitment:

1. this PR: the parameter contract, one producer, one consumer, behind a flag.
2. producers for Oracle, SQL Server and MariaDB/MySQL, and gating attachment on columns that can actually be toasted. The option would move to `RelationalDatabaseConnectorConfig` at that point; it sits in `PostgresConnectorConfig` here because PostgreSQL is the only connector that honours it.
3. flip the default and delete the inference: `ReselectColumnsPostProcessor#isUnavailableValueHolder(Schema, Object)`, `#isUnavailableArrayValueHolder`, and `OracleDatabaseSchema#isColumnUnavailableValuePlaceholder`.

Two things worth stating up front:

- Step 1 attaches the parameter to columns that can never hold a placeholder, because the probe cannot yet tell them apart. It is harmless, since a genuine value of such a column cannot collide with a representation it never carries, but it makes the schema footprint larger than it needs to be. That is what step 2's toastability gate is for, and it is why the default is off: with the flag forced on, 64 of the 132 `RecordsStreamProducerIT` cases see a new schema parameter on columns unrelated to TOAST.
- A declared representation cannot disambiguate a genuine value that is byte-for-byte the placeholder. Declaring the convention removes the guesswork about the value's shape, not the in-band nature of the signal itself. This seems inherent and worth documenting rather than solving.

Some choices that are not obvious from the diff:

- The parameter is not attached through `ColumnMapper#alterFieldSchema`, which is how `__debezium.source.column.*` is attached and would need no changes to `PostgresValueConverter`. A mapper receives the `Column` and the `SchemaBuilder` but not the `ValueConverter`, and deriving the representation from the converter is the property that keeps the declaration honest.
- `SchemaUtil#asString` already renders lists, maps and binary values, but it is a debug formatter: it is schema free, so `5` and `"5"` render alike, and promoting it to a wire contract embedded in registered schemas would freeze a debug format.
- `matches` bounds its work by the length of the declared representation, so a multi-megabyte value is rejected without being serialized in full.

The unavailable value placeholder is also not recognized at all under `binary.handling.mode=base64` and `base64-url-safe`, for every connector that emits a binary placeholder. That is a pre-existing defect independent of this change and will be raised separately.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

