### PR TITLE
debezium/dbz#2533 Respect the buffer position in ByteBuffers.equals heap path

### DIFF
--- a/debezium-util/src/main/java/io/debezium/util/ByteBuffers.java
+++ b/debezium-util/src/main/java/io/debezium/util/ByteBuffers.java
@@ -42,7 +42,9 @@ public final class ByteBuffers {
         // For HeapByteBuffer, use the backing array directly
         if (buffer.hasArray()) {
             byte[] bufferArray = buffer.array();
-            int bufferOffset = buffer.arrayOffset();
+            // Start at the buffer's current position, not index 0, so a partially-consumed buffer is
+            // compared over the same [position, limit) window as remaining() and the direct branch.
+            int bufferOffset = buffer.arrayOffset() + buffer.position();
             int bufferLength = buffer.remaining();
 
             // Compare the relevant portion of the buffer's backing array

--- a/debezium-util/src/test/java/io/debezium/util/ByteBuffersTest.java
+++ b/debezium-util/src/test/java/io/debezium/util/ByteBuffersTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit test for {@link ByteBuffers}.
+ */
+public class ByteBuffersTest {
+
+    @Test
+    @FixFor("debezium/dbz#2533")
+    public void shouldCompareRemainingContentOfPartiallyConsumedHeapBuffer() {
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        buffer.put(new byte[]{ 9, 9, 3, 4 });
+        buffer.flip();
+        buffer.position(2); // remaining content is {3, 4}
+        assertThat(ByteBuffers.equals(buffer, new byte[]{ 3, 4 })).isTrue();
+        assertThat(ByteBuffers.equals(buffer, new byte[]{ 9, 9 })).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2533")
+    public void heapAndDirectBuffersShouldAgreeForTheSameContent() {
+        byte[] content = { 9, 9, 3, 4 };
+        byte[] expected = { 3, 4 };
+
+        ByteBuffer heap = ByteBuffer.allocate(4);
+        heap.put(content);
+        heap.flip();
+        heap.position(2);
+
+        ByteBuffer direct = ByteBuffer.allocateDirect(4);
+        direct.put(content);
+        direct.flip();
+        direct.position(2);
+
+        assertThat(ByteBuffers.equals(heap, expected)).isTrue();
+        assertThat(ByteBuffers.equals(direct, expected)).isEqualTo(ByteBuffers.equals(heap, expected));
+    }
+
+    @Test
+    public void shouldCompareWrappedArray() {
+        assertThat(ByteBuffers.equals(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }), new byte[]{ 1, 2, 3 })).isTrue();
+        assertThat(ByteBuffers.equals(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }), new byte[]{ 1, 2, 4 })).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseWhenLengthsDiffer() {
+        assertThat(ByteBuffers.equals(ByteBuffer.wrap(new byte[]{ 1, 2 }), new byte[]{ 1, 2, 3 })).isFalse();
+    }
+
+    @Test
+    public void shouldHandleNulls() {
+        assertThat(ByteBuffers.equals(null, null)).isTrue();
+        assertThat(ByteBuffers.equals(null, new byte[]{ 1 })).isFalse();
+        assertThat(ByteBuffers.equals(ByteBuffer.wrap(new byte[]{ 1 }), null)).isFalse();
+    }
+}


### PR DESCRIPTION
Fixes [debezium/dbz#2533](https://github.com/debezium/dbz/issues/2533).

### Problem

`ByteBuffers.equals(ByteBuffer, byte[])` returns different results for the same logical content depending on whether the buffer is heap- or direct-backed, because the heap fast-path ignores the buffer's `position()`:

```java
if (buffer.hasArray()) {
    int bufferOffset = buffer.arrayOffset();   // omits + position()
    int bufferLength = buffer.remaining();
    return Arrays.equals(bufferArray, bufferOffset, bufferOffset + bufferLength, array, 0, array.length);
}
```

The length gate uses `buffer.remaining()` (= `limit - position`) and the direct-buffer branch reads `buffer.get(position + i)`, so both treat the buffer's content as the `[position, limit)` window. The heap branch instead scans `[arrayOffset, arrayOffset + remaining)` — starting at logical index 0, correct only when `position() == 0`.

```java
byte[] array = {3, 4};
ByteBuffer heap = ByteBuffer.allocate(4);
heap.put(new byte[]{9, 9, 3, 4}); heap.flip(); heap.position(2);   // remaining = {3, 4}
ByteBuffers.equals(heap, array);   // false — expected true; a direct buffer with the same content returns true
```

The only in-repo caller (`ReselectColumnsPostProcessor`) passes a `wrap(...)` with `position() == 0`, so this is latent for the shipping connectors — but `ByteBuffers` is a public utility and the two branches genuinely disagree for a partially-consumed heap buffer.

### Fix

`int bufferOffset = buffer.arrayOffset() + buffer.position();` — so the heap path compares the same `[position, limit)` window as `remaining()` and the direct branch.

### Test

`ByteBuffers` had no test. `ByteBuffersTest` covers a partially-consumed heap buffer, heap/direct agreement for the same content, wrapped arrays, length mismatch, and nulls. The two position-sensitive cases fail against the current code and pass with the fix.
