### PR TITLE
Ensure properties are omitted for deleted relationships in Neo4J SMT

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
@@ -86,7 +86,7 @@ public class CudEventFactory {
         final var to = new CudRelationshipEvent.Endpoint(
                 List.of(relMapping.targetLabel()), targetIds, relMapping.targetNodeOp());
 
-        final var relProps = extractRelationshipProperties(data, relMapping);
+        final var relProps = cudOp == Operation.DELETE ? null : extractRelationshipProperties(data, relMapping);
 
         if (relMapping.direction() == RelationshipMapping.Direction.INCOMING) {
             return new CudRelationshipEvent(cudOp, relMapping.type(), to, from, relProps);
@@ -145,7 +145,7 @@ public class CudEventFactory {
         final var to = new CudRelationshipEvent.Endpoint(List.of(toMapping.targetLabel()), toIds, endpointOp);
 
         final var fkColumns = mapping.fkColumns();
-        final var relProps = extractNonFkProperties(data, fkColumns, fromMapping);
+        final var relProps = cudOp == Operation.DELETE ? null : extractNonFkProperties(data, fkColumns, fromMapping);
 
         // Endpoint roles are fixed by direction (outgoing = source, incoming = target), so the relationship
         // always runs from -> to; the type and properties come from the outgoing (source) mapping.

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventSerializer.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventSerializer.java
@@ -61,7 +61,9 @@ public class CudEventSerializer {
         map.put("rel_type", rel.relType());
         map.put("from", toEndpointMap(rel.from()));
         map.put("to", toEndpointMap(rel.to()));
-        map.put("properties", toPropertyValues(rel.properties()));
+        if (rel.properties() != null) {
+            map.put("properties", toPropertyValues(rel.properties()));
+        }
         return map;
     }
 

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/Neo4jCudConverterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/Neo4jCudConverterTest.java
@@ -526,6 +526,33 @@ class Neo4jCudConverterTest {
             assertThat(events).hasSize(1);
             assertThat(events.get(0).get("type")).isEqualTo("relationship");
             assertThat(events.get(0).get("op")).isEqualTo("delete");
+            // The Neo4j CUD format forbids a properties block on relationship deletes; the key must be absent.
+            assertThat(events.get(0)).doesNotContainKey("properties");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("DELETE in single output mode omits properties on the relationship")
+        void joinTableDeleteSingleMode() throws Exception {
+            final var transform = configureOrderItemTransform("single");
+            final var before = orderItemAfter();
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(ORDER_ITEM_SCHEMA)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var source = createSource("order_items");
+            final var payload = envelope.delete(before, source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.order_items",
+                    envelope.schema(), payload);
+
+            final var result = transform.apply(record);
+
+            final var parsed = OBJECT_MAPPER.readValue((String) result.value(), Map.class);
+            assertThat(parsed.get("type")).isEqualTo("relationship");
+            assertThat(parsed.get("op")).isEqualTo("delete");
+            assertThat(parsed).doesNotContainKey("properties");
 
             transform.close();
         }

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventSerializerTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventSerializerTest.java
@@ -111,6 +111,23 @@ class CudEventSerializerTest {
             assertThat(asMap(parsed, "from")).containsEntry("op", "merge");
             assertThat(asMap(parsed, "to")).containsEntry("op", "match");
         }
+
+        @Test
+        @DisplayName("Serializes a delete relationship with no properties")
+        void serializeDeleteRelationship() throws Exception {
+            final var from = new CudRelationshipEvent.Endpoint(
+                    List.of("Order"), Map.of("id", 5001L), Operation.MATCH);
+            final var to = new CudRelationshipEvent.Endpoint(
+                    List.of("Product"), Map.of("id", 201L), Operation.MATCH);
+            final var event = new CudRelationshipEvent(Operation.DELETE, "CONTAINS", from, to, null);
+
+            final var json = serializer.serializeSingle(event);
+
+            final var parsed = parseJson(json);
+            assertThat(parsed.get("type")).isEqualTo("relationship");
+            assertThat(parsed.get("op")).isEqualTo("delete");
+            assertThat(parsed).doesNotContainKey("properties");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Description

Neo4J Sink connector forbids a properties block on relationship deletes; the key must be absent.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
