### PR TITLE
debezium/dbz#1643 Validate capture.target according to capture.scope

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -1101,7 +1101,8 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
                     CURSOR_MAX_AWAIT_TIME_MS)
             .group(Field.Group.FILTERS, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, COLLECTION_INCLUDE_LIST, COLLECTION_EXCLUDE_LIST, FIELD_EXCLUDE_LIST, FIELD_RENAMES,
                     SNAPSHOT_FILTER_QUERY_BY_COLLECTION)
-            .group(Field.Group.CONNECTOR, TOPIC_PREFIX, SNAPSHOT_MODE, CAPTURE_MODE, JSON_SERIALIZATION_MODE, SCHEMA_NAME_ADJUSTMENT_MODE, SOURCE_INFO_STRUCT_MAKER)
+            .group(Field.Group.CONNECTOR, TOPIC_PREFIX, SNAPSHOT_MODE, CAPTURE_MODE, CAPTURE_SCOPE, CAPTURE_TARGET, JSON_SERIALIZATION_MODE, SCHEMA_NAME_ADJUSTMENT_MODE,
+                    SOURCE_INFO_STRUCT_MAKER)
             .create();
 
     /**
@@ -1285,18 +1286,36 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
 
     private static int validateCaptureTarget(Configuration config, Field field, ValidationOutput problems) {
         var value = config.getString(field);
-        var scope = config.getString(MongoDbConnectorConfig.CAPTURE_SCOPE);
+        var scope = CaptureScope.parse(config.getString(CAPTURE_SCOPE), CAPTURE_SCOPE.defaultValueAsString());
 
-        if (value != null && CaptureScope.DEPLOYMENT.value.equals(scope)) {
-            LOGGER.warn("Config property '{}' will be ignored due to {}={}", field.name(), CAPTURE_SCOPE.name(), scope);
+        if (scope == null) {
+            // An invalid capture.scope value is reported by the capture.scope field validation
+            return 0;
         }
 
-        if (value == null) {
-            problems.accept(field, null, field.name() + "property is missing");
-            return 1;
+        switch (scope) {
+            case DEPLOYMENT:
+                if (value != null) {
+                    LOGGER.warn("Config property '{}' will be ignored due to {}={}", field.name(), CAPTURE_SCOPE.name(), scope.getValue());
+                }
+                return 0;
+            case DATABASE:
+                if (value == null) {
+                    problems.accept(field, null, "The '" + field.name() + "' property must be set to a database name when '"
+                            + CAPTURE_SCOPE.name() + "' is '" + scope.getValue() + "'");
+                    return 1;
+                }
+                return 0;
+            case COLLECTION:
+            default:
+                final String[] parts = value == null ? null : value.split("\\.");
+                if (parts == null || parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+                    problems.accept(field, value, "The '" + field.name() + "' property must be set to '<databaseName>.<collectionName>' when '"
+                            + CAPTURE_SCOPE.name() + "' is '" + scope.getValue() + "'");
+                    return 1;
+                }
+                return 0;
         }
-
-        return 0;
     }
 
     public SnapshotMode getSnapshotMode() {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
@@ -92,4 +92,66 @@ public class MongoDbConnectorConfigTest {
         }
     }
 
+    @Test
+    void captureScopeAndTargetAreValidatedFields() {
+        // capture.target validation only runs when the fields are part of ALL_FIELDS
+        Assertions.assertNotNull(MongoDbConnectorConfig.ALL_FIELDS.fieldWithName(MongoDbConnectorConfig.CAPTURE_SCOPE.name()));
+        Assertions.assertNotNull(MongoDbConnectorConfig.ALL_FIELDS.fieldWithName(MongoDbConnectorConfig.CAPTURE_TARGET.name()));
+    }
+
+    @Test
+    void validateCaptureTarget() {
+        // deployment scope does not use capture.target
+        verifyCaptureTargetValidateSuccess("deployment", null);
+        verifyCaptureTargetValidateSuccess("deployment", "inventory");
+        verifyCaptureTargetValidateSuccess(null, null);
+
+        // database scope requires a database name
+        verifyCaptureTargetValidateSuccess("database", "inventory");
+        verifyCaptureTargetValidateError("database", null,
+                "The 'capture.target' property must be set to a database name when 'capture.scope' is 'database'");
+
+        // collection scope requires <databaseName>.<collectionName>
+        verifyCaptureTargetValidateSuccess("collection", "inventory.orders");
+        for (String invalid : new String[]{ null, "inventory", "inventory.", ".orders", "inventory.orders.archive" }) {
+            verifyCaptureTargetValidateError("collection", invalid,
+                    "The 'capture.target' property must be set to '<databaseName>.<collectionName>' when 'capture.scope' is 'collection'");
+        }
+    }
+
+    private static void verifyCaptureTargetValidateError(String scope, String value, String expectedError) {
+        verifyCaptureTargetValidate(scope, value, expectedError, false);
+    }
+
+    private static void verifyCaptureTargetValidateSuccess(String scope, String value) {
+        verifyCaptureTargetValidate(scope, value, null, true);
+    }
+
+    private static void verifyCaptureTargetValidate(String scope, String value, String expectedError, boolean success) {
+        // Given:
+        var config = mock(Configuration.class);
+        var output = mock(Field.ValidationOutput.class);
+        var errorMessage = ArgumentCaptor.forClass(String.class);
+        var field = MongoDbConnectorConfig.CAPTURE_TARGET;
+        given(config.getString(field)).willReturn(value);
+        given(config.getString(MongoDbConnectorConfig.CAPTURE_SCOPE)).willReturn(scope);
+
+        doNothing().when(output).accept(eq(field), eq(value), errorMessage.capture());
+
+        // When:
+        field.validate(config, output);
+
+        // Then:
+        if (success) {
+            assertThat(errorMessage.getAllValues())
+                    .isEmpty();
+        }
+        else {
+            assertThat(errorMessage.getAllValues())
+                    .hasSize(1)
+                    .element(0)
+                    .isEqualTo(expectedError);
+        }
+    }
+
 }

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1857,8 +1857,14 @@ Because the `source` channel must be enabled to permit connectors to process inc
 
 |[[mongodb-property-capture-target]]<<mongodb-property-capture-target, `+capture.target+`>>
 |
-| Specifies the database that the connector monitors for changes.
-This property applies only if the xref:mongodb-property-capture-scope[`capture.scope`] is set to `database`.
+| Specifies the database or collection that the connector monitors for changes, depending on the xref:mongodb-property-capture-scope[`capture.scope`] value:
+
+* If `capture.scope` is set to `database`, set this property to the name of the database to capture, for example, `inventory`.
+* If `capture.scope` is set to `collection`, set this property to the fully-qualified name of the single collection to capture, in the form `_databaseName_._collectionName_`, for example, `inventory.orders`.
+With this scope, the connector captures only the collection that `capture.target` specifies; the xref:mongodb-property-collection-include-list[`collection.include.list`] property cannot widen the capture to other collections.
+
+This property is required when `capture.scope` is set to `database` or `collection`; the connector fails validation if the property is not set.
+The property is ignored when `capture.scope` is set to `deployment`.
 
 |[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `+field.exclude.list+`>>
 |_empty string_


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/1643

`capture.scope=collection` without `capture.target` fails at streaming start with a cryptic `NoSuchElementException` ("Error while attempting to Setting resume token: No value present") from `MongoUtils.openChangeStream()`'s `getCaptureTarget().orElseThrow()`.

A validator for `capture.target` already exists but never runs: neither `capture.scope` nor `capture.target` is registered in `CONFIG_DEFINITION`, so they are not part of the `ALL_FIELDS` set used for validation. Its logic was also incorrect — it required `capture.target` regardless of scope, which would fail every default (`deployment`) configuration had it run.

* Register `CAPTURE_SCOPE`/`CAPTURE_TARGET` in `CONFIG_DEFINITION` so validation actually runs
* Make `validateCaptureTarget` scope-aware: unused for `deployment` (warn if set), database name for `database`, `<databaseName>.<collectionName>` for `collection` (matching what the runtime parsing supports)
* Fix the `capture.target` docs, which stated the property applies only to `database` scope
* Add unit tests for all scope/target combinations and a guard test that the fields stay registered