### PR TITLE
debezium/dbz#414 Fail connector validation for standalone MongoDB servers

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.client.MongoClient;
+import com.mongodb.connection.ClusterType;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
@@ -161,13 +162,7 @@ public class MongoDbConnector extends BaseSourceConnector implements ConfigDescr
                         }
                     }
 
-                    // For RS clusters check that replica set name is present
-                    // Java driver is smart enough to work without it but the specs says it should be set
-                    if (!connectionContext.hasReplicaSetNameIfRequired()) {
-                        var type = connectionContext.getClusterType();
-                        LOGGER.warn("Replica set not specified in connection string for {} cluster.", type);
-                        connectionStringValidation.addErrorMessage("Replica set not specified in connection string for " + type + " cluster.");
-                    }
+                    validateClusterTopology(connectionContext, connectionStringValidation);
                 }
                 catch (MongoException e) {
                     connectionStringValidation.addErrorMessage("Unable to connect: " + e.getMessage());
@@ -179,6 +174,27 @@ public class MongoDbConnector extends BaseSourceConnector implements ConfigDescr
         }
         catch (Exception e) {
             connectionStringValidation.addErrorMessage("Error during connection validation: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Validates that the connected cluster topology is one the connector can capture changes from.
+     */
+    static void validateClusterTopology(MongoDbConnectionContext connectionContext, ConfigValue connectionStringValidation) {
+        // For RS clusters check that replica set name is present
+        // Java driver is smart enough to work without it but the specs says it should be set
+        if (!connectionContext.hasReplicaSetNameIfRequired()) {
+            var type = connectionContext.getClusterType();
+            LOGGER.warn("Replica set not specified in connection string for {} cluster.", type);
+            connectionStringValidation.addErrorMessage("Replica set not specified in connection string for " + type + " cluster.");
+        }
+
+        // Standalone servers have no oplog and reject change streams (server error 40573), so the
+        // connector would pass validation here only to fail once streaming starts
+        if (connectionContext.getClusterType() == ClusterType.STANDALONE) {
+            LOGGER.warn("Connection points to a standalone MongoDB server which does not support change streams.");
+            connectionStringValidation.addErrorMessage("MongoDB deployed as a standalone server is not supported: "
+                    + "change streams require a replica set or sharded cluster (a single-node replica set is sufficient)");
         }
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTest.java
@@ -6,14 +6,22 @@
 package io.debezium.connector.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.ConfigKey;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Connector;
 import org.junit.jupiter.api.Test;
+
+import com.mongodb.connection.ClusterType;
+
+import io.debezium.connector.mongodb.connection.MongoDbConnectionContext;
 
 /**
  * @author Randall Hauch
@@ -54,6 +62,41 @@ public class MongoDbConnectorTest {
             assertThat(key.validator).isNull();
             assertThat(key.recommender).isNull();
         });
+    }
+
+    @Test
+    void validateClusterTopologyShouldRejectStandaloneServer() {
+        assertThat(validateTopology(ClusterType.STANDALONE, true))
+                .hasSize(1)
+                .element(0).asString()
+                .contains("standalone")
+                .contains("replica set or sharded cluster");
+    }
+
+    @Test
+    void validateClusterTopologyShouldAcceptSupportedTopologies() {
+        assertThat(validateTopology(ClusterType.REPLICA_SET, true)).isEmpty();
+        assertThat(validateTopology(ClusterType.SHARDED, true)).isEmpty();
+        assertThat(validateTopology(ClusterType.LOAD_BALANCED, true)).isEmpty();
+        assertThat(validateTopology(ClusterType.UNKNOWN, true)).isEmpty();
+    }
+
+    @Test
+    void validateClusterTopologyShouldRequireReplicaSetName() {
+        assertThat(validateTopology(ClusterType.REPLICA_SET, false))
+                .hasSize(1)
+                .element(0).asString()
+                .contains("Replica set not specified");
+    }
+
+    private static List<String> validateTopology(ClusterType clusterType, boolean hasReplicaSetNameIfRequired) {
+        var connectionContext = mock(MongoDbConnectionContext.class);
+        given(connectionContext.getClusterType()).willReturn(clusterType);
+        given(connectionContext.hasReplicaSetNameIfRequired()).willReturn(hasReplicaSetNameIfRequired);
+
+        var validation = new ConfigValue(MongoDbConnectorConfig.CONNECTION_STRING.name());
+        MongoDbConnector.validateClusterTopology(connectionContext, validation);
+        return validation.errorMessages();
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/414

A connector pointed at a standalone MongoDB server passes `validate()` — the topology checks only verify that a replica set name is present *when connecting to a replica set* — and then fails at task start, because standalone servers have no oplog and reject change streams (server error 40573, reproduced on MongoDB 8.3).

* Reject `ClusterType.STANDALONE` during connection validation with a message pointing at the fix ("a single-node replica set is sufficient"); `REPLICA_SET`/`SHARDED`/`LOAD_BALANCED`/`UNKNOWN` are unaffected
* Extract the topology checks into a testable method (behavior unchanged) and add unit tests for all topology combinations

Verified live against MongoDB 8.3.8: standalone now fails validation with the new message; a replica set still validates cleanly.