### PR TITLE
debezium/dbz#765 Support Date document id keys in MongoDB incremental snapshot

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -12,6 +12,7 @@ import static io.debezium.pipeline.notification.IncrementalSnapshotNotificationS
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -714,21 +715,24 @@ public class MongoDbIncrementalSnapshotChangeEventSource
             case STRING:
                 key = documentId.asString().getValue();
                 break;
+            case DATE_TIME:
+                key = new Date(documentId.asDateTime().getValue());
+                break;
             case BINARY:
                 var subtype = documentId.asBinary().getType();
                 if (!BsonBinarySubType.isUuid(subtype)) {
-                    throw new IllegalStateException("Unsupported type of document id");
+                    throw new IllegalStateException("Unsupported binary subtype of document id: " + subtype);
                 }
 
                 if (BsonBinarySubType.UUID_STANDARD.getValue() == subtype) {
                     key = documentId.asBinary().asUuid(UuidRepresentation.STANDARD);
                 }
                 else {
-                    throw new IllegalStateException("Unsupported subtype of UUID document id");
+                    throw new IllegalStateException("Unsupported subtype of UUID document id: " + subtype);
                 }
                 break;
             default:
-                throw new IllegalStateException("Unsupported type of document id");
+                throw new IllegalStateException("Unsupported type of document id: " + documentId.getBsonType());
         }
 
         return new Object[]{ key };

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -437,6 +438,13 @@ public class IncrementalSnapshotIT extends AbstractMongoConnectorIT {
     @Test
     void snapshotOnlyUUID() throws Exception {
         snapshotOnly(UUID.randomUUID(), k -> UUID.randomUUID());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#765")
+    void snapshotOnlyDate() throws Exception {
+        Date firstKey = new Date();
+        snapshotOnly(firstKey, k -> new Date(k.getTime() + 1000));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/765

Incremental snapshot fails with `IllegalStateException: Unsupported type of document id` when a collection's `_id` is a BSON date — `keyFromRow()` supports numeric/ObjectId/String/UUID keys but not `DATE_TIME` (follow-up to DBZ-5973).

* Add `DATE_TIME` handling, mapping to `java.util.Date`: the driver encodes it back to a BSON date for chunk `$gt`/`$lte` queries, it is `Serializable` for chunk offsets, and window deduplication is unaffected (record keys compare as extended-JSON strings)
* Include the actual BSON type/binary subtype in the "unsupported document id" exception messages, which previously gave no hint about what was rejected
* Add `snapshotOnlyDate()` to `IncrementalSnapshotIT`, following the existing per-type test pattern (fails before the fix, passes after; the other 7 key-type tests remain green)