### PR TITLE
debezium/dbz#2549 Prevent CDC record loss across poll batches

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -1380,6 +1380,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
                 for (int rowIndex = startingRowNumber; rowIndex != numRows; ++rowIndex) {
                     U row = rows.get(rowIndex);
                     changeEventValidator.validate(tableId, row);
+                    offsetContext.markSourceEventStarted();
                     offsetContext.setRowNumber(rowIndex, numRows);
                     offsetContext.event(tableId, eventTimestamp);
                     changeEmitter.emit(tableId, row);

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogRestartIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogRestartIT.java
@@ -16,6 +16,8 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.util.BinlogTestConnection;
@@ -105,5 +107,189 @@ public abstract class BinlogRestartIT<C extends SourceConnector> extends Abstrac
                 .isEqualTo(5);
 
         stopConnector();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldReplayDeleteWhenStoppedBeforeTombstoneIsCommitted() throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("restart_table"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.MAX_BATCH_SIZE, 1)
+                .build();
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute(
+                    "CREATE TABLE restart_table (id INT PRIMARY KEY, val INT)",
+                    "INSERT INTO restart_table VALUES(1, 10)");
+        }
+
+        start(getConnectorClass(), config, record -> record.value() == null
+                && ((Struct) record.key()).getInt32("id") == 1);
+
+        final SourceRecord snapshotRecord = consumeRecord();
+        assertThat(((Struct) snapshotRecord.key()).getInt32("id")).isEqualTo(1);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("DELETE FROM restart_table WHERE id = 1");
+        }
+
+        final SourceRecord deleteBeforeStop = consumeRecord();
+        assertThat(((Struct) deleteBeforeStop.key()).getInt32("id")).isEqualTo(1);
+        assertThat(((Struct) deleteBeforeStop.value()).getString("op")).isEqualTo("d");
+
+        waitForEngineShutdown();
+        stopConnector();
+
+        start(getConnectorClass(), config);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("INSERT INTO restart_table VALUES(3, 30)");
+        }
+
+        final SourceRecord replayedDelete = consumeRecord();
+        assertThat(((Struct) replayedDelete.key()).getInt32("id")).isEqualTo(1);
+        assertThat(((Struct) replayedDelete.value()).getString("op")).isEqualTo("d");
+
+        final SourceRecord replayedTombstone = consumeRecord();
+        assertThat(((Struct) replayedTombstone.key()).getInt32("id")).isEqualTo(1);
+        assertThat(replayedTombstone.value()).isNull();
+
+        final SourceRecord markerCreate = consumeRecord();
+        assertThat(((Struct) markerCreate.key()).getInt32("id")).isEqualTo(3);
+        assertThat(((Struct) markerCreate.value()).getString("op")).isEqualTo("c");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    @FixFor("debezium/dbz#2549")
+    public void shouldReplayPrimaryKeyUpdateWhenStoppedBetweenSplitRecords(boolean stopBeforeTombstone) throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("restart_table"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.MAX_BATCH_SIZE, 1)
+                .build();
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute(
+                    "CREATE TABLE restart_table (id INT PRIMARY KEY, val INT)",
+                    "INSERT INTO restart_table VALUES(1, 10)");
+        }
+
+        start(getConnectorClass(), config, record -> {
+            if (stopBeforeTombstone) {
+                return record.value() == null && ((Struct) record.key()).getInt32("id") == 1;
+            }
+            return record.value() != null
+                    && ((Struct) record.key()).getInt32("id") == 2
+                    && ((Struct) record.value()).getString("op").equals("c");
+        });
+
+        final SourceRecord snapshotRecord = consumeRecord();
+        assertThat(((Struct) snapshotRecord.key()).getInt32("id")).isEqualTo(1);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("UPDATE restart_table SET id = 2 WHERE id = 1");
+        }
+
+        final SourceRecord deleteBeforeStop = consumeRecord();
+        assertThat(((Struct) deleteBeforeStop.key()).getInt32("id")).isEqualTo(1);
+        assertThat(((Struct) deleteBeforeStop.value()).getString("op")).isEqualTo("d");
+
+        if (!stopBeforeTombstone) {
+            final SourceRecord tombstoneBeforeStop = consumeRecord();
+            assertThat(((Struct) tombstoneBeforeStop.key()).getInt32("id")).isEqualTo(1);
+            assertThat(tombstoneBeforeStop.value()).isNull();
+        }
+
+        waitForEngineShutdown();
+        stopConnector();
+
+        start(getConnectorClass(), config);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("INSERT INTO restart_table VALUES(3, 30)");
+        }
+
+        final SourceRecord replayedDelete = consumeRecord();
+        assertThat(((Struct) replayedDelete.key()).getInt32("id")).isEqualTo(1);
+        assertThat(((Struct) replayedDelete.value()).getString("op")).isEqualTo("d");
+
+        final SourceRecord replayedTombstone = consumeRecord();
+        assertThat(((Struct) replayedTombstone.key()).getInt32("id")).isEqualTo(1);
+        assertThat(replayedTombstone.value()).isNull();
+
+        final SourceRecord replayedCreate = consumeRecord();
+        assertThat(((Struct) replayedCreate.key()).getInt32("id")).isEqualTo(2);
+        assertThat(((Struct) replayedCreate.value()).getString("op")).isEqualTo("c");
+
+        final SourceRecord markerCreate = consumeRecord();
+        assertThat(((Struct) markerCreate.key()).getInt32("id")).isEqualTo(3);
+        assertThat(((Struct) markerCreate.value()).getString("op")).isEqualTo("c");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldReplayPrimaryKeyUpdateWhenTombstonesAreDisabled() throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SNAPSHOT_MODE, BinlogConnectorConfig.SnapshotMode.INITIAL)
+                .with(BinlogConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("restart_table"))
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.TOMBSTONES_ON_DELETE, false)
+                .with(BinlogConnectorConfig.MAX_BATCH_SIZE, 1)
+                .build();
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute(
+                    "CREATE TABLE restart_table (id INT PRIMARY KEY, val INT)",
+                    "INSERT INTO restart_table VALUES(1, 10)");
+        }
+
+        start(getConnectorClass(), config, record -> record.value() != null
+                && ((Struct) record.key()).getInt32("id") == 2
+                && ((Struct) record.value()).getString("op").equals("c"));
+
+        final SourceRecord snapshotRecord = consumeRecord();
+        assertThat(((Struct) snapshotRecord.key()).getInt32("id")).isEqualTo(1);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("UPDATE restart_table SET id = 2 WHERE id = 1");
+        }
+
+        final SourceRecord deleteBeforeStop = consumeRecord();
+        assertThat(((Struct) deleteBeforeStop.key()).getInt32("id")).isEqualTo(1);
+        assertThat(((Struct) deleteBeforeStop.value()).getString("op")).isEqualTo("d");
+
+        waitForEngineShutdown();
+        stopConnector();
+
+        start(getConnectorClass(), config);
+
+        try (BinlogTestConnection db = getTestDatabaseConnection(DATABASE.getDatabaseName());
+                JdbcConnection connection = db.connect()) {
+            connection.execute("INSERT INTO restart_table VALUES(3, 30)");
+        }
+
+        final SourceRecord replayedDelete = consumeRecord();
+        assertThat(((Struct) replayedDelete.key()).getInt32("id")).isEqualTo(1);
+        assertThat(((Struct) replayedDelete.value()).getString("op")).isEqualTo("d");
+
+        final SourceRecord replayedCreate = consumeRecord();
+        assertThat(((Struct) replayedCreate.key()).getInt32("id")).isEqualTo(2);
+        assertThat(((Struct) replayedCreate.value()).getString("op")).isEqualTo("c");
+
+        final SourceRecord markerCreate = consumeRecord();
+        assertThat(((Struct) markerCreate.key()).getInt32("id")).isEqualTo(3);
+        assertThat(((Struct) markerCreate.value()).getString("op")).isEqualTo("c");
     }
 }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogSourceInfoTest.java
@@ -82,6 +82,19 @@ public abstract class BinlogSourceInfoTest<S extends BinlogSourceInfo, O extends
         assertThat(offsetContext.isInitialSnapshotRunning()).isFalse();
     }
 
+    @Test
+    @FixFor("debezium/dbz#2549")
+    void shouldRetainOffsetFromBeforeCurrentSourceEvent() {
+        offsetContext.setBinlogStartPoint(FILENAME, 100);
+
+        offsetContext.markSourceEventStarted();
+        offsetContext.setRowNumber(0, 2);
+
+        assertThat(offsetContext.getOffset().get(BinlogSourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY)).isEqualTo(1L);
+        assertThat(offsetContext.getOffsetForIncompleteEvent())
+                .doesNotContainKey(BinlogSourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY);
+    }
+
     // -------------------------------------------------------------------------------------
     // Test reading the offset map and recovering the proper SourceInfo state
     // -------------------------------------------------------------------------------------

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/CommonOffsetContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/CommonOffsetContext.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.pipeline;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.kafka.connect.data.Struct;
@@ -44,6 +46,8 @@ public abstract class CommonOffsetContext<T extends BaseSourceInfo> implements O
      */
     protected boolean snapshotCompleted;
 
+    private Map<String, ?> offsetBeforeEvent;
+
     public CommonOffsetContext(T sourceInfo) {
         this.sourceInfo = sourceInfo;
     }
@@ -51,6 +55,16 @@ public abstract class CommonOffsetContext<T extends BaseSourceInfo> implements O
     public CommonOffsetContext(T sourceInfo, boolean snapshotCompleted) {
         this.sourceInfo = sourceInfo;
         this.snapshotCompleted = snapshotCompleted;
+    }
+
+    @Override
+    public void markSourceEventStarted() {
+        offsetBeforeEvent = new HashMap<>(getOffset());
+    }
+
+    @Override
+    public Map<String, ?> getOffsetForIncompleteEvent() {
+        return offsetBeforeEvent == null ? getOffset() : new HashMap<>(offsetBeforeEvent);
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/CommonOffsetContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/CommonOffsetContext.java
@@ -46,7 +46,7 @@ public abstract class CommonOffsetContext<T extends BaseSourceInfo> implements O
      */
     protected boolean snapshotCompleted;
 
-    private Map<String, ?> offsetBeforeEvent;
+    private Map<String, Object> offsetBeforeEvent;
 
     public CommonOffsetContext(T sourceInfo) {
         this.sourceInfo = sourceInfo;
@@ -65,6 +65,13 @@ public abstract class CommonOffsetContext<T extends BaseSourceInfo> implements O
     @Override
     public Map<String, ?> getOffsetForIncompleteEvent() {
         return offsetBeforeEvent == null ? getOffset() : new HashMap<>(offsetBeforeEvent);
+    }
+
+    @Override
+    public void updateTransactionContextForIncompleteEvent() {
+        if (offsetBeforeEvent != null) {
+            getTransactionContext().store(offsetBeforeEvent);
+        }
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -306,6 +306,18 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
                                              OffsetContext offset,
                                              ConnectHeaders headers)
                             throws InterruptedException {
+                        changeRecord(partition, schema, operation, key, value, offset, headers, true);
+                    }
+
+                    @Override
+                    public void changeRecord(P partition,
+                                             DataCollectionSchema schema,
+                                             Operation operation,
+                                             Object key, Struct value,
+                                             OffsetContext offset,
+                                             ConnectHeaders headers,
+                                             boolean sourceEventComplete)
+                            throws InterruptedException {
 
                         LOGGER.trace("Received change record {} for {} operation on key {} with "
                                 + "context {}", maybeRedactSensitiveData(value), operation, maybeRedactSensitiveData(key), offset);
@@ -326,7 +338,7 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
                             if (incrementalSnapshotChangeEventSource != null) {
                                 incrementalSnapshotChangeEventSource.processMessage(partition, dataCollectionId, key, offset);
                             }
-                            streamingReceiver.changeRecord(partition, schema, operation, key, value, offset, headers);
+                            streamingReceiver.changeRecord(partition, schema, operation, key, value, offset, headers, sourceEventComplete);
                         }
                     }
 
@@ -517,6 +529,18 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
                                  OffsetContext offsetContext,
                                  ConnectHeaders headers)
                 throws InterruptedException {
+            changeRecord(partition, dataCollectionSchema, operation, key, value, offsetContext, headers, true);
+        }
+
+        @Override
+        public void changeRecord(P partition,
+                                 DataCollectionSchema dataCollectionSchema,
+                                 Operation operation,
+                                 Object key, Struct value,
+                                 OffsetContext offsetContext,
+                                 ConnectHeaders headers,
+                                 boolean sourceEventComplete)
+                throws InterruptedException {
 
             Objects.requireNonNull(value, "value must not be null");
 
@@ -531,9 +555,13 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
             doPostProcessing(key, value);
 
             var extendedHeaders = getExtendedHeaders(headers);
+            final boolean recordCompletesSourceEvent = sourceEventComplete && !(emitTombstonesOnDelete && operation == Operation.DELETE);
+            final Map<String, ?> recordOffset = recordCompletesSourceEvent
+                    ? offsetContext.getOffset()
+                    : offsetContext.getOffsetForIncompleteEvent();
 
             SourceRecord record = new SourceRecord(partition.getSourcePartition(),
-                    offsetContext.getOffset(),
+                    recordOffset,
                     topicName, null,
                     keySchema, key,
                     dataCollectionSchema.getEnvelopeSchema().schema(),
@@ -544,15 +572,20 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
             queue.enqueue(changeEventCreator.createDataChangeEvent(record));
 
             if (emitTombstonesOnDelete && operation == Operation.DELETE) {
-                SourceRecord tombStone = record.newRecord(
-                        record.topic(),
-                        record.kafkaPartition(),
-                        record.keySchema(),
-                        record.key(),
+                final Map<String, ?> tombstoneOffset = sourceEventComplete
+                        ? offsetContext.getOffset()
+                        : offsetContext.getOffsetForIncompleteEvent();
+                SourceRecord tombStone = new SourceRecord(
+                        partition.getSourcePartition(),
+                        tombstoneOffset,
+                        topicName,
+                        null,
+                        keySchema,
+                        key,
                         null, // value schema
                         null, // value
-                        record.timestamp(),
-                        record.headers());
+                        null,
+                        extendedHeaders);
 
                 queue.enqueue(changeEventCreator.createDataChangeEvent(tombStone));
             }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
@@ -57,6 +57,17 @@ public interface ChangeRecordEmitter<P extends Partition> {
                           OffsetContext offset, ConnectHeaders headers)
                 throws InterruptedException;
 
+        /**
+         * Emits one of potentially multiple records produced from a single source event.
+         *
+         * @param sourceEventComplete whether this record completes processing of the source event
+         */
+        default void changeRecord(P partition, DataCollectionSchema schema, Operation operation, Object key, Struct value,
+                                  OffsetContext offset, ConnectHeaders headers, boolean sourceEventComplete)
+                throws InterruptedException {
+            changeRecord(partition, schema, operation, key, value, offset, headers);
+        }
+
         default void unchangedEventSkipped(P partition) {
         }
     }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -58,6 +58,26 @@ public interface OffsetContext {
 
     Map<String, ?> getOffset();
 
+    /**
+     * Captures the offset immediately before processing the next source event.
+     * <p>
+     * Connectors should invoke this before advancing their offset context to a source event that is about to be
+     * dispatched. The captured offset can then be used for records that do not complete processing of that source
+     * event, such as the delete and tombstone records produced for a primary key update.
+     */
+    default void markSourceEventStarted() {
+    }
+
+    /**
+     * Returns an offset from which the current source event will be replayed after a restart.
+     *
+     * @return the offset captured before the current source event, or the current offset if the connector does not
+     *         provide one
+     */
+    default Map<String, ?> getOffsetForIncompleteEvent() {
+        return getOffset();
+    }
+
     Schema getSourceInfoSchema();
 
     Struct getSourceInfo();

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -78,6 +78,16 @@ public interface OffsetContext {
         return getOffset();
     }
 
+    /**
+     * Updates the transaction state in the offset captured for the current source event without advancing its source
+     * position.
+     * <p>
+     * This is used when an implicit transaction boundary is emitted while processing a source event. It ensures that
+     * the transaction boundary can be restored after a restart while the source event itself is still replayed.
+     */
+    default void updateTransactionContextForIncompleteEvent() {
+    }
+
     Schema getSourceInfoSchema();
 
     Struct getSourceInfo();

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionContext.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionContext.java
@@ -48,6 +48,9 @@ public class TransactionContext {
     }
 
     public Map<String, Object> store(Map<String, Object> offset) {
+        offset.remove(OFFSET_TRANSACTION_ID);
+        offset.keySet().removeIf(key -> key.startsWith(OFFSET_TABLE_COUNT_PREFIX));
+
         if (!Objects.isNull(transactionId)) {
             offset.put(OFFSET_TRANSACTION_ID, transactionId);
         }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
@@ -92,18 +92,22 @@ public class TransactionMonitor {
                 LOGGER.trace("Transaction was in progress, executing implicit transaction commit");
                 endTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
                 transactionContext.endTransaction();
+                offset.updateTransactionContextForIncompleteEvent();
             }
             return;
         }
 
         if (!transactionContext.isTransactionInProgress()) {
             transactionContext.beginTransaction(transactionInfo);
+            offset.updateTransactionContextForIncompleteEvent();
             beginTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
         }
         else if (!transactionContext.getTransactionId().equals(txId)) {
             endTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
             transactionContext.endTransaction();
+            offset.updateTransactionContextForIncompleteEvent();
             transactionContext.beginTransaction(transactionInfo);
+            offset.updateTransactionContextForIncompleteEvent();
             beginTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
         }
         transactionEvent(offset, source, value);

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
@@ -8,6 +8,7 @@ package io.debezium.pipeline.txmetadata;
 import static io.debezium.util.Loggings.maybeRedactSensitiveData;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.kafka.connect.data.Schema;
@@ -89,7 +90,7 @@ public class TransactionMonitor {
             // commit transaction
             if (transactionContext.isTransactionInProgress()) {
                 LOGGER.trace("Transaction was in progress, executing implicit transaction commit");
-                endTransaction(partition, offset, eventMetadataProvider.getEventTimestamp(source, offset, key, value));
+                endTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
                 transactionContext.endTransaction();
             }
             return;
@@ -97,13 +98,13 @@ public class TransactionMonitor {
 
         if (!transactionContext.isTransactionInProgress()) {
             transactionContext.beginTransaction(transactionInfo);
-            beginTransaction(partition, offset, eventMetadataProvider.getEventTimestamp(source, offset, key, value));
+            beginTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
         }
         else if (!transactionContext.getTransactionId().equals(txId)) {
-            endTransaction(partition, offset, eventMetadataProvider.getEventTimestamp(source, offset, key, value));
+            endTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
             transactionContext.endTransaction();
             transactionContext.beginTransaction(transactionInfo);
-            beginTransaction(partition, offset, eventMetadataProvider.getEventTimestamp(source, offset, key, value));
+            beginTransaction(partition, offset, offset.getOffsetForIncompleteEvent(), eventMetadataProvider.getEventTimestamp(source, offset, key, value));
         }
         transactionEvent(offset, source, value);
     }
@@ -113,7 +114,7 @@ public class TransactionMonitor {
             return;
         }
         if (offset.getTransactionContext().isTransactionInProgress()) {
-            endTransaction(partition, offset, timestamp);
+            endTransaction(partition, offset, offset.getOffset(), timestamp);
         }
         offset.getTransactionContext().endTransaction();
     }
@@ -130,7 +131,7 @@ public class TransactionMonitor {
             return;
         }
         transactionContext.beginTransaction(transactionInfo);
-        beginTransaction(partition, offset, timestamp);
+        beginTransaction(partition, offset, offset.getOffset(), timestamp);
     }
 
     protected Struct prepareTxKey(OffsetContext offsetContext) {
@@ -163,17 +164,19 @@ public class TransactionMonitor {
         value.put(Envelope.FieldName.TRANSACTION, txStruct);
     }
 
-    private void beginTransaction(Partition partition, OffsetContext offsetContext, Instant timestamp) throws InterruptedException {
+    private void beginTransaction(Partition partition, OffsetContext offsetContext, Map<String, ?> sourceOffset, Instant timestamp)
+            throws InterruptedException {
         final Struct key = prepareTxKey(offsetContext);
         final Struct value = prepareTxBeginValue(offsetContext, timestamp);
-        sender.accept(new SourceRecord(partition.getSourcePartition(), offsetContext.getOffset(),
+        sender.accept(new SourceRecord(partition.getSourcePartition(), sourceOffset,
                 topicName, null, key.schema(), key, value.schema(), value));
     }
 
-    private void endTransaction(Partition partition, OffsetContext offsetContext, Instant timestamp) throws InterruptedException {
+    private void endTransaction(Partition partition, OffsetContext offsetContext, Map<String, ?> sourceOffset, Instant timestamp)
+            throws InterruptedException {
         final Struct key = prepareTxKey(offsetContext);
         final Struct value = prepareTxEndValue(offsetContext, timestamp);
-        sender.accept(new SourceRecord(partition.getSourcePartition(), offsetContext.getOffset(),
+        sender.accept(new SourceRecord(partition.getSourcePartition(), sourceOffset,
                 topicName, null, key.schema(), key, value.schema(), value));
     }
 }

--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalChangeRecordEmitter.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalChangeRecordEmitter.java
@@ -179,12 +179,12 @@ public abstract class RelationalChangeRecordEmitter<P extends Partition>
         headers.add(PK_UPDATE_NEWKEY_FIELD, newKey, tableSchema.keySchema());
 
         Struct envelope = tableSchema.getEnvelopeSchema().delete(oldValue, sourceInfo, getClock().currentTimeAsInstant());
-        receiver.changeRecord(getPartition(), tableSchema, Operation.DELETE, oldKey, envelope, offset, headers);
+        receiver.changeRecord(getPartition(), tableSchema, Operation.DELETE, oldKey, envelope, offset, headers, false);
 
         headers = new ConnectHeaders();
         headers.add(PK_UPDATE_OLDKEY_FIELD, oldKey, tableSchema.keySchema());
 
         envelope = tableSchema.getEnvelopeSchema().create(newValue, sourceInfo, getClock().currentTimeAsInstant());
-        receiver.changeRecord(getPartition(), tableSchema, Operation.CREATE, newKey, envelope, offset, headers);
+        receiver.changeRecord(getPartition(), tableSchema, Operation.CREATE, newKey, envelope, offset, headers, true);
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/EventDispatcherTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/EventDispatcherTest.java
@@ -8,10 +8,14 @@ package io.debezium.pipeline;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.StreamSupport;
 
@@ -35,11 +39,13 @@ import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.common.DebeziumHeaderProducer;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
+import io.debezium.heartbeat.Heartbeat.ScheduledHeartbeat;
 import io.debezium.pipeline.signal.SignalProcessor;
 import io.debezium.pipeline.signal.channels.SourceSignalChannel;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.pipeline.spi.ChangeRecordEmitter;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.pipeline.txmetadata.TransactionStructMaker;
@@ -47,6 +53,7 @@ import io.debezium.pipeline.txmetadata.spi.TransactionMetadataFactory;
 import io.debezium.processors.PostProcessorRegistry;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.SnapshotChangeRecordEmitter;
+import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.schema.DataCollectionFilters;
 import io.debezium.schema.DataCollectionSchema;
@@ -250,6 +257,146 @@ public class EventDispatcherTest {
         dispatcher.dispatchSnapshotEvent(partition, dataCollectionId, changeRecordEmitter, new PartitionSnapshotReceiver());
 
         assertThat(connectHeaders).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldAdvanceOffsetOnlyAfterDeleteTombstone() throws InterruptedException {
+        initializeStreamingDispatcher();
+
+        final Map<String, Object> offsetBeforeEvent = Map.of("position", 1L);
+        final Map<String, Object> currentOffset = Map.of("position", 2L);
+        doReturn(offsetBeforeEvent).when(offsetContext).getOffsetForIncompleteEvent();
+        doReturn(currentOffset).when(offsetContext).getOffset();
+
+        dispatcher.dispatchDataChangeEvent(partition, dataCollectionId,
+                changeRecordEmitter((schema, receiver) -> receiver.changeRecord(
+                        partition, schema, Envelope.Operation.DELETE, "key", struct, offsetContext, new ConnectHeaders(), true),
+                        Envelope.Operation.DELETE));
+
+        verify(changeEventCreator, times(2)).createDataChangeEvent(sourceRecordCaptor.capture());
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::sourceOffset)
+                .containsExactly(offsetBeforeEvent, currentOffset);
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::value)
+                .containsExactly(struct, null);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldAdvanceOffsetOnlyAfterPrimaryKeyUpdateRecords() throws InterruptedException {
+        initializeStreamingDispatcher(true);
+
+        final Map<String, Object> offsetBeforeEvent = Map.of("position", 1L);
+        final Map<String, Object> currentOffset = Map.of("position", 2L);
+        doReturn(offsetBeforeEvent).when(offsetContext).getOffsetForIncompleteEvent();
+        doReturn(currentOffset).when(offsetContext).getOffset();
+
+        dispatcher.dispatchDataChangeEvent(partition, dataCollectionId,
+                changeRecordEmitter((schema, receiver) -> {
+                    receiver.changeRecord(partition, schema, Envelope.Operation.DELETE, "old-key", struct, offsetContext, new ConnectHeaders(), false);
+                    receiver.changeRecord(partition, schema, Envelope.Operation.CREATE, "new-key", struct, offsetContext, new ConnectHeaders(), true);
+                }, Envelope.Operation.UPDATE));
+
+        verify(changeEventCreator, times(3)).createDataChangeEvent(sourceRecordCaptor.capture());
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::sourceOffset)
+                .containsExactly(offsetBeforeEvent, offsetBeforeEvent, currentOffset);
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::key)
+                .containsExactly("old-key", "old-key", "new-key");
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::value)
+                .containsExactly(struct, null, struct);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldAdvanceOffsetOnlyAfterPrimaryKeyUpdateWhenTombstonesAreDisabled() throws InterruptedException {
+        initializeStreamingDispatcher(false);
+
+        final Map<String, Object> offsetBeforeEvent = Map.of("position", 1L);
+        final Map<String, Object> currentOffset = Map.of("position", 2L);
+        doReturn(offsetBeforeEvent).when(offsetContext).getOffsetForIncompleteEvent();
+        doReturn(currentOffset).when(offsetContext).getOffset();
+
+        dispatcher.dispatchDataChangeEvent(partition, dataCollectionId,
+                changeRecordEmitter((schema, receiver) -> {
+                    receiver.changeRecord(partition, schema, Envelope.Operation.DELETE, "old-key", struct, offsetContext, new ConnectHeaders(), false);
+                    receiver.changeRecord(partition, schema, Envelope.Operation.CREATE, "new-key", struct, offsetContext, new ConnectHeaders(), true);
+                }, Envelope.Operation.UPDATE));
+
+        verify(changeEventCreator, times(2)).createDataChangeEvent(sourceRecordCaptor.capture());
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::sourceOffset)
+                .containsExactly(offsetBeforeEvent, currentOffset);
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::key)
+                .containsExactly("old-key", "new-key");
+        assertThat(sourceRecordCaptor.getAllValues())
+                .extracting(SourceRecord::value)
+                .containsExactly(struct, struct);
+    }
+
+    private void initializeStreamingDispatcher() {
+        initializeStreamingDispatcher(true);
+    }
+
+    private void initializeStreamingDispatcher(boolean emitTombstonesOnDelete) {
+        final TableId tableId = new TableId(null, null, "table");
+        when(dataCollectionSchema.getEnvelopeSchema()).thenReturn(envelope);
+        when(dataCollectionSchema.keySchema()).thenReturn(schema);
+        when(dataCollectionSchema.id()).thenReturn(tableId);
+        when(envelope.schema()).thenReturn(schema);
+        when(databaseSchema.schemaFor(dataCollectionId)).thenReturn(dataCollectionSchema);
+        when(databaseSchema.isHistorized()).thenReturn(false);
+        when(dataCollectionFilters.isIncluded(dataCollectionId)).thenReturn(true);
+        when(partition.getSourcePartition()).thenReturn(Map.of("server", "test"));
+        when(topicNamingStrategy.dataChangeTopic(tableId)).thenReturn("server.table");
+        when(topicNamingStrategy.transactionTopic()).thenReturn("server.transaction");
+        when(config.isEmitTombstoneOnDelete()).thenReturn(emitTombstonesOnDelete);
+        when(config.getSkippedOperations()).thenReturn(EnumSet.noneOf(Envelope.Operation.class));
+        when(config.supportsOperationFiltering()).thenReturn(true);
+        when(config.getServiceRegistry()).thenReturn(serviceRegistry);
+        when(serviceRegistry.tryGetService(PostProcessorRegistry.class)).thenReturn(postProcessorRegistry);
+        when(config.getSourceInfoStructMaker()).thenReturn(sourceInfoStructMaker);
+        when(sourceInfoStructMaker.schema()).thenReturn(schema);
+        when(config.getTransactionMetadataFactory()).thenReturn(transactionMetadataFactory);
+        when(transactionMetadataFactory.getTransactionStructMaker()).thenReturn(transactionStructMaker);
+        when(changeEventCreator.createDataChangeEvent(any())).thenAnswer(invocation -> new DataChangeEvent(invocation.getArgument(0)));
+
+        dispatcher = new EventDispatcher<>(config, topicNamingStrategy, databaseSchema, changeEventQueue, dataCollectionFilters, changeEventCreator,
+                eventMetadataProvider, ScheduledHeartbeat.NOOP_HEARTBEAT, SchemaNameAdjuster.NO_OP, null, null);
+    }
+
+    private ChangeRecordEmitter<Partition> changeRecordEmitter(RecordEmission emission, Envelope.Operation operation) {
+        return new ChangeRecordEmitter<>() {
+            @Override
+            public void emitChangeRecords(DataCollectionSchema schema, Receiver<Partition> receiver) throws InterruptedException {
+                emission.emit(schema, receiver);
+            }
+
+            @Override
+            public Partition getPartition() {
+                return partition;
+            }
+
+            @Override
+            public OffsetContext getOffset() {
+                return offsetContext;
+            }
+
+            @Override
+            public Envelope.Operation getOperation() {
+                return operation;
+            }
+        };
+    }
+
+    @FunctionalInterface
+    private interface RecordEmission {
+        void emit(DataCollectionSchema schema, ChangeRecordEmitter.Receiver<Partition> receiver) throws InterruptedException;
     }
 
     private static class PartitionSnapshotReceiver implements EventDispatcher.SnapshotReceiver<Partition> {

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionContextTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionContextTest.java
@@ -38,6 +38,29 @@ public class TransactionContextTest {
     }
 
     @Test
+    public void shouldReplacePreviousTransactionStateWhenStoring() {
+        final TransactionContext previousContext = new TransactionContext();
+        previousContext.beginTransaction(new DefaultTransactionInfo("tx-1"));
+        previousContext.event(new TableId("catalog", "schema", "table1"));
+        previousContext.event(new TableId("catalog", "schema", "table2"));
+        final Map<String, Object> offsets = previousContext.store(new HashMap<>());
+        offsets.put("position", 1L);
+
+        final TransactionContext currentContext = new TransactionContext();
+        currentContext.beginTransaction(new DefaultTransactionInfo("tx-2"));
+        currentContext.store(offsets);
+
+        assertThat(offsets).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "position", 1L,
+                TransactionContext.OFFSET_TRANSACTION_ID, "tx-2"));
+
+        currentContext.endTransaction();
+        currentContext.store(offsets);
+
+        assertThat(offsets).containsExactlyInAnyOrderEntriesOf(Map.of("position", 1L));
+    }
+
+    @Test
     public void load() {
         String expectedId = "foo";
         Map offsets = Map.of(TransactionContext.OFFSET_TRANSACTION_ID, expectedId);

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionMonitorTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionMonitorTest.java
@@ -7,6 +7,7 @@ package io.debezium.pipeline.txmetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -15,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -113,7 +116,7 @@ public class TransactionMonitorTest {
     public void shouldBeginNewTransactionWhenStartEventHasDifferentTransactionId() throws Exception {
         when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
         when(partition.getSourcePartition()).thenReturn(Map.of());
-        when(offsetContext.getOffset()).thenReturn(Map.of());
+        doReturn(Map.of("position", 1L)).when(offsetContext).getOffset();
 
         final TransactionContext transactionContext = new TransactionContext();
         transactionContext.beginTransaction(new DefaultTransactionInfo("tx-1"));
@@ -124,6 +127,7 @@ public class TransactionMonitorTest {
 
         assertThat(sentRecords).hasSize(1);
         final Struct begin = (Struct) sentRecords.get(0).value();
+        assertThat(sentRecords.get(0).sourceOffset()).isEqualTo(Map.of("position", 1L));
         assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_STATUS_KEY)).isEqualTo(TransactionStatus.BEGIN.name());
         assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY)).isEqualTo("tx-2");
         assertThat(transactionContext.getTransactionId()).isEqualTo("tx-2");
@@ -134,7 +138,7 @@ public class TransactionMonitorTest {
     public void shouldBeginTransactionWhenNoTransactionIsInProgress() throws Exception {
         when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
         when(partition.getSourcePartition()).thenReturn(Map.of());
-        when(offsetContext.getOffset()).thenReturn(Map.of());
+        doReturn(Map.of("position", 1L)).when(offsetContext).getOffset();
 
         final TransactionContext transactionContext = new TransactionContext();
         when(offsetContext.getTransactionContext()).thenReturn(transactionContext);
@@ -143,8 +147,34 @@ public class TransactionMonitorTest {
 
         assertThat(sentRecords).hasSize(1);
         final Struct begin = (Struct) sentRecords.get(0).value();
+        assertThat(sentRecords.get(0).sourceOffset()).isEqualTo(Map.of("position", 1L));
         assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_STATUS_KEY)).isEqualTo(TransactionStatus.BEGIN.name());
         assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY)).isEqualTo("tx-1");
         assertThat(transactionContext.getTransactionId()).isEqualTo("tx-1");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldUseIncompleteOffsetWhenDataEventStartsTransaction() throws Exception {
+        when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
+        when(partition.getSourcePartition()).thenReturn(Map.of());
+        doReturn(Map.of("position", 1L)).when(offsetContext).getOffsetForIncompleteEvent();
+
+        final TransactionContext transactionContext = new TransactionContext();
+        final Struct value = new Struct(SchemaBuilder.struct()
+                .field(Envelope.FieldName.TRANSACTION, DefaultTransactionStructMaker.TRANSACTION_BLOCK_SCHEMA)
+                .build());
+        when(offsetContext.getTransactionContext()).thenReturn(transactionContext);
+        when(eventMetadataProvider.getTransactionId(TABLE_A, offsetContext, "key", value)).thenReturn("tx-1");
+        when(eventMetadataProvider.getTransactionInfo(TABLE_A, offsetContext, "key", value)).thenReturn(new DefaultTransactionInfo("tx-1"));
+        when(eventMetadataProvider.getEventTimestamp(TABLE_A, offsetContext, "key", value)).thenReturn(Instant.ofEpochMilli(1_000));
+
+        monitor.dataEvent(partition, TABLE_A, offsetContext, "key", value);
+
+        assertThat(sentRecords).hasSize(1);
+        assertThat(sentRecords.get(0).sourceOffset()).isEqualTo(Map.of("position", 1L));
+        final Struct begin = (Struct) sentRecords.get(0).value();
+        assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_STATUS_KEY)).isEqualTo(TransactionStatus.BEGIN.name());
+        assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY)).isEqualTo("tx-1");
     }
 }

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionMonitorTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/txmetadata/TransactionMonitorTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -27,14 +28,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.connector.common.BaseSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
+import io.debezium.pipeline.CommonOffsetContext;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.pipeline.txmetadata.spi.TransactionMetadataFactory;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.spi.schema.DataCollectionId;
 
 @ExtendWith(MockitoExtension.class)
 public class TransactionMonitorTest {
@@ -158,23 +162,111 @@ public class TransactionMonitorTest {
     public void shouldUseIncompleteOffsetWhenDataEventStartsTransaction() throws Exception {
         when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
         when(partition.getSourcePartition()).thenReturn(Map.of());
-        doReturn(Map.of("position", 1L)).when(offsetContext).getOffsetForIncompleteEvent();
 
         final TransactionContext transactionContext = new TransactionContext();
+        final TestOffsetContext eventOffsetContext = new TestOffsetContext(1L, transactionContext);
+        eventOffsetContext.markSourceEventStarted();
+        eventOffsetContext.setPosition(2L);
         final Struct value = new Struct(SchemaBuilder.struct()
                 .field(Envelope.FieldName.TRANSACTION, DefaultTransactionStructMaker.TRANSACTION_BLOCK_SCHEMA)
                 .build());
-        when(offsetContext.getTransactionContext()).thenReturn(transactionContext);
-        when(eventMetadataProvider.getTransactionId(TABLE_A, offsetContext, "key", value)).thenReturn("tx-1");
-        when(eventMetadataProvider.getTransactionInfo(TABLE_A, offsetContext, "key", value)).thenReturn(new DefaultTransactionInfo("tx-1"));
-        when(eventMetadataProvider.getEventTimestamp(TABLE_A, offsetContext, "key", value)).thenReturn(Instant.ofEpochMilli(1_000));
+        when(eventMetadataProvider.getTransactionId(TABLE_A, eventOffsetContext, "key", value)).thenReturn("tx-1");
+        when(eventMetadataProvider.getTransactionInfo(TABLE_A, eventOffsetContext, "key", value)).thenReturn(new DefaultTransactionInfo("tx-1"));
+        when(eventMetadataProvider.getEventTimestamp(TABLE_A, eventOffsetContext, "key", value)).thenReturn(Instant.ofEpochMilli(1_000));
 
-        monitor.dataEvent(partition, TABLE_A, offsetContext, "key", value);
+        monitor.dataEvent(partition, TABLE_A, eventOffsetContext, "key", value);
 
         assertThat(sentRecords).hasSize(1);
-        assertThat(sentRecords.get(0).sourceOffset()).isEqualTo(Map.of("position", 1L));
+        assertThat(sentRecords.get(0).sourceOffset()).isEqualTo(Map.of(
+                "position", 1L,
+                TransactionContext.OFFSET_TRANSACTION_ID, "tx-1"));
+        assertThat(eventOffsetContext.getOffsetForIncompleteEvent()).isEqualTo(Map.of(
+                "position", 1L,
+                TransactionContext.OFFSET_TRANSACTION_ID, "tx-1"));
+        assertThat(TransactionContext.load(eventOffsetContext.getOffset()).getTotalEventCount()).isEqualTo(1L);
         final Struct begin = (Struct) sentRecords.get(0).value();
         assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_STATUS_KEY)).isEqualTo(TransactionStatus.BEGIN.name());
         assertThat(begin.getString(TransactionStructMaker.DEBEZIUM_TRANSACTION_ID_KEY)).isEqualTo("tx-1");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldReplaceTransactionContextInIncompleteOffsetWhenTransactionChanges() throws Exception {
+        when(connectorConfig.shouldProvideTransactionMetadata()).thenReturn(true);
+        when(partition.getSourcePartition()).thenReturn(Map.of());
+
+        final TransactionContext transactionContext = new TransactionContext();
+        transactionContext.beginTransaction(new DefaultTransactionInfo("tx-1"));
+        transactionContext.event(TABLE_A);
+        transactionContext.event(TABLE_A);
+        transactionContext.event(TABLE_B);
+        final TestOffsetContext eventOffsetContext = new TestOffsetContext(1L, transactionContext);
+        eventOffsetContext.markSourceEventStarted();
+        eventOffsetContext.setPosition(2L);
+        final Struct value = new Struct(SchemaBuilder.struct()
+                .field(Envelope.FieldName.TRANSACTION, DefaultTransactionStructMaker.TRANSACTION_BLOCK_SCHEMA)
+                .build());
+        when(eventMetadataProvider.getTransactionId(TABLE_A, eventOffsetContext, "key", value)).thenReturn("tx-2");
+        when(eventMetadataProvider.getTransactionInfo(TABLE_A, eventOffsetContext, "key", value)).thenReturn(new DefaultTransactionInfo("tx-2"));
+        when(eventMetadataProvider.getEventTimestamp(TABLE_A, eventOffsetContext, "key", value)).thenReturn(Instant.ofEpochMilli(1_000));
+
+        monitor.dataEvent(partition, TABLE_A, eventOffsetContext, "key", value);
+
+        assertThat(sentRecords).hasSize(2);
+        final TransactionContext endOffsetTransaction = TransactionContext.load(sentRecords.get(0).sourceOffset());
+        assertThat(endOffsetTransaction.getTransactionId()).isEqualTo("tx-1");
+        assertThat(endOffsetTransaction.getTotalEventCount()).isEqualTo(3L);
+        assertThat(endOffsetTransaction.getPerTableEventCount()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                TABLE_A.toString(), 2L,
+                TABLE_B.toString(), 1L));
+
+        assertThat(sentRecords.get(1).sourceOffset()).isEqualTo(Map.of(
+                "position", 1L,
+                TransactionContext.OFFSET_TRANSACTION_ID, "tx-2"));
+        assertThat(eventOffsetContext.getOffsetForIncompleteEvent()).isEqualTo(Map.of(
+                "position", 1L,
+                TransactionContext.OFFSET_TRANSACTION_ID, "tx-2"));
+
+        final TransactionContext currentOffsetTransaction = TransactionContext.load(eventOffsetContext.getOffset());
+        assertThat(currentOffsetTransaction.getTransactionId()).isEqualTo("tx-2");
+        assertThat(currentOffsetTransaction.getTotalEventCount()).isEqualTo(1L);
+        assertThat(currentOffsetTransaction.getPerTableEventCount()).containsExactlyInAnyOrderEntriesOf(Map.of(TABLE_A.toString(), 1L));
+    }
+
+    private static class TestOffsetContext extends CommonOffsetContext<BaseSourceInfo> {
+
+        private long position;
+        private final TransactionContext transactionContext;
+
+        private TestOffsetContext(long position, TransactionContext transactionContext) {
+            super(null);
+            this.position = position;
+            this.transactionContext = transactionContext;
+        }
+
+        @Override
+        public Map<String, ?> getOffset() {
+            final Map<String, Object> offset = new HashMap<>();
+            offset.put("position", position);
+            return transactionContext.store(offset);
+        }
+
+        @Override
+        public Schema getSourceInfoSchema() {
+            return null;
+        }
+
+        @Override
+        public void event(DataCollectionId collectionId, Instant timestamp) {
+        }
+
+        @Override
+        public TransactionContext getTransactionContext() {
+            return transactionContext;
+        }
+
+        private void setPosition(long position) {
+            this.position = position;
+        }
     }
 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbOffsetContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbOffsetContext.java
@@ -234,7 +234,7 @@ public class MongoDbOffsetContext extends CommonOffsetContext<SourceInfo> {
 
             return new MongoDbOffsetContext(
                     sourceInfo,
-                    new TransactionContext(),
+                    TransactionContext.load(offset),
                     MongoDbIncrementalSnapshotContext.load(offset, false));
         }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -174,6 +174,7 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
                 event.getNamespace().getCollectionName());
 
         var emitter = new MongoDbChangeRecordEmitter(partition, offsetContext, clock, event, connectorConfig);
+        offsetContext.markSourceEventStarted();
         offsetContext.changeStreamEvent(event);
         dispatcher.dispatchDataChangeEvent(partition, collectionId, emitter);
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -1147,6 +1147,57 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     }
 
     @Test
+    @FixFor("debezium/dbz#2549")
+    void shouldReplayDeleteWhenStoppedBeforeTombstoneIsCommitted() throws Exception {
+        final String collectionName = "delete_restart";
+        final String topicName = "mongo.dbit." + collectionName;
+
+        config = TestHelper.getConfiguration(mongo).edit()
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit." + collectionName)
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NO_DATA)
+                .with(MongoDbConnectorConfig.MAX_BATCH_SIZE, 1)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
+                .build();
+
+        context = new MongoDbTaskContext(config);
+        TestHelper.cleanDatabase(mongo, "dbit");
+
+        start(MongoDbConnector.class, config, record -> topicName.equals(record.topic()) && record.value() == null);
+        waitForStreamingRunning("mongodb", "mongo");
+
+        insertDocuments("dbit", collectionName, new Document("_id", 1).append("value", "before-delete"));
+
+        final SourceRecord createRecord = consumeRecord();
+        verifyCreateOperation(createRecord);
+
+        deleteDocuments("dbit", collectionName, new Document("_id", 1));
+
+        final SourceRecord deleteBeforeStop = consumeRecord();
+        assertThat(deleteBeforeStop.key()).isEqualTo(createRecord.key());
+        verifyDeleteOperation(deleteBeforeStop);
+
+        waitForEngineShutdown();
+        stopConnector();
+
+        start(MongoDbConnector.class, config);
+        waitForStreamingRunning("mongodb", "mongo");
+
+        insertDocuments("dbit", collectionName, new Document("_id", 2).append("value", "restart-marker"));
+
+        final SourceRecord replayedDelete = consumeRecord();
+        assertThat(replayedDelete.key()).isEqualTo(createRecord.key());
+        verifyDeleteOperation(replayedDelete);
+
+        final SourceRecord replayedTombstone = consumeRecord();
+        assertThat(replayedTombstone.key()).isEqualTo(createRecord.key());
+        assertThat(replayedTombstone.value()).isNull();
+
+        final SourceRecord markerCreate = consumeRecord();
+        verifyCreateOperation(markerCreate);
+    }
+
+    @Test
     @FixFor("DBZ-1168")
     public void shouldConsumeAllEventsFromDatabaseWithCustomAuthSource() throws InterruptedException, IOException {
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbOffsetContextTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbOffsetContextTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.txmetadata.DefaultTransactionInfo;
+import io.debezium.pipeline.txmetadata.TransactionContext;
 
 /**
  * Unit tests for {@link MongoDbOffsetContext} and its {@link MongoDbOffsetContext.Loader}.
@@ -79,6 +82,29 @@ public class MongoDbOffsetContextTest {
         assertThat(context.isInitialSnapshotRunning())
                 .as("Normal offset (no initsync) should not be flagged as snapshot running")
                 .isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void loaderShouldRestoreTransactionContextFromOffset() {
+        final TransactionContext transactionContext = new TransactionContext();
+        transactionContext.beginTransaction(new DefaultTransactionInfo("tx-1"));
+        transactionContext.event(new CollectionId("dbA", "c1"));
+        transactionContext.event(new CollectionId("dbA", "c1"));
+        transactionContext.event(new CollectionId("dbA", "c2"));
+        final Map<String, Object> offset = new HashMap<>();
+        offset.put(SourceInfo.TIMESTAMP, 1666193824);
+        offset.put(SourceInfo.ORDER, 1);
+        offset.put(SourceInfo.RESUME_TOKEN, "someBase64Token");
+        transactionContext.store(offset);
+
+        final MongoDbOffsetContext context = loader.load(offset);
+
+        assertThat(context.getTransactionContext().getTransactionId()).isEqualTo("tx-1");
+        assertThat(context.getTransactionContext().getTotalEventCount()).isEqualTo(3L);
+        assertThat(context.getTransactionContext().getPerTableEventCount())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("dbA.c1", 2L, "dbA.c2", 1L));
+        assertThat(context.getOffset()).isEqualTo(offset);
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TransactionMetadataIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TransactionMetadataIT.java
@@ -9,12 +9,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.mongodb.MongoDbConnectorConfig.SnapshotMode;
+import io.debezium.data.Envelope;
+import io.debezium.data.Envelope.Operation;
 import io.debezium.doc.FixFor;
+import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Collect;
 
@@ -74,6 +78,68 @@ public class TransactionMetadataIT extends AbstractMongoConnectorIT {
         assertEndTransaction(all.get(7), txId1, 6, Collect.hashMapOf("dbA.c1", 6));
 
         stopConnector();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    void shouldReplayDeleteWithoutDuplicateTransactionEndWhenStoppedBeforeTombstoneIsCommitted() throws Exception {
+        final String collectionName = "c1";
+        final String topicName = "mongo1.dbA." + collectionName;
+
+        config = TestHelper.getConfiguration(mongo)
+                .edit()
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA." + collectionName)
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(MongoDbConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                .with(MongoDbConnectorConfig.MAX_BATCH_SIZE, 1)
+                .build();
+
+        context = new MongoDbTaskContext(config);
+        TestHelper.cleanDatabase(mongo, "dbA");
+
+        if (!TestHelper.transactionsSupported()) {
+            return;
+        }
+
+        start(MongoDbConnector.class, config, record -> topicName.equals(record.topic()) && record.value() == null);
+        waitForStreamingRunning("mongodb", "mongo1");
+
+        insertDocumentsInTx("dbA", collectionName, new Document("_id", 1).append("value", "before-delete"));
+
+        final SourceRecord begin = consumeRecord();
+        final String transactionId = assertBeginTransaction(begin);
+
+        final SourceRecord create = consumeRecord();
+        assertOperation(create, Operation.CREATE);
+
+        deleteDocuments("dbA", collectionName, new Document("_id", 1));
+
+        final SourceRecord end = consumeRecord();
+        assertEndTransaction(end, transactionId, 1, Collect.hashMapOf("dbA.c1", 1));
+
+        final SourceRecord deleteBeforeStop = consumeRecord();
+        assertThat(deleteBeforeStop.key()).isEqualTo(create.key());
+        assertThat(deleteBeforeStop.sourceOffset()).doesNotContainKey(TransactionContext.OFFSET_TRANSACTION_ID);
+        assertOperation(deleteBeforeStop, Operation.DELETE);
+
+        waitForEngineShutdown();
+        stopConnector();
+
+        start(MongoDbConnector.class, config);
+        waitForStreamingRunning("mongodb", "mongo1");
+
+        insertDocuments("dbA", collectionName, new Document("_id", 2).append("value", "restart-marker"));
+
+        final SourceRecord replayedDelete = consumeRecord();
+        assertThat(replayedDelete.key()).isEqualTo(create.key());
+        assertOperation(replayedDelete, Operation.DELETE);
+
+        final SourceRecord replayedTombstone = consumeRecord();
+        assertThat(replayedTombstone.key()).isEqualTo(create.key());
+        assertThat(replayedTombstone.value()).isNull();
+
+        final SourceRecord markerCreate = consumeRecord();
+        assertOperation(markerCreate, Operation.CREATE);
     }
 
     @Test
@@ -189,5 +255,10 @@ public class TransactionMetadataIT extends AbstractMongoConnectorIT {
         assertEndTransaction(all.get(3), txId, 2, Collect.hashMapOf("dbA.c1", 2));
 
         stopConnector();
+    }
+
+    private static void assertOperation(SourceRecord record, Operation expected) {
+        final Struct value = (Struct) record.value();
+        assertThat(value.getString(Envelope.FieldName.OPERATION)).isEqualTo(expected.code());
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/buffered/BufferedLogMinerStreamingChangeEventSource.java
@@ -526,6 +526,7 @@ public class BufferedLogMinerStreamingChangeEventSource extends AbstractLogMiner
                     }
                 }
 
+                getOffsetContext().markSourceEventStarted();
                 getOffsetContext().setEventScn(event.getScn());
                 getOffsetContext().setEventCommitScn(row.getScn());
                 getOffsetContext().setTransactionId(transactionId);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/unbuffered/UnbufferedLogMinerStreamingChangeEventSource.java
@@ -543,6 +543,7 @@ public class UnbufferedLogMinerStreamingChangeEventSource extends AbstractLogMin
             getMetrics().calculateLagFromSource(dmlEvent.getChangeTime());
 
             // Set per-event details
+            getOffsetContext().markSourceEventStarted();
             getOffsetContext().setEventScn(dmlEvent.getScn());
             getOffsetContext().setTransactionId(eventTrxId);
             getOffsetContext().setTransactionSequence(eventTrxSeq);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/olr/OpenLogReplicatorStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/olr/OpenLogReplicatorStreamingChangeEventSource.java
@@ -382,6 +382,7 @@ public class OpenLogReplicatorStreamingChangeEventSource implements StreamingCha
         // Update offsets. The position moves here, on a change that is about to be dispatched, so
         // that it always describes something the connector has emitted. The index identifies the
         // change within its transaction and is what a replay skips through on restart.
+        offsetContext.markSourceEventStarted();
         offsetContext.setScn(event.getCheckpointScn());
         offsetContext.setScnIndex(event.getCheckpointIndex());
         offsetContext.setEventScn(event.getCheckpointScn());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -105,6 +105,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                 return;
             }
 
+            offsetContext.markSourceEventStarted();
             offsetContext.setRowId(""); // specifically reset on each event
             offsetContext.setScn(lcrPosition.getScn());
             offsetContext.setEventCommitScn(lcrPosition.getCommitScn());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -406,6 +406,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 Objects.requireNonNull(tableId);
             }
 
+            offsetContext.markSourceEventStarted();
             offsetContext.incrementLsnEventsProcessed(lsn);
             offsetContext.updateWalPosition(lsn, lastCompletelyProcessedLsn, message.getCommitTime(), toLong(message.getTransactionId()),
                     getSlotXmin(),

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -3686,36 +3686,42 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
                         "CREATE TABLE public.pk_restart (id INTEGER PRIMARY KEY, value INTEGER);" +
                         "INSERT INTO public.pk_restart VALUES (1, 10);");
 
-        final Configuration config = TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.pk_restart")
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
-                .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 1)
-                .build();
+        try {
+            final Configuration config = TestHelper.defaultConfig()
+                    .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                    .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.pk_restart")
+                    .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
+                    .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 1)
+                    .build();
 
-        start(PostgresConnector.class, config, record -> record.value() instanceof Struct value
-                && "c".equals(value.getString(Envelope.FieldName.OPERATION))
-                && ((Struct) record.key()).getInt32("id") == 2);
+            start(PostgresConnector.class, config, record -> record.value() instanceof Struct value
+                    && "c".equals(value.getString(Envelope.FieldName.OPERATION))
+                    && ((Struct) record.key()).getInt32("id") == 2);
 
-        VerifyRecord.isValidRead(consumeRecord(), "id", 1);
+            VerifyRecord.isValidRead(consumeRecord(), "id", 1);
 
-        TestHelper.execute("UPDATE public.pk_restart SET id = 2 WHERE id = 1;");
+            TestHelper.execute("UPDATE public.pk_restart SET id = 2 WHERE id = 1;");
 
-        VerifyRecord.isValidDelete(consumeRecord(), "id", 1);
-        VerifyRecord.isValidTombstone(consumeRecord());
+            VerifyRecord.isValidDelete(consumeRecord(), "id", 1);
+            VerifyRecord.isValidTombstone(consumeRecord());
 
-        waitForEngineShutdown();
-        cleanupTestFwkState();
+            waitForEngineShutdown();
+            stopConnector();
 
-        start(PostgresConnector.class, config);
-        assertConnectorIsRunning();
+            start(PostgresConnector.class, config);
+            assertConnectorIsRunning();
 
-        TestHelper.execute("INSERT INTO public.pk_restart VALUES (3, 30);");
+            TestHelper.execute("INSERT INTO public.pk_restart VALUES (3, 30);");
 
-        VerifyRecord.isValidDelete(consumeRecord(), "id", 1);
-        VerifyRecord.isValidTombstone(consumeRecord());
-        VerifyRecord.isValidInsert(consumeRecord(), "id", 2);
-        VerifyRecord.isValidInsert(consumeRecord(), "id", 3);
+            VerifyRecord.isValidDelete(consumeRecord(), "id", 1);
+            VerifyRecord.isValidTombstone(consumeRecord());
+            VerifyRecord.isValidInsert(consumeRecord(), "id", 2);
+            VerifyRecord.isValidInsert(consumeRecord(), "id", 3);
+        }
+        finally {
+            stopConnector();
+            TestHelper.execute("DROP TABLE IF EXISTS public.pk_restart;");
+        }
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -3679,6 +3679,46 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldReplayPrimaryKeyUpdateWhenStoppedBeforeCreateIsCommitted() throws Exception {
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS public.pk_restart;" +
+                        "CREATE TABLE public.pk_restart (id INTEGER PRIMARY KEY, value INTEGER);" +
+                        "INSERT INTO public.pk_restart VALUES (1, 10);");
+
+        final Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.pk_restart")
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
+                .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 1)
+                .build();
+
+        start(PostgresConnector.class, config, record -> record.value() instanceof Struct value
+                && "c".equals(value.getString(Envelope.FieldName.OPERATION))
+                && ((Struct) record.key()).getInt32("id") == 2);
+
+        VerifyRecord.isValidRead(consumeRecord(), "id", 1);
+
+        TestHelper.execute("UPDATE public.pk_restart SET id = 2 WHERE id = 1;");
+
+        VerifyRecord.isValidDelete(consumeRecord(), "id", 1);
+        VerifyRecord.isValidTombstone(consumeRecord());
+
+        waitForEngineShutdown();
+        cleanupTestFwkState();
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+
+        TestHelper.execute("INSERT INTO public.pk_restart VALUES (3, 30);");
+
+        VerifyRecord.isValidDelete(consumeRecord(), "id", 1);
+        VerifyRecord.isValidTombstone(consumeRecord());
+        VerifyRecord.isValidInsert(consumeRecord(), "id", 2);
+        VerifyRecord.isValidInsert(consumeRecord(), "id", 3);
+    }
+
+    @Test
     @FixFor("DBZ-5783")
     public void shouldSuppressLoggingOptionalOfExcludedColumns() throws Exception {
         TestHelper.execute(CREATE_TABLES_STMT);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresOffsetContextTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresOffsetContextTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.connector.postgresql.connection.ReplicationMessage.Operation;
 import io.debezium.doc.FixFor;
 import io.debezium.pipeline.spi.OffsetContext;
 
@@ -41,5 +42,20 @@ public class PostgresOffsetContextTest {
 
         final PostgresOffsetContext offsetContext = (PostgresOffsetContext) offsetLoader.load(offsetValues);
         assertThat(offsetContext.lsn()).isEqualTo(Lsn.valueOf(12345L));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2549")
+    public void shouldRetainOffsetFromBeforeCurrentSourceEvent() {
+        final Map<String, Object> offsetValues = new HashMap<>();
+        offsetValues.put(SourceInfo.LSN_KEY, 12345L);
+        offsetValues.put(SourceInfo.TIMESTAMP_USEC_KEY, 67890L);
+
+        final PostgresOffsetContext offsetContext = (PostgresOffsetContext) offsetLoader.load(offsetValues);
+        offsetContext.markSourceEventStarted();
+        offsetContext.updateWalPosition(Lsn.valueOf(23456L), Lsn.valueOf(23456L), null, null, null, Operation.UPDATE);
+
+        assertThat(offsetContext.getOffset().get(SourceInfo.LSN_KEY)).isEqualTo(23456L);
+        assertThat(offsetContext.getOffsetForIncompleteEvent().get(SourceInfo.LSN_KEY)).isEqualTo(12345L);
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -371,6 +371,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                         final Object[] dataNext = (operation == SqlServerChangeRecordEmitter.OP_UPDATE_BEFORE) ? tableWithSmallestLsn.getData() : null;
 
                         final ResultSet resultSet = tableWithSmallestLsn.getResultSet();
+                        offsetContext.markSourceEventStarted();
                         offsetContext.setChangePosition(tableWithSmallestLsn.getChangePosition(), eventCount);
                         offsetContext.event(
                                 tableWithSmallestLsn.getChangeTable().getSourceTableId(),


### PR DESCRIPTION
Fixes debezium/dbz#2549

## Description

A single database source event can produce several Kafka Connect records, such as DELETE, tombstone, and CREATE for a primary key update. When these records cross a poll batch boundary, committing the advanced offset from an intermediate record can cause the remaining records to be permanently lost after a connector restart.

This change:

* Captures the source offset before each affected streaming event advances its database position or MongoDB resume token.
* Marks whether an emitted record completes the source event.
* Uses the previous completed offset for intermediate records.
* Uses the current offset only for the final derived record.
* Handles normal deletes, primary key updates with tombstones enabled or disabled, and implicit transaction metadata.
* Extends the same semantics to MongoDB change-stream events, including normal DELETE and tombstone sequences, and restores persisted transaction context when loading MongoDB offsets.
* Adds default SPI methods so existing connector implementations retain their current behavior unless they opt into previous-offset capture.

The resulting behavior follows at-least-once delivery. Intermediate records can be replayed after failure, while the final tombstone or CREATE record is no longer permanently lost.

## Testing

* Common dispatcher tests for DELETE, tombstone, and primary key update offset ordering.
* Common transaction metadata tests.
* MySQL 8.2 restart tests with `max.batch.size=1`.
* MySQL 8.2 coverage with `tombstones.on.delete=true` and `false`.
* PostgreSQL 17 primary key update restart test with `max.batch.size=1`.
* MongoDB restart test for a normal DELETE split from its tombstone with `max.batch.size=1`.
* MongoDB transaction metadata restart test covering END, DELETE, and tombstone across poll batches.
* MongoDB offset loader test for persisted transaction context.
* Connector-specific offset context tests.
* Main and test source compilation for the binlog, MongoDB, PostgreSQL, SQL Server, and Oracle connector modules.
* Debezium formatter and `git diff --check`.

SQL Server and Oracle database integration tests were not run locally.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature or change per PR
- [x] Rebased on upstream `main`


