### PR TITLE
debezium/dbz#2550 Update cron schedule to run size check at 2 AM UTC every Monday

### DIFF
--- a/.github/workflows/nightly-build-size-check.yml
+++ b/.github/workflows/nightly-build-size-check.yml
@@ -2,8 +2,8 @@ name: Nightly Build Size Check
 
 on:
   schedule:
-    # Run at 2 AM UTC every day
-    - cron: '0 2 * * *'
+    # Run at 2 AM UTC every Monday
+    - cron: '0 2 * * 1'
   workflow_dispatch: # Allow manual trigger
 
 env:


### PR DESCRIPTION
Fixes debezium/dbz#2550

## Description
Update the cron schedule to run the size check weekly instead of daily, while waiting for the repository split optimisation to complete.

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
