### PR TITLE
debezium/dbz#2551 Prevent SQL Server Agent status query check from fa…

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -833,7 +833,11 @@ public class SqlServerConnection extends JdbcConnection {
     public boolean isAgentRunning(String databaseName) throws SQLException {
         final String query = replaceDatabaseNamePlaceholder(config().getString(AGENT_STATUS_QUERY), databaseName);
         return queryAndMap(query,
-                singleResultMapper(rs -> rs.getBoolean(1), "SQL Server Agent running status query must return exactly one value"));
+                singleResultMapper(rs -> rs.getBoolean(1), true,
+                        "Configured SQL Server Agent status query \"" + query + "\" "
+                                + "did not return the expected single row indicating whether the SQL Server Agent is running. "
+                                + "If this query is not applicable to your SQL Server deployment, override 'database.sqlserver.agent.status.query' "
+                                + "with a query appropriate for your deployment."));
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -68,6 +68,7 @@ import io.debezium.doc.FixFor;
 import io.debezium.embedded.async.AbstractAsyncEngineConnectorTest;
 import io.debezium.embedded.async.RetryingCallable;
 import io.debezium.heartbeat.DatabaseHeartbeatImpl;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.Flaky;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.pipeline.spi.Offsets;
@@ -2518,6 +2519,35 @@ public class SqlServerConnectorIT extends AbstractAsyncEngineConnectorTest {
 
         final String message = "Streaming is disabled for snapshot mode initial_only";
         stopConnector(value -> assertThat(logInterceptor.containsMessage(message)).isTrue());
+    }
+
+    @Test
+    @FixFor("dbz#2551")
+    public void connectorShouldKeepRunningWhenAgentStatusQueryReturnsNoRowsOnIdleDatabase() throws Exception {
+        final Configuration config = TestHelper.defaultConfig()
+                .with("database.sqlserver.agent.status.query", "SELECT 1 WHERE 1 = 0")
+                .build();
+
+        final LogInterceptor logInterceptor = new LogInterceptor(JdbcConnection.class);
+
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+
+        // Wait for snapshot completion so streaming has started
+        consumeRecordsByTopic(1);
+
+        // Simulate the CDC clean up job emptying lsn_time_mapping on an idle database, so the next
+        // poll sees no maximum LSN and falls into the Agent status check.
+        connection.execute("DELETE FROM cdc.lsn_time_mapping");
+
+        Awaitility.await()
+                .atMost(TestHelper.waitTimeForLogEntries(), TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(logInterceptor.containsWarnMessage(
+                        "did not return the expected single row indicating whether the SQL Server Agent is running")).isTrue());
+
+        assertConnectorIsRunning();
+
+        stopConnector();
     }
 
     @Test


### PR DESCRIPTION
…iling the task

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2551



## Description
The PR updates the sqlserver agent running check to use non-fatal `singleResultMapper`. It only logs the warn message and does not throw an exception. This is to keep the failures consistent with the caller which logs error/warn in case the agent is not running or the query execution fails with a SQLException. There are database deployment where the present query may not work and the task may fail. The warning log would explain the user to change the query and not cause the task failure. 

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [ ] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [ ] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [ ] One feature/change per PR unless tightly coupled
- [ ] Do a rebase on upstream `main`
