### PR TITLE
debezium/dbz#1236 Add minimal_instance snapshot locking mode using LOCK INSTANCE FOR BACKUP

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSnapshotChangeEventSource.java
@@ -43,6 +43,7 @@ import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
 import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection.DatabaseLocales;
 import io.debezium.connector.binlog.jdbc.BinlogSystemVariables;
 import io.debezium.connector.binlog.metrics.BinlogSnapshotChangeEventSourceMetrics;
+import io.debezium.connector.binlog.snapshot.lock.UnlockStatementProvider;
 import io.debezium.data.Envelope;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.jdbc.JdbcConnection;
@@ -503,8 +504,11 @@ public abstract class BinlogSnapshotChangeEventSource<P extends BinlogPartition,
         // Stop the keep-alive first so that no other thread uses the connection while we release the lock.
         stopLockHeartbeat();
         synchronized (binlogConnectionMutex) {
+            final String unlockingStatement = snapshotterService.getSnapshotLock() instanceof UnlockStatementProvider unlockProvider
+                    ? unlockProvider.globalUnlockingStatement()
+                    : "UNLOCK TABLES";
             LOGGER.info("Releasing global read lock to enable MySQL writes");
-            connection.executeWithoutCommitting("UNLOCK TABLES");
+            connection.executeWithoutCommitting(unlockingStatement);
         }
         long lockReleased = clock.currentTimeInMillis();
         metrics.setGlobalLockReleased();

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/snapshot/lock/UnlockStatementProvider.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/snapshot/lock/UnlockStatementProvider.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog.snapshot.lock;
+
+/**
+ * Contract for {@link io.debezium.snapshot.spi.SnapshotLock} implementations whose global lock is not
+ * released by the default {@code UNLOCK TABLES} statement, e.g. the MySQL instance-level backup lock
+ * that requires {@code UNLOCK INSTANCE}.
+ */
+public interface UnlockStatementProvider {
+
+    /**
+     * @return the statement that releases the global lock acquired by the locking statement; never null
+     */
+    String globalUnlockingStatement();
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -134,6 +134,17 @@ public class MySqlConnectorConfig extends BinlogConnectorConfig {
         MINIMAL_PERCONA_NO_TABLE_LOCKS("minimal_percona_no_table_locks"),
 
         /**
+         * The connector holds an instance-level backup lock ({@code LOCK INSTANCE FOR BACKUP}, MySQL 8.0+) for just the initial
+         * portion of the snapshot while the connector reads the database schemas and other metadata. The backup lock blocks DDL
+         * statements while permitting concurrent DML, and requires the {@code BACKUP_ADMIN} privilege instead of {@code RELOAD}.
+         * The remaining work in a snapshot involves selecting all rows from each table, and this can be done in a consistent
+         * fashion using the REPEATABLE READ transaction even when the backup lock is no longer held and while other MySQL
+         * clients are updating the database. Note that unlike the global read lock, concurrent writes to non-transactional
+         * tables (e.g. MyISAM) are not blocked and may not be captured consistently.
+         */
+        MINIMAL_INSTANCE("minimal_instance"),
+
+        /**
          * This mode will avoid using ANY table locks during the snapshot process.  This mode can only be used with SnapShotMode
          * set to schema_only or schema_only_recovery.
          */
@@ -159,6 +170,7 @@ public class MySqlConnectorConfig extends BinlogConnectorConfig {
             return value.equals(MINIMAL.value) ||
                     value.equals(MINIMAL_PERCONA.value) ||
                     value.equals(MINIMAL_PERCONA_NO_TABLE_LOCKS.value) ||
+                    value.equals(MINIMAL_INSTANCE.value) ||
                     value.equals(MINIMAL_AT_LEAST_ONCE.getValue());
         }
 
@@ -167,7 +179,8 @@ public class MySqlConnectorConfig extends BinlogConnectorConfig {
         }
 
         public boolean flushResetsIsolationLevel() {
-            return !value.equals(MINIMAL_PERCONA.value) && !value.equals(MINIMAL_PERCONA_NO_TABLE_LOCKS.value);
+            return !value.equals(MINIMAL_PERCONA.value) && !value.equals(MINIMAL_PERCONA_NO_TABLE_LOCKS.value)
+                    && !value.equals(MINIMAL_INSTANCE.value);
         }
 
         public boolean preventsTableLocks() {
@@ -175,7 +188,8 @@ public class MySqlConnectorConfig extends BinlogConnectorConfig {
         }
 
         public boolean useConsistentSnapshotTransaction() {
-            return value.equals(MINIMAL.value) || value.equals(MINIMAL_PERCONA.value) || value.equals(MINIMAL_PERCONA_NO_TABLE_LOCKS.value);
+            return value.equals(MINIMAL.value) || value.equals(MINIMAL_PERCONA.value) || value.equals(MINIMAL_PERCONA_NO_TABLE_LOCKS.value)
+                    || value.equals(MINIMAL_INSTANCE.value);
         }
 
         /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/MinimalInstanceSnapshotLock.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/snapshot/lock/MinimalInstanceSnapshotLock.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.lock;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+import io.debezium.annotation.ConnectorSpecific;
+import io.debezium.connector.binlog.snapshot.lock.UnlockStatementProvider;
+import io.debezium.connector.mysql.MySqlConnector;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.snapshot.spi.SnapshotLock;
+
+/**
+ * Instance-level backup lock ({@code LOCK INSTANCE FOR BACKUP}, MySQL 8.0+): blocks DDL while permitting
+ * concurrent DML, and requires the {@code BACKUP_ADMIN} privilege instead of {@code RELOAD}.
+ */
+@ConnectorSpecific(connector = MySqlConnector.class)
+public class MinimalInstanceSnapshotLock implements SnapshotLock, UnlockStatementProvider {
+
+    @Override
+    public String name() {
+        return MySqlConnectorConfig.SnapshotLockingMode.MINIMAL_INSTANCE.getValue();
+    }
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+
+    }
+
+    @Override
+    public Optional<String> tableLockingStatement(Duration lockTimeout, String tableId) {
+        return Optional.of("LOCK INSTANCE FOR BACKUP");
+    }
+
+    @Override
+    public String globalUnlockingStatement() {
+        return "UNLOCK INSTANCE";
+    }
+}

--- a/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
+++ b/debezium-connector-mysql/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
@@ -2,4 +2,5 @@ io.debezium.connector.mysql.snapshot.lock.ExtendedSnapshotLock
 io.debezium.connector.mysql.snapshot.lock.MinimalSnapshotLock
 io.debezium.connector.mysql.snapshot.lock.MinimalPerconaSnapshotLock
 io.debezium.connector.mysql.snapshot.lock.MinimalPerconaNoTableLocksSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.MinimalInstanceSnapshotLock
 io.debezium.connector.mysql.snapshot.lock.NoneSnapshotLock

--- a/debezium-connector-mysql/src/test/docker/init-alt-replica/001-setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init-alt-replica/001-setup.sql
@@ -12,6 +12,8 @@ CREATE USER 'snapper' IDENTIFIED BY 'snapperpass';
 GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'snapper'@'%';
 CREATE USER 'cloud' IDENTIFIED BY 'cloudpass';
 GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, LOCK TABLES  ON *.* TO 'cloud'@'%';
+-- MySQL 8.0+ only: dynamic privilege for LOCK INSTANCE FOR BACKUP (statement is a no-op on older versions)
+/*!80011 GRANT BACKUP_ADMIN ON *.* TO 'cloud'@'%' */;
 GRANT ALL PRIVILEGES ON *.* TO 'mysqlreplica'@'%';
 
 -- Start the GTID-based replication ...

--- a/debezium-connector-mysql/src/test/docker/init-percona/001-setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init-percona/001-setup.sql
@@ -12,6 +12,8 @@ CREATE USER 'snapper' IDENTIFIED BY 'snapperpass';
 GRANT SELECT, INSERT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'snapper'@'%';
 CREATE USER 'cloud' IDENTIFIED BY 'cloudpass';
 GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, LOCK TABLES  ON *.* TO 'cloud'@'%';
+-- MySQL 8.0+ only: dynamic privilege for LOCK INSTANCE FOR BACKUP (statement is a no-op on older versions)
+/*!80011 GRANT BACKUP_ADMIN ON *.* TO 'cloud'@'%' */;
 GRANT ALL PRIVILEGES ON *.* TO 'mysqluser'@'%';
 
 -- ----------------------------------------------------------------------------------------------------------------

--- a/debezium-connector-mysql/src/test/docker/init-replica/001-setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init-replica/001-setup.sql
@@ -12,6 +12,8 @@ CREATE USER 'snapper' IDENTIFIED BY 'snapperpass';
 GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'snapper'@'%';
 CREATE USER 'cloud' IDENTIFIED BY 'cloudpass';
 GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, LOCK TABLES  ON *.* TO 'cloud'@'%';
+-- MySQL 8.0+ only: dynamic privilege for LOCK INSTANCE FOR BACKUP (statement is a no-op on older versions)
+/*!80011 GRANT BACKUP_ADMIN ON *.* TO 'cloud'@'%' */;
 GRANT ALL PRIVILEGES ON *.* TO 'mysqlreplica'@'%';
 
 -- Start the GTID-based replication ...

--- a/debezium-connector-mysql/src/test/docker/init/001-setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/001-setup.sql
@@ -12,6 +12,8 @@ CREATE USER 'snapper' IDENTIFIED BY 'snapperpass';
 GRANT SELECT, INSERT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'snapper'@'%';
 CREATE USER 'cloud' IDENTIFIED BY 'cloudpass';
 GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, LOCK TABLES  ON *.* TO 'cloud'@'%';
+-- MySQL 8.0+ only: dynamic privilege for LOCK INSTANCE FOR BACKUP (statement is a no-op on older versions)
+/*!80011 GRANT BACKUP_ADMIN ON *.* TO 'cloud'@'%' */;
 GRANT ALL PRIVILEGES ON *.* TO 'mysqluser'@'%';
 
 -- ----------------------------------------------------------------------------------------------------------------

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotSourceIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotSourceIT.java
@@ -20,11 +20,14 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Field;
 import io.debezium.connector.binlog.BinlogConnectorConfig;
+import io.debezium.connector.binlog.BinlogSnapshotChangeEventSource;
 import io.debezium.connector.binlog.BinlogSnapshotSourceIT;
 import io.debezium.data.KeyValueStore;
 import io.debezium.data.SchemaChangeHistory;
 import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.junit.logging.LogInterceptor;
 
 /**
  * @author Randall Hauch
@@ -71,6 +74,54 @@ public class SnapshotSourceIT extends BinlogSnapshotSourceIT<MySqlConnector> imp
         final int recordCount = 9 + 9 + 4 + 5 + 1;
         SourceRecords sourceRecords = consumeRecordsByTopic(recordCount);
         assertThat(sourceRecords.allRecordsInOrder()).hasSize(recordCount);
+        connection.connection().close();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1236")
+    public void snapshotWithInstanceBackupLockShouldNotWaitForReads() throws Exception {
+        if (isMySQL5()) {
+            return; // LOCK INSTANCE FOR BACKUP requires MySQL 8.0+
+        }
+
+        // the init scripts grant the dynamic BACKUP_ADMIN privilege to 'cloud' on MySQL 8.0+
+        config = simpleConfig()
+                .with(MySqlConnectorConfig.USER, "cloud")
+                .with(MySqlConnectorConfig.PASSWORD, "cloudpass")
+                .with(MySqlConnectorConfig.SNAPSHOT_LOCKING_MODE, MySqlConnectorConfig.SnapshotLockingMode.MINIMAL_INSTANCE)
+                .build();
+
+        final LogInterceptor logInterceptor = new LogInterceptor(BinlogSnapshotChangeEventSource.class);
+
+        final MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName());
+        final JdbcConnection connection = db.connect();
+        final CountDownLatch latch = new CountDownLatch(1);
+        Thread t = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    connection.executeWithoutCommitting("SELECT *, SLEEP(20) FROM products_on_hand WHERE product_id=101");
+                    latch.countDown();
+                }
+                catch (Exception e) {
+                    // Do nothing.
+                }
+            }
+        };
+        t.start();
+
+        latch.await(10, TimeUnit.SECONDS);
+        // Start the connector ...
+        start(MySqlConnector.class, config);
+        waitForSnapshotToBeCompleted("mysql", DATABASE.getServerName());
+
+        // Poll for records ...
+        final int recordCount = 9 + 9 + 4 + 5 + 1;
+        SourceRecords sourceRecords = consumeRecordsByTopic(recordCount);
+        assertThat(sourceRecords.allRecordsInOrder()).hasSize(recordCount);
+
+        // The instance backup lock must have been acquired without falling back to table-level locks
+        assertThat(logInterceptor.containsMessage("Unable to flush and acquire global read lock")).isFalse();
         connection.connection().close();
     }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/snapshot/lock/MinimalInstanceSnapshotLockTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/snapshot/lock/MinimalInstanceSnapshotLockTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.snapshot.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotLockingMode;
+
+public class MinimalInstanceSnapshotLockTest {
+
+    @Test
+    public void shouldUseInstanceBackupLockStatements() {
+        final MinimalInstanceSnapshotLock lock = new MinimalInstanceSnapshotLock();
+
+        assertThat(lock.name()).isEqualTo(SnapshotLockingMode.MINIMAL_INSTANCE.getValue());
+        assertThat(lock.tableLockingStatement(null, null)).contains("LOCK INSTANCE FOR BACKUP");
+        assertThat(lock.globalUnlockingStatement()).isEqualTo("UNLOCK INSTANCE");
+    }
+
+    @Test
+    public void modeFlagsShouldMatchBackupLockSemantics() {
+        final SnapshotLockingMode mode = SnapshotLockingMode.MINIMAL_INSTANCE;
+
+        // lock is held only for the initial schema portion of the snapshot
+        assertThat(mode.usesLocking()).isTrue();
+        assertThat(mode.usesMinimalLocking()).isTrue();
+        // no FLUSH is executed, so the isolation level does not need to be restored
+        assertThat(mode.flushResetsIsolationLevel()).isFalse();
+        assertThat(mode.useConsistentSnapshotTransaction()).isTrue();
+        // table-level lock fallback stays available, mirroring minimal_percona
+        assertThat(mode.preventsTableLocks()).isFalse();
+    }
+}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -652,6 +652,16 @@ During the next phase of the snapshot, the connector releases the lock as it sel
 To perform the SELECT operation in a consistent fashion, the connector uses a REPEATABLE READ transaction.
 Although the release of the global read lock permits other {connector-name} clients to update the database, use of REPEATABLE READ isolation ensures a consistent snapshot, because the connector continues to read the same data for the duration of  the transaction.
 
+ifdef::MYSQL[]
+`minimal_instance`:::: The connector holds an instance-level backup lock (`LOCK INSTANCE FOR BACKUP`) during the initial phase of the snapshot while it reads the database schemas and other metadata.
+This mode is available for MySQL 8.0 and later and requires the `BACKUP_ADMIN` privilege.
+The backup lock permits concurrent DML while preventing operations that could result in an inconsistent snapshot.
+After the connector releases the backup lock, it uses a REPEATABLE READ transaction to read table data consistently.
+Because the backup lock does not block concurrent writes to non-transactional tables, such as MyISAM tables, those tables might not be captured consistently.
+If the connector cannot acquire the backup lock, it falls back to table-level locks, which require the `LOCK TABLES` privilege.
+For more information, see the link:https://dev.mysql.com/doc/refman/8.0/en/lock-instance-for-backup.html[MySQL documentation].
+endif::MYSQL[]
+
 `extended`:::: Blocks all write operations for the duration of the snapshot.
 Use this setting if clients submit concurrent operations that are incompatible with the REPEATABLE READ isolation level in {connector-name}.
 


### PR DESCRIPTION
Addresses the MySQL snapshot-locking side of https://github.com/debezium/dbz/issues/1236.

The existing FTWRL-based `extended` and `minimal` locking modes block writes during the schema phase of a snapshot and require `RELOAD` or `FLUSH_TABLES` privileges. Standard MySQL 8.0+ provides `LOCK INSTANCE FOR BACKUP`, which blocks DDL while allowing DML and requires only the `BACKUP_ADMIN` dynamic privilege.

This PR adds `snapshot.locking.mode=minimal_instance`.

## Changes

* Adds `MinimalInstanceSnapshotLock`, using:
  * `LOCK INSTANCE FOR BACKUP` to protect the initial schema snapshot phase.
  * `START TRANSACTION WITH CONSISTENT SNAPSHOT` for consistent row reads.
  * The existing table-lock fallback when necessary.
* Adds an optional `UnlockStatementProvider` contract in the binlog module so locks that require a custom unlock statement can provide one.
  * `minimal_instance` uses `UNLOCK INSTANCE`.
  * Existing snapshot lock implementations continue to use `UNLOCK TABLES` unchanged.

## Scope

MariaDB is intentionally excluded because its `BACKUP STAGE` mechanism has different semantics.

A `minimal_instance_no_table_locks` variant can be added separately if needed, analogous to the existing Percona modes.