### PR TITLE
debezium/dbz#2554: SqlServerDatabaseDialect.getQueryBindingWithValueCast should explicitly cast to VARCHAR

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
@@ -7,6 +7,7 @@ package io.debezium.connector.jdbc.dialect.sqlserver;
 
 import java.util.Optional;
 
+import org.apache.kafka.connect.data.Schema;
 import org.hibernate.SessionFactory;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.SQLServerDialect;
@@ -19,6 +20,8 @@ import io.debezium.connector.jdbc.dialect.GeneralDatabaseDialect;
 import io.debezium.connector.jdbc.dialect.SqlStatementBuilder;
 import io.debezium.connector.jdbc.dialect.sqlserver.connect.ConnectTimeType;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
 
 /**
  * A {@link DatabaseDialect} implementation for SQL Server.
@@ -128,6 +131,18 @@ public class SqlServerDatabaseDialect extends GeneralDatabaseDialect {
     @Override
     public String getTimestampNegativeInfinityValue() {
         return "0001-01-01T00:00:00+00:00";
+    }
+
+    @Override
+    public String getQueryBindingWithValueCast(ColumnDescriptor column, Schema schema, JdbcType type) {
+        if (schema.type() == Schema.Type.STRING) {
+            final String typeName = column.getTypeName().toLowerCase();
+
+            if ("varchar".equals(typeName)) {
+                return "cast(? as varchar)";
+            }
+        }
+        return super.getQueryBindingWithValueCast(column, schema, type);
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialect.java
@@ -139,7 +139,15 @@ public class SqlServerDatabaseDialect extends GeneralDatabaseDialect {
             final String typeName = column.getTypeName().toLowerCase();
 
             if ("varchar".equals(typeName)) {
-                return "cast(? as varchar)";
+                final int precision = column.getPrecision();
+                final String precisionString;
+                if (precision > getMaxVarcharLengthInKey() || precision <= 0) {
+                    precisionString = "max";
+                }
+                else {
+                    precisionString = Integer.toString(precision);
+                }
+                return "cast(? as varchar(" + precisionString + "))";
             }
         }
         return super.getQueryBindingWithValueCast(column, schema, type);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialectQueryBindingTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialectQueryBindingTest.java
@@ -32,6 +32,7 @@ import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.data.Xml;
 import io.debezium.sink.column.ColumnDescriptor;
 
+
 @Tag("UnitTests")
 class SqlServerDatabaseDialectQueryBindingTest {
 
@@ -77,7 +78,7 @@ class SqlServerDatabaseDialectQueryBindingTest {
 
         final JdbcType type = dialect.getSchemaType(Schema.STRING_SCHEMA);
 
-        assertThat(type.getQueryBinding(column, Schema.STRING_SCHEMA, "hello")).isEqualTo("cast(? as varchar)");
+        assertThat(type.getQueryBinding(column, Schema.STRING_SCHEMA, "hello")).isEqualTo("cast(? as varchar(max))");
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialectQueryBindingTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/sqlserver/SqlServerDatabaseDialectQueryBindingTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Types;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.hibernate.SessionFactory;
+import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
+import org.hibernate.type.spi.TypeConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.data.Xml;
+import io.debezium.sink.column.ColumnDescriptor;
+
+@Tag("UnitTests")
+class SqlServerDatabaseDialectQueryBindingTest {
+
+    private DatabaseDialect dialect;
+
+    @BeforeEach
+    void createDialect() {
+        final SessionFactory sessionFactory = mock(SessionFactory.class);
+        final SessionFactoryImplementor implementor = mock(SessionFactoryImplementor.class);
+        final JdbcServices jdbcServices = mock(JdbcServices.class);
+        final JdbcEnvironment jdbcEnvironment = mock(JdbcEnvironment.class);
+        final IdentifierHelper identifierHelper = mock(IdentifierHelper.class);
+        final TypeConfiguration typeConfiguration = mock(TypeConfiguration.class);
+        final DdlTypeRegistry ddlTypeRegistry = mock(DdlTypeRegistry.class);
+
+        when(sessionFactory.unwrap(SessionFactoryImplementor.class)).thenReturn(implementor);
+        when(implementor.getJdbcServices()).thenReturn(jdbcServices);
+        when(implementor.getTypeConfiguration()).thenReturn(typeConfiguration);
+        // Real Hibernate dialect: the SQL Server provider and identifier/quoting logic inspect the
+        // actual type, not a mock.
+        when(jdbcServices.getDialect()).thenReturn(new SQLServerDialect());
+        when(jdbcServices.getJdbcEnvironment()).thenReturn(jdbcEnvironment);
+        when(jdbcEnvironment.getIdentifierHelper()).thenReturn(identifierHelper);
+        when(typeConfiguration.getDdlTypeRegistry()).thenReturn(ddlTypeRegistry);
+        // sessionFactory.openStatelessSession() is intentionally left unstubbed: the constructor's
+        // best-effort database timezone lookup swallows any failure and falls back to "N/A".
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                JdbcSinkConnectorConfig.CONNECTION_URL, "jdbc:sqlserver://localhost:1433",
+                JdbcSinkConnectorConfig.CONNECTION_USER, "sa"));
+
+        dialect = new SqlServerDatabaseDialect.SqlServerDatabaseDialectProvider().instantiate(config, sessionFactory);
+    }
+
+    @Test
+    @DisplayName("Should bind varchar field with cast to varchar")
+    void shouldBindVarcharFieldWithCastToVarchar() {
+        final ColumnDescriptor column = ColumnDescriptor.builder()
+                .columnName("name")
+                .jdbcType(Types.VARCHAR)
+                .typeName("varchar")
+                .build();
+
+        final JdbcType type = dialect.getSchemaType(Schema.STRING_SCHEMA);
+
+        assertThat(type.getQueryBinding(column, Schema.STRING_SCHEMA, "hello")).isEqualTo("cast(? as varchar)");
+    }
+
+    @Test
+    @DisplayName("Should bind nvarchar field without cast")
+    void shouldBindNvarcharFieldWithoutCast() {
+        final ColumnDescriptor column = ColumnDescriptor.builder()
+                .columnName("name")
+                .jdbcType(Types.NVARCHAR)
+                .typeName("nvarchar")
+                .build();
+
+        final JdbcType type = dialect.getSchemaType(Schema.STRING_SCHEMA);
+
+        assertThat(type.getQueryBinding(column, Schema.STRING_SCHEMA, "hello")).isEqualTo("?");
+    }
+
+    @Test
+    @DisplayName("Should bind xml field with cast to xml")
+    void shouldBindXmlFieldWithCastToXml() {
+        final Schema schema = Xml.schema();
+
+        final ColumnDescriptor column = ColumnDescriptor.builder()
+                .columnName("payload")
+                .jdbcType(Types.SQLXML)
+                .typeName("xml")
+                .build();
+
+        final JdbcType type = dialect.getSchemaType(schema);
+
+        assertThat(type.getQueryBinding(column, schema, "<a/>")).isEqualTo("cast(? as xml)");
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2554

## Description

SqlServerDatabaseDialect.getQueryBindingWithValueCast now returns `CAST(? AS VARCHAR)` if the target column is of type `VARCHAR`. 
Added some tests for this method.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
