### PR TITLE
debezium/dbz#917 Honor MongoDB read preference after replica set elections

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbReadPreferenceMonitor.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbReadPreferenceMonitor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ClusterConnectionMode;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterType;
+
+import io.debezium.util.Clock;
+
+/**
+ * Detects when an open change stream cursor no longer satisfies its configured read preference.
+ */
+final class MongoDbReadPreferenceMonitor {
+
+    enum Status {
+        SATISFIED,
+        RELOCATE,
+        NO_ELIGIBLE_SERVER,
+        UNVERIFIED
+    }
+
+    private final ReadPreference readPreference;
+    private final long checkIntervalMs;
+    private final long checkIntervalNanos;
+    private final Clock clock;
+    private long lastCheckTimeNanos;
+
+    MongoDbReadPreferenceMonitor(ReadPreference readPreference, long checkIntervalMs, Clock clock) {
+        this.readPreference = Objects.requireNonNull(readPreference);
+        this.checkIntervalMs = Math.max(1, checkIntervalMs);
+        this.checkIntervalNanos = TimeUnit.MILLISECONDS.toNanos(this.checkIntervalMs);
+        this.clock = Objects.requireNonNull(clock);
+        this.lastCheckTimeNanos = clock.currentTimeInNanos();
+    }
+
+    Status evaluate(ClusterDescription clusterDescription, ServerAddress cursorAddress) {
+        if (clusterDescription.getType() != ClusterType.REPLICA_SET
+                || clusterDescription.getConnectionMode() != ClusterConnectionMode.MULTIPLE) {
+            return Status.SATISFIED;
+        }
+
+        var cursorServer = clusterDescription.getServerDescriptions().stream()
+                .filter(server -> server.getAddress().equals(cursorAddress))
+                .filter(server -> server.isOk())
+                .findFirst();
+
+        if (cursorServer.isEmpty()) {
+            return Status.UNVERIFIED;
+        }
+
+        var candidates = readPreference.choose(clusterDescription);
+        if (candidates.stream().anyMatch(server -> server.getAddress().equals(cursorAddress))) {
+            return Status.SATISFIED;
+        }
+
+        return candidates.isEmpty() ? Status.NO_ELIGIBLE_SERVER : Status.RELOCATE;
+    }
+
+    boolean shouldWaitForEligibleServer(ClusterDescription clusterDescription) {
+        if (clusterDescription.getConnectionMode() != ClusterConnectionMode.MULTIPLE) {
+            return false;
+        }
+
+        if (clusterDescription.getType() == ClusterType.UNKNOWN) {
+            return true;
+        }
+
+        return clusterDescription.getType() == ClusterType.REPLICA_SET
+                && readPreference.choose(clusterDescription).isEmpty();
+    }
+
+    ReadPreference getReadPreference() {
+        return readPreference;
+    }
+
+    long getCheckIntervalMs() {
+        return checkIntervalMs;
+    }
+
+    boolean isCheckDue() {
+        var now = clock.currentTimeInNanos();
+        if (now - lastCheckTimeNanos < checkIntervalNanos) {
+            return false;
+        }
+
+        lastCheckTimeNanos = now;
+        return true;
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -148,6 +148,11 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
                             var cursorAddress = cursor.getCurrentServerAddress();
                             if (cursorAddress.isPresent()) {
                                 nextAction = readPreferenceMonitor.evaluate(client.getClusterDescription(), cursorAddress.get());
+                                if (nextAction == MongoDbReadPreferenceMonitor.Status.UNVERIFIED) {
+                                    LOGGER.debug("Unable to verify whether change stream server '{}' satisfies read preference '{}'; "
+                                            + "the topology will be checked again at the next monitoring interval",
+                                            cursorAddress.get(), readPreferenceMonitor.getReadPreference());
+                                }
                                 if (nextAction == MongoDbReadPreferenceMonitor.Status.RELOCATE) {
                                     LOGGER.info("Change stream server '{}' no longer matches read preference '{}'; reopening from offset '{}'",
                                             cursorAddress.get(), readPreferenceMonitor.getReadPreference(), effectiveOffset.getOffset());

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mongodb;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -13,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.mongodb.MongoException;
+import com.mongodb.ReadPreference;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
@@ -34,6 +36,7 @@ import io.debezium.pipeline.monitor.OffsetActivityMonitorService;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.snapshot.SnapshotterService;
 import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
 
 /**
  * @author Chris Cranford
@@ -114,28 +117,99 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
     private void readChangeStream(MongoClient client, ChangeEventSourceContext context, MongoDbPartition partition) {
         LOGGER.info("Reading change stream");
         final SplitEventHandler<BsonDocument> splitHandler = new SplitEventHandler<>();
-        final ChangeStreamIterable<BsonDocument> stream = initChangeStream(client, effectiveOffset);
+        final ReadPreference readPreference = Optional.ofNullable(connectorConfig.getConnectionString().getReadPreference())
+                .orElse(ReadPreference.primary());
+        final MongoDbReadPreferenceMonitor readPreferenceMonitor = new MongoDbReadPreferenceMonitor(
+                readPreference, connectorConfig.getHeartbeatFrequencyMs(), clock);
 
-        try (var cursor = BufferingChangeStreamCursor.fromIterable(stream, taskContext, streamingMetrics, clock).start()) {
+        try {
             while (context.isRunning()) {
-                waitWhenStreamingPaused(context, cursor);
-                var resumableEvent = cursor.tryNext();
-                if (resumableEvent != null) {
-                    var result = resumableEvent.document
-                            .map(doc -> processChangeStreamDocument(doc, splitHandler, partition, effectiveOffset))
-                            .orElseGet(() -> errorHandled(() -> dispatchHeartbeatEvent(resumableEvent, partition, effectiveOffset)));
+                // The buffering cursor may have fetched beyond this point, so always resume from the last dispatched offset.
+                final ChangeStreamIterable<BsonDocument> stream = initChangeStream(client, effectiveOffset);
+                var nextAction = MongoDbReadPreferenceMonitor.Status.SATISFIED;
 
-                    if (result == StreamStatus.ERROR) {
-                        return;
+                try (var cursor = BufferingChangeStreamCursor.fromIterable(stream, taskContext, streamingMetrics, clock).start()) {
+                    while (context.isRunning()) {
+                        waitWhenStreamingPaused(context, cursor);
+                        var resumableEvent = cursor.tryNext();
+                        if (resumableEvent != null) {
+                            var result = resumableEvent.document
+                                    .map(doc -> processChangeStreamDocument(doc, splitHandler, partition, effectiveOffset))
+                                    .orElseGet(() -> errorHandled(() -> dispatchHeartbeatEvent(resumableEvent, partition, effectiveOffset)));
+
+                            if (result == StreamStatus.ERROR) {
+                                return;
+                            }
+                        }
+
+                        offsetActivityMonitorService.pulse(partition, effectiveOffset);
+
+                        if (effectiveOffset.hasOffset() && splitHandler.isEmpty() && readPreferenceMonitor.isCheckDue()) {
+                            var cursorAddress = cursor.getCurrentServerAddress();
+                            if (cursorAddress.isPresent()) {
+                                nextAction = readPreferenceMonitor.evaluate(client.getClusterDescription(), cursorAddress.get());
+                                if (nextAction == MongoDbReadPreferenceMonitor.Status.RELOCATE) {
+                                    LOGGER.info("Change stream server '{}' no longer matches read preference '{}'; reopening from offset '{}'",
+                                            cursorAddress.get(), readPreferenceMonitor.getReadPreference(), effectiveOffset.getOffset());
+                                    break;
+                                }
+                                if (nextAction == MongoDbReadPreferenceMonitor.Status.NO_ELIGIBLE_SERVER) {
+                                    LOGGER.info("Change stream server '{}' no longer matches read preference '{}', and no eligible server is available; "
+                                            + "pausing change stream consumption at offset '{}'",
+                                            cursorAddress.get(), readPreferenceMonitor.getReadPreference(), effectiveOffset.getOffset());
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
 
-                offsetActivityMonitorService.pulse(partition, effectiveOffset);
+                if (nextAction == MongoDbReadPreferenceMonitor.Status.NO_ELIGIBLE_SERVER
+                        && !waitForEligibleServer(client, context, readPreferenceMonitor, partition)) {
+                    return;
+                }
+                if (nextAction != MongoDbReadPreferenceMonitor.Status.RELOCATE
+                        && nextAction != MongoDbReadPreferenceMonitor.Status.NO_ELIGIBLE_SERVER) {
+                    return;
+                }
             }
+        }
+        catch (InterruptedException e) {
+            LOGGER.info("Interrupted while waiting for a server that satisfies read preference '{}'", readPreferenceMonitor.getReadPreference());
+            Thread.currentThread().interrupt();
         }
         catch (MongoException e) {
             LOGGER.error("Error while reading change stream", e);
             errorHandler.setProducerThrowable(e);
+        }
+    }
+
+    private boolean waitForEligibleServer(MongoClient client, ChangeEventSourceContext context,
+                                          MongoDbReadPreferenceMonitor readPreferenceMonitor, MongoDbPartition partition)
+            throws InterruptedException {
+        final Metronome metronome = Metronome.parker(Duration.ofMillis(readPreferenceMonitor.getCheckIntervalMs()), clock);
+
+        while (context.isRunning()) {
+            waitWhenStreamingPaused(context);
+            if (!readPreferenceMonitor.shouldWaitForEligibleServer(client.getClusterDescription())) {
+                LOGGER.info("An eligible server for read preference '{}' is available; resuming change stream consumption from offset '{}'",
+                        readPreferenceMonitor.getReadPreference(), effectiveOffset.getOffset());
+                return true;
+            }
+
+            offsetActivityMonitorService.pulse(partition, effectiveOffset);
+            metronome.pause();
+        }
+
+        return false;
+    }
+
+    private void waitWhenStreamingPaused(ChangeEventSourceContext context) throws InterruptedException {
+        if (context.isPaused()) {
+            LOGGER.info("Streaming will now pause while waiting for an eligible change stream server");
+            context.streamingPaused();
+            context.waitSnapshotCompletion();
+            LOGGER.info("Streaming resumed");
         }
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/events/BufferingChangeStreamCursor.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/events/BufferingChangeStreamCursor.java
@@ -453,8 +453,18 @@ public class BufferingChangeStreamCursor<TResult> implements MongoChangeStreamCu
      * Returns the address of the server hosting the underlying cursor, if the fetcher has opened it.
      */
     public Optional<ServerAddress> getCurrentServerAddress() {
-        return Optional.ofNullable(fetcher.cursorRef.get())
-                .map(MongoChangeStreamCursor::getServerAddress);
+        final var cursor = fetcher.cursorRef.get();
+        if (cursor == null) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.ofNullable(cursor.getServerAddress());
+        }
+        catch (IllegalStateException e) {
+            // The fetcher closed the cursor concurrently; the address is simply unavailable.
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/events/BufferingChangeStreamCursor.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/events/BufferingChangeStreamCursor.java
@@ -449,6 +449,14 @@ public class BufferingChangeStreamCursor<TResult> implements MongoChangeStreamCu
         return fetcher.cursorRef.get().getServerAddress();
     }
 
+    /**
+     * Returns the address of the server hosting the underlying cursor, if the fetcher has opened it.
+     */
+    public Optional<ServerAddress> getCurrentServerAddress() {
+        return Optional.ofNullable(fetcher.cursorRef.get())
+                .map(MongoChangeStreamCursor::getServerAddress);
+    }
+
     @Override
     public void close() {
         fetcher.close();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -12,6 +12,7 @@ import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,6 +61,7 @@ import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig.FiltersMatchMode;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig.FullUpdateType;
+import io.debezium.connector.mongodb.connection.ConnectionStrings;
 import io.debezium.connector.mongodb.events.BufferingChangeStreamCursor;
 import io.debezium.converters.CloudEventsConverterTest;
 import io.debezium.data.Envelope;
@@ -70,6 +72,8 @@ import io.debezium.heartbeat.Heartbeat;
 import io.debezium.junit.SkipWhenDatabaseVersion;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.schema.DatabaseSchema;
+import io.debezium.testing.testcontainers.MongoDbContainer;
+import io.debezium.testing.testcontainers.MongoDbReplicaSet;
 import io.debezium.util.Collect;
 import io.debezium.util.IoUtil;
 import io.debezium.util.Testing;
@@ -132,6 +136,79 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         Config result = connector.validate(config.asMap());
 
         assertConfigurationErrors(result, MongoDbConnectorConfig.CONNECTION_STRING, 2);
+    }
+
+    @Test
+    void shouldReopenPrimaryChangeStreamAfterElection() throws InterruptedException {
+        var replicaSet = requireThreeMemberReplicaSet();
+        var previousPrimary = replicaSet.tryPrimary().orElseThrow();
+
+        startReadPreferenceTestConnector("primary");
+        assertReadPreferenceTestDocument(1);
+
+        replicaSet.stepDown();
+        awaitPrimaryChange(replicaSet, previousPrimary);
+        awaitReadPreferenceReopen();
+
+        assertReadPreferenceTestDocument(2);
+    }
+
+    @Test
+    void shouldKeepConnectorRunningWhileWaitingForExactReadPreference() throws InterruptedException {
+        var replicaSet = requireThreeMemberReplicaSet();
+        var previousPrimary = replicaSet.tryPrimary().orElseThrow();
+        var secondaryMembers = replicaSet.getMembers().stream()
+                .filter(member -> member != previousPrimary)
+                .toList();
+
+        startReadPreferenceTestConnector("primary");
+        assertReadPreferenceTestDocument(1);
+
+        try {
+            secondaryMembers.forEach(member -> member.eval("db.adminCommand({ replSetFreeze: 30 })"));
+            previousPrimary.eval("db.adminCommand({ replSetStepDown: 30, force: true })");
+
+            awaitReadPreferencePause();
+            assertConnectorIsRunning();
+
+            var replacementPrimary = secondaryMembers.get(0);
+            replacementPrimary.eval("db.adminCommand({ replSetFreeze: 0 })");
+            replacementPrimary.eval("db.adminCommand({ replSetStepUp: 1 })");
+            awaitPrimary(replicaSet, replacementPrimary);
+            awaitReadPreferenceResume();
+
+            assertConnectorIsRunning();
+            assertReadPreferenceTestDocument(2);
+        }
+        finally {
+            var currentPrimary = replicaSet.tryPrimary().orElse(null);
+            replicaSet.getMembers().stream()
+                    .filter(member -> member != currentPrimary)
+                    .forEach(member -> member.eval("db.adminCommand({ replSetFreeze: 0 })"));
+        }
+    }
+
+    @Test
+    void shouldReopenSecondaryChangeStreamAfterElection() throws InterruptedException {
+        var replicaSet = requireThreeMemberReplicaSet();
+        var previousPrimary = replicaSet.tryPrimary().orElseThrow();
+        var secondaryMembers = replicaSet.getMembers().stream()
+                .filter(member -> member != previousPrimary)
+                .toList();
+
+        startReadPreferenceTestConnector("secondary");
+        assertReadPreferenceTestDocument(1);
+
+        for (var secondary : secondaryMembers) {
+            secondary.eval("db.adminCommand({ replSetStepUp: 1 })");
+            awaitPrimary(replicaSet, secondary);
+            if (awaitReadPreferenceReopen(5)) {
+                break;
+            }
+        }
+        awaitReadPreferenceReopen();
+
+        assertReadPreferenceTestDocument(2);
     }
 
     @Test
@@ -3212,6 +3289,88 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         MongoDbConnector connector = new MongoDbConnector();
         Config result = connector.validate(config.asMap());
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.CONNECTION_STRING);
+    }
+
+    private MongoDbReplicaSet requireThreeMemberReplicaSet() {
+        assumeTrue(mongo instanceof MongoDbReplicaSet, "Read preference election tests require a Docker replica set");
+        var replicaSet = (MongoDbReplicaSet) mongo;
+        assumeTrue(replicaSet.getMembers().size() >= 3, "Read preference election tests require at least three members");
+        return replicaSet;
+    }
+
+    private void startReadPreferenceTestConnector(String readPreference) throws InterruptedException {
+        var connectionString = ConnectionStrings.appendParameter(mongo.getConnectionString(), "readPreference", readPreference);
+        config = TestHelper.getConfiguration(connectionString).edit()
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NO_DATA)
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.read_preference")
+                .with(MongoDbConnectorConfig.HEARTBEAT_FREQUENCY_MS, 500)
+                .with(MongoDbConnectorConfig.CURSOR_MAX_AWAIT_TIME_MS, 500)
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
+                .build();
+
+        context = new MongoDbTaskContext(config);
+        logInterceptor = new LogInterceptor(MongoDbStreamingChangeEventSource.class);
+        start(MongoDbConnector.class, config);
+        waitForStreamingRunning("mongodb", "mongo");
+    }
+
+    private void assertReadPreferenceTestDocument(int id) throws InterruptedException {
+        insertDocuments("dbit", "read_preference", new Document("_id", id));
+        var records = consumeRecordsByTopic(1).allRecordsInOrder();
+
+        assertThat(records).hasSize(1);
+        var value = (Struct) records.get(0).value();
+        assertThat(Document.parse(value.getString(Envelope.FieldName.AFTER)).getInteger("_id")).isEqualTo(id);
+    }
+
+    private void awaitPrimaryChange(MongoDbReplicaSet replicaSet, MongoDbContainer previousPrimary) {
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .ignoreExceptions()
+                .until(() -> replicaSet.tryPrimary()
+                        .filter(primary -> primary != previousPrimary)
+                        .isPresent());
+    }
+
+    private void awaitPrimary(MongoDbReplicaSet replicaSet, MongoDbContainer expectedPrimary) {
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .ignoreExceptions()
+                .until(() -> replicaSet.tryPrimary()
+                        .filter(primary -> primary == expectedPrimary)
+                        .isPresent());
+    }
+
+    private void awaitReadPreferenceReopen() {
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .until(() -> logInterceptor.containsMessage("no longer matches read preference"));
+    }
+
+    private void awaitReadPreferencePause() {
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .until(() -> logInterceptor.containsMessage("no eligible server is available"));
+    }
+
+    private void awaitReadPreferenceResume() {
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .until(() -> logInterceptor.containsMessage("An eligible server for read preference"));
+    }
+
+    private boolean awaitReadPreferenceReopen(long timeoutSeconds) throws InterruptedException {
+        var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (System.nanoTime() < deadline) {
+            if (logInterceptor.containsMessage("no longer matches read preference")) {
+                return true;
+            }
+            Thread.sleep(100);
+        }
+        return logInterceptor.containsMessage("no longer matches read preference");
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbReadPreferenceMonitorTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbReadPreferenceMonitorTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static io.debezium.connector.mongodb.MongoDbReadPreferenceMonitor.Status.NO_ELIGIBLE_SERVER;
+import static io.debezium.connector.mongodb.MongoDbReadPreferenceMonitor.Status.RELOCATE;
+import static io.debezium.connector.mongodb.MongoDbReadPreferenceMonitor.Status.SATISFIED;
+import static io.debezium.connector.mongodb.MongoDbReadPreferenceMonitor.Status.UNVERIFIED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ClusterConnectionMode;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterType;
+import com.mongodb.connection.ServerConnectionState;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.ServerType;
+
+import io.debezium.util.Clock;
+
+class MongoDbReadPreferenceMonitorTest {
+
+    private static final ServerAddress SERVER_A = new ServerAddress("server-a", 27017);
+    private static final ServerAddress SERVER_B = new ServerAddress("server-b", 27017);
+
+    @Test
+    void shouldDetectPrimaryCursorDemotion() {
+        var monitor = monitor(ReadPreference.primary());
+        var cluster = replicaSet(
+                server(SERVER_A, ServerType.REPLICA_SET_SECONDARY),
+                server(SERVER_B, ServerType.REPLICA_SET_PRIMARY));
+
+        assertThat(monitor.evaluate(cluster, SERVER_A)).isEqualTo(RELOCATE);
+        assertThat(monitor.evaluate(cluster, SERVER_B)).isEqualTo(SATISFIED);
+    }
+
+    @Test
+    void shouldDetectSecondaryCursorPromotion() {
+        var monitor = monitor(ReadPreference.secondary());
+        var cluster = replicaSet(
+                server(SERVER_A, ServerType.REPLICA_SET_PRIMARY),
+                server(SERVER_B, ServerType.REPLICA_SET_SECONDARY));
+
+        assertThat(monitor.evaluate(cluster, SERVER_A)).isEqualTo(RELOCATE);
+        assertThat(monitor.evaluate(cluster, SERVER_B)).isEqualTo(SATISFIED);
+    }
+
+    @Test
+    void shouldHonorPreferredModeFallbacks() {
+        var primaryPreferred = monitor(ReadPreference.primaryPreferred());
+        var secondaryPreferred = monitor(ReadPreference.secondaryPreferred());
+        var cluster = replicaSet(
+                server(SERVER_A, ServerType.REPLICA_SET_PRIMARY),
+                server(SERVER_B, ServerType.REPLICA_SET_SECONDARY));
+
+        assertThat(primaryPreferred.evaluate(cluster, SERVER_B)).isEqualTo(RELOCATE);
+        assertThat(secondaryPreferred.evaluate(cluster, SERVER_A)).isEqualTo(RELOCATE);
+
+        assertThat(primaryPreferred.evaluate(
+                replicaSet(server(SERVER_B, ServerType.REPLICA_SET_SECONDARY)), SERVER_B)).isEqualTo(SATISFIED);
+        assertThat(secondaryPreferred.evaluate(
+                replicaSet(server(SERVER_A, ServerType.REPLICA_SET_PRIMARY)), SERVER_A)).isEqualTo(SATISFIED);
+    }
+
+    @Test
+    void shouldKeepNearestCursorAfterRoleChange() {
+        var monitor = monitor(ReadPreference.nearest());
+        var cluster = replicaSet(
+                server(SERVER_A, ServerType.REPLICA_SET_PRIMARY),
+                server(SERVER_B, ServerType.REPLICA_SET_SECONDARY));
+
+        assertThat(monitor.evaluate(cluster, SERVER_A)).isEqualTo(SATISFIED);
+        assertThat(monitor.evaluate(cluster, SERVER_B)).isEqualTo(SATISFIED);
+    }
+
+    @Test
+    void shouldReportWhenExactPreferenceHasNoEligibleServer() {
+        var primary = monitor(ReadPreference.primary());
+        var secondary = monitor(ReadPreference.secondary());
+        var onlyPrimary = replicaSet(server(SERVER_A, ServerType.REPLICA_SET_PRIMARY));
+        var onlySecondary = replicaSet(server(SERVER_B, ServerType.REPLICA_SET_SECONDARY));
+
+        assertThat(primary.evaluate(onlySecondary, SERVER_B)).isEqualTo(NO_ELIGIBLE_SERVER);
+        assertThat(secondary.evaluate(onlyPrimary, SERVER_A)).isEqualTo(NO_ELIGIBLE_SERVER);
+        assertThat(primary.shouldWaitForEligibleServer(onlySecondary)).isTrue();
+        assertThat(secondary.shouldWaitForEligibleServer(onlyPrimary)).isTrue();
+        assertThat(primary.shouldWaitForEligibleServer(onlyPrimary)).isFalse();
+        assertThat(secondary.shouldWaitForEligibleServer(onlySecondary)).isFalse();
+
+        var unknown = new ClusterDescription(
+                ClusterConnectionMode.MULTIPLE,
+                ClusterType.UNKNOWN,
+                List.of());
+        assertThat(primary.shouldWaitForEligibleServer(unknown)).isTrue();
+    }
+
+    @Test
+    void shouldReportWhenCursorServerCannotBeVerified() {
+        var monitor = monitor(ReadPreference.primary());
+        var cluster = replicaSet(server(SERVER_A, ServerType.REPLICA_SET_PRIMARY));
+
+        assertThat(monitor.evaluate(cluster, SERVER_B)).isEqualTo(UNVERIFIED);
+    }
+
+    @Test
+    void shouldIgnoreUnsupportedTopologies() {
+        var monitor = monitor(ReadPreference.primary());
+        var primary = server(SERVER_A, ServerType.REPLICA_SET_PRIMARY);
+        var sharded = new ClusterDescription(
+                ClusterConnectionMode.MULTIPLE,
+                ClusterType.SHARDED,
+                List.of(server(SERVER_A, ServerType.SHARD_ROUTER)));
+        var direct = new ClusterDescription(
+                ClusterConnectionMode.SINGLE,
+                ClusterType.REPLICA_SET,
+                List.of(primary));
+
+        assertThat(monitor.evaluate(sharded, SERVER_A)).isEqualTo(SATISFIED);
+        assertThat(monitor.evaluate(direct, SERVER_A)).isEqualTo(SATISFIED);
+        assertThat(monitor.shouldWaitForEligibleServer(sharded)).isFalse();
+        assertThat(monitor.shouldWaitForEligibleServer(direct)).isFalse();
+    }
+
+    @Test
+    void shouldCheckAtHeartbeatInterval() {
+        var time = new AtomicLong(100);
+        var monitor = new MongoDbReadPreferenceMonitor(ReadPreference.primary(), 10, time::get);
+        var cluster = replicaSet(
+                server(SERVER_A, ServerType.REPLICA_SET_SECONDARY),
+                server(SERVER_B, ServerType.REPLICA_SET_PRIMARY));
+
+        assertThat(monitor.isCheckDue()).isFalse();
+        time.set(109);
+        assertThat(monitor.isCheckDue()).isFalse();
+        time.set(110);
+        assertThat(monitor.isCheckDue()).isTrue();
+        assertThat(monitor.evaluate(cluster, SERVER_A)).isEqualTo(RELOCATE);
+        assertThat(monitor.isCheckDue()).isFalse();
+    }
+
+    @Test
+    void shouldUseMonotonicTimeForCheckInterval() {
+        var wallTime = new AtomicLong(100);
+        var monotonicTime = new AtomicLong(100);
+        var clock = new Clock() {
+            @Override
+            public long currentTimeInMillis() {
+                return wallTime.get();
+            }
+
+            @Override
+            public long currentTimeInNanos() {
+                return TimeUnit.MILLISECONDS.toNanos(monotonicTime.get());
+            }
+        };
+        var monitor = new MongoDbReadPreferenceMonitor(ReadPreference.primary(), 10, clock);
+        var cluster = replicaSet(
+                server(SERVER_A, ServerType.REPLICA_SET_SECONDARY),
+                server(SERVER_B, ServerType.REPLICA_SET_PRIMARY));
+
+        wallTime.set(50);
+        monotonicTime.set(109);
+        assertThat(monitor.isCheckDue()).isFalse();
+        monotonicTime.set(110);
+        assertThat(monitor.isCheckDue()).isTrue();
+        assertThat(monitor.evaluate(cluster, SERVER_A)).isEqualTo(RELOCATE);
+    }
+
+    private static MongoDbReadPreferenceMonitor monitor(ReadPreference readPreference) {
+        return new MongoDbReadPreferenceMonitor(readPreference, 1, () -> 0);
+    }
+
+    private static ClusterDescription replicaSet(ServerDescription... servers) {
+        return new ClusterDescription(
+                ClusterConnectionMode.MULTIPLE,
+                ClusterType.REPLICA_SET,
+                List.of(servers));
+    }
+
+    private static ServerDescription server(ServerAddress address, ServerType type) {
+        return ServerDescription.builder()
+                .address(address)
+                .type(type)
+                .state(ServerConnectionState.CONNECTED)
+                .ok(true)
+                .setName("rs0")
+                .roundTripTime(1, TimeUnit.MILLISECONDS)
+                .lastWriteDate(new Date())
+                .build();
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -109,11 +109,21 @@ You specify the replica member that the connector reads from by configuring the 
 If you do not specify a read preference, the driver default of `primary` applies, and the connector streams changes from the primary node.
 
 To reduce the load on the primary, it's possible to configure the connector to read from a secondary node, by setting `readPreference=secondaryPreferred`.
-Under normal operating conditions, configuring the connector to read from a secondary node does not significantly increase data-capture latency. 
+Under normal operating conditions, configuring the connector to read from a secondary node does not significantly increase data-capture latency.
 However, events captured from a secondary can arrive later than they would from the primary due to resource contention or network latency.
-Additional latency can also occur because change streams emit events only after changes are majority committed. 
-A change is majority committed when a majority of voting replica set members confirm that they have written the change to their journals. 
+Additional latency can also occur because change streams emit events only after changes are majority committed.
+A change is majority committed when a majority of voting replica set members confirm that they have written the change to their journals.
 As a result, a secondary node can emit an event only after it receives confirmation that the change has been majority committed.
+
+When the connection string identifies a replica set and does not set `directConnection=true`, the connector periodically verifies that the member serving the change stream still satisfies the configured read preference.
+The verification interval is controlled by xref:mongodb-property-mongodb-heartbeat-frequency-ms[`mongodb.heartbeat.frequency.ms`], so the connector does not detect role changes instantaneously.
+After a replica set election, the MongoDB driver's topology view must be updated and the next verification must run before the connector detects that the member's role changed.
+During this interval, the connector might continue to receive change stream events from that member.
+If a replica set election causes that member to stop satisfying the read preference, the connector closes the change stream and resumes it on an eligible member from the last processed offset.
+For the exact `primary` and `secondary` modes, if no eligible member is available, change stream consumption waits while the connector task remains running.
+Consumption resumes from the last processed offset when an eligible member becomes available.
+The `primaryPreferred` and `secondaryPreferred` modes continue to use the fallback behavior defined by the MongoDB driver.
+When the connector connects to a sharded cluster, `mongos` is responsible for applying the read preference to the members of each shard.
 
 // Type: assembly
 // ModuleID: how-debezium-mongodb-connectors-work


### PR DESCRIPTION
Fixes debezium/dbz#917

## Description

MongoDB change stream cursors remain bound to the server on which they were opened. After a replica set election, that server can change its role while the cursor remains open. As a result, the connector can continue consuming from a member that no longer satisfies the configured read preference.

This change periodically verifies the server hosting the change stream cursor against the configured MongoDB `readPreference`.

When the current server no longer satisfies the read preference:

* If an eligible server is available, the connector closes the existing cursor and reopens the change stream on an eligible member.
* If no eligible server is available for the exact `primary` or `secondary` modes, change stream consumption waits while the connector task remains running.
* Consumption resumes automatically when the MongoDB driver discovers an eligible member.
* The change stream resumes from the last processed offset. Events prefetched by the buffering cursor do not advance this offset.
* Cursor relocation is deferred while a split event is being assembled.

The implementation delegates candidate selection to the MongoDB driver. This preserves read preference tags, max staleness settings, and the fallback behavior of `primaryPreferred` and `secondaryPreferred`.

No new connector configuration is introduced. The default read preference remains `primary`.

Role verification applies to discoverable replica set connections. It is not applied to `directConnection=true` connections or sharded cluster connections. For sharded clusters, `mongos` remains responsible for applying the read preference.

The verification interval uses `mongodb.heartbeat.frequency.ms`. Interval measurement uses monotonic time so that wall clock adjustments do not affect the check cadence. Cursor address and cluster topology are queried only when a verification is due.

Role changes are not detected instantaneously. After an election, the MongoDB driver's topology view must be updated and the next periodic verification must run. The connector might continue receiving change stream events from the previous member during this interval.

Documentation has been updated to describe the behavior and this limitation.

## Testing

Added unit coverage for primary demotion, secondary promotion, exact and preferred read preference modes, topology restoration, unsupported topologies, verification cadence, and monotonic time behavior.

Added integration coverage using a three-member replica set for reopening primary and secondary change streams after elections, keeping the connector task running when no eligible server is available, and resuming consumption after an eligible server becomes available.

Verification completed successfully:

* MongoDB connector unit tests: 192 passed, 1 skipped
* Read preference monitor unit tests: 9 passed
* Read preference election integration tests: 3 passed
* Formatter and Checkstyle validation passed

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to the change
- [x] One feature/change per PR unless tightly coupled
- [x] Rebased on upstream `main`
