### PR TITLE
debezium/dbz#2555 Stop depending on relocated Kafka util Sanitizer class

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/metrics/Metrics.java
+++ b/debezium-connector-common/src/main/java/io/debezium/metrics/Metrics.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.apache.kafka.common.utils.Sanitizer;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import io.debezium.annotation.ThreadSafe;
@@ -19,6 +18,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.pipeline.JmxUtils;
 import io.debezium.util.Collect;
+import io.debezium.util.Sanitizer;
 
 /**
  * Base for metrics implementations.

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/JmxUtils.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/JmxUtils.java
@@ -16,13 +16,13 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.apache.kafka.common.utils.Sanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.util.Clock;
 import io.debezium.util.Metronome;
+import io.debezium.util.Sanitizer;
 
 public class JmxUtils {
 

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/metrics/JdbcSinkConnectorMetrics.java
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.apache.kafka.common.utils.Sanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +17,7 @@ import io.debezium.DebeziumException;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.pipeline.JmxUtils;
 import io.debezium.sink.spi.SinkProgressListener;
+import io.debezium.util.Sanitizer;
 
 /**
  * JMX metrics for the JDBC sink connector. Counters are updated on the record-processing path and

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -26,7 +26,6 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.apache.kafka.common.utils.Sanitizer;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
@@ -49,6 +48,7 @@ import io.debezium.relational.TableId;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.util.Collect;
 import io.debezium.util.IoUtil;
+import io.debezium.util.Sanitizer;
 import io.debezium.util.Strings;
 import io.debezium.util.Testing;
 

--- a/debezium-util/src/main/java/io/debezium/util/Sanitizer.java
+++ b/debezium-util/src/main/java/io/debezium/util/Sanitizer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.regex.Pattern;
+
+import javax.management.ObjectName;
+
+/**
+ * Utility for sanitizing values used to build JMX {@link ObjectName}s.
+ * <p>
+ * This is an internal replacement for {@code org.apache.kafka.common.utils.Sanitizer#jmxSanitize(String)}.
+ * That class was relocated to {@code org.apache.kafka.common.utils.internals} by upstream KAFKA-20297,
+ * which is not a stable API for connector code to depend on across Kafka versions.
+ */
+public class Sanitizer {
+
+    private static final Pattern MBEAN_PATTERN = Pattern.compile("[\\w-%\\. \t]*");
+
+    private Sanitizer() {
+    }
+
+    /**
+     * Quote the value if it contains characters that are not safe to use unquoted in a JMX
+     * {@link ObjectName}, otherwise return it unchanged.
+     */
+    public static String jmxSanitize(String value) {
+        return MBEAN_PATTERN.matcher(value).matches() ? value : ObjectName.quote(value);
+    }
+}

--- a/debezium-util/src/test/java/io/debezium/util/SanitizerTest.java
+++ b/debezium-util/src/test/java/io/debezium/util/SanitizerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.management.ObjectName;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+public class SanitizerTest {
+
+    @Test
+    @FixFor("debezium/dbz#2555")
+    public void shouldLeaveJmxSafeValuesUnquoted() {
+        assertThat(Sanitizer.jmxSanitize("my-connector.0")).isEqualTo("my-connector.0");
+        assertThat(Sanitizer.jmxSanitize("a b_c-1.2%")).isEqualTo("a b_c-1.2%");
+        assertThat(Sanitizer.jmxSanitize("")).isEmpty();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2555")
+    public void shouldQuoteValuesWithJmxUnsafeCharacters() {
+        assertThat(Sanitizer.jmxSanitize("has:colon")).isEqualTo(ObjectName.quote("has:colon"));
+        assertThat(Sanitizer.jmxSanitize("a*b,c=d")).isEqualTo(ObjectName.quote("a*b,c=d"));
+    }
+}


### PR DESCRIPTION

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2555

## Description
Apache Kafka's KAFKA-20297 relocates org.apache.kafka.common.utils.Sanitizer (and AppInfoParser, SecurityUtils, ConfigUtils, LogContext, Crc32C, Checksums) to org.apache.kafka.common.utils.internals starting with 4.4.0-rc-0. That package was never public API, so this is not something Kafka is expected to preserve for us; the fix belongs on the Debezium side.

Sanitizer.jmxSanitize() was the only one of these classes actually used in this codebase, to build JMX ObjectName tag values in JmxUtils, Metrics, JdbcSinkConnectorMetrics, and the SQL Server TestHelper. Added io.debezium.util.Sanitizer (in debezium-util) reproducing the same logic (identical MBEAN_PATTERN regex and ObjectName.quote() fallback) and repointed all four call sites at it, removing the dependency on Kafka's internal utility package so the connectors build against Kafka 4.4.x.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
