### PR TITLE
debezium/dbz#2560 Fix JavaScript with scope conversion

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -322,18 +322,13 @@ public class MongoDataConverter {
                 break;
 
             case JAVASCRIPT_WITH_SCOPE:
-                SchemaBuilder jsWithScope = SchemaBuilder.struct().name(builder.name() + "." + key);
+                final SchemaBuilder jsWithScope = SchemaBuilder.struct().name(builder.name() + "." + key);
                 jsWithScope.field("code", Schema.OPTIONAL_STRING_SCHEMA);
-                SchemaBuilder scope = SchemaBuilder.struct().name(jsWithScope.name() + "." + key + ".scope").optional();
+                final SchemaBuilder scope = SchemaBuilder.struct().name(jsWithScope.name() + ".scope").optional();
+                final BsonDocument scopeDocument = ((BsonValue) obj).asJavaScriptWithScope().getScope();
+                buildSchema(parseBsonDocument(scopeDocument), scope);
 
-                for (Entry<?, ?> jwsDoc : ((Map<?, ?>) obj).entrySet()) {
-                    String fieldName = fieldNamer.fieldNameFor(jwsDoc.getKey().toString());
-                    Object value = jwsDoc.getValue();
-                    schema(fieldName, (Entry<Object, BsonType>) value, scope);
-                }
-
-                Schema scopeBuild = scope.build();
-                jsWithScope.field("scope", scopeBuild).build();
+                jsWithScope.field("scope", scope.build());
                 builder.field(key, jsWithScope);
                 break;
 
@@ -677,14 +672,15 @@ public class MongoDataConverter {
 
         switch (type) {
             case JAVASCRIPT_WITH_SCOPE:
-                Struct jsStruct = new Struct(schema.field(key).schema());
-                Struct jsScopeStruct = new Struct(
-                        schema.field(key).schema().field("scope").schema());
+                final Schema jsSchema = schema.field(key).schema();
+                final Struct jsStruct = new Struct(jsSchema);
+                final Schema scopeSchema = jsSchema.field("scope").schema();
+                final Struct jsScopeStruct = new Struct(scopeSchema);
                 jsStruct.put("code", value.asJavaScriptWithScope().getCode());
-                BsonDocument jwsDoc = value.asJavaScriptWithScope().getScope().asDocument();
+                final BsonDocument scopeDocument = value.asJavaScriptWithScope().getScope();
 
-                for (Entry<String, BsonValue> entry : jwsDoc.entrySet()) {
-                    buildStruct(entry, schema.field(key).schema().field(key).schema(), jsScopeStruct);
+                for (final Entry<String, BsonValue> entry : scopeDocument.entrySet()) {
+                    buildStruct(entry, scopeSchema, jsScopeStruct);
                 }
 
                 jsStruct.put("scope", jsScopeStruct);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -123,6 +123,51 @@ public class MongoDataConverterTest {
                 .build());
     }
 
+    @Test
+    @FixFor("debezium/dbz#2560")
+    void shouldProcessJavaScriptWithScope() {
+        val = BsonDocument.parse("""
+                {
+                    "function": {
+                        "$code": "function() { return x; }",
+                        "$scope": {
+                            "x": { "$numberInt": "1" },
+                            "nested": { "value": "test" }
+                        }
+                    }
+                }
+                """);
+        builder = SchemaBuilder.struct().name("javascript");
+
+        final Map<String, Map<Object, BsonType>> schemaMap = converter.parseBsonDocument(val);
+        converter.buildSchema(schemaMap, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (final Map.Entry<String, BsonValue> entry : val.entrySet()) {
+            converter.buildStruct(entry, finalSchema, struct);
+        }
+
+        final Schema functionSchema = finalSchema.field("function").schema();
+        assertThat(functionSchema.name()).isEqualTo("javascript.function");
+        assertThat(functionSchema.fields()).extracting("name").containsExactly("code", "scope");
+        assertThat(functionSchema.field("code").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+
+        final Schema scopeSchema = functionSchema.field("scope").schema();
+        assertThat(scopeSchema.name()).isEqualTo("javascript.function.scope");
+        assertThat(scopeSchema.fields()).extracting("name").containsExactly("x", "nested");
+        assertThat(scopeSchema.field("x").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+
+        final Schema nestedSchema = scopeSchema.field("nested").schema();
+        assertThat(nestedSchema.name()).isEqualTo("javascript.function.scope.nested");
+        assertThat(nestedSchema.field("value").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+
+        final Struct function = struct.getStruct("function");
+        assertThat(function.getString("code")).isEqualTo("function() { return x; }");
+        assertThat(function.getStruct("scope").getInt32("x")).isEqualTo(1);
+        assertThat(function.getStruct("scope").getStruct("nested").getString("value")).isEqualTo("test");
+    }
+
     private String getFile(final String fileName) throws IOException, URISyntaxException {
         final URL jsonResource = getClass().getClassLoader().getResource(fileName);
         return new String(


### PR DESCRIPTION
Fixes debezium/dbz#2560

## Description

The MongoDB `ExtractNewDocumentState` SMT fails with a `ClassCastException` when it processes a `BsonJavaScriptWithScope` value.

This change:

* reads the scope document from `BsonJavaScriptWithScope` and reuses the existing recursive schema conversion
* builds scope values using the corresponding scope schema
* restores the intended scope schema name
* adds regression coverage for primitive and nested scope fields

## Testing

```shell
./mvnw -pl debezium-connector-mongodb -am -Dtest=MongoDataConverterTest,ExtractNewDocumentStateTest,ToAvroMongoDataConverterTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl debezium-connector-mongodb -am install -DskipITs
```

## PR Checklist

- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature/change per PR
- [x] Rebased on upstream `main`