### PR TITLE
debezium/dbz#2562 Support regular expression arrays

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -41,6 +41,11 @@ import io.debezium.schema.SchemaNameAdjuster;
  */
 public class MongoDataConverter {
     public static final String SCHEMA_NAME_REGEX = "io.debezium.mongodb.regex";
+    private static final Schema REGULAR_EXPRESSION_SCHEMA = SchemaBuilder.struct().name(SCHEMA_NAME_REGEX).optional()
+            .field("regex", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("options", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
     private final ArrayEncoding arrayEncoding;
     private final FieldNamer<String> fieldNamer;
 
@@ -338,10 +343,7 @@ public class MongoDataConverter {
                 break;
 
             case REGULAR_EXPRESSION:
-                SchemaBuilder regexwop = SchemaBuilder.struct().name(SCHEMA_NAME_REGEX).optional();
-                regexwop.field("regex", Schema.OPTIONAL_STRING_SCHEMA);
-                regexwop.field("options", Schema.OPTIONAL_STRING_SCHEMA);
-                builder.field(key, regexwop.build());
+                builder.field(key, REGULAR_EXPRESSION_SCHEMA);
                 break;
 
             case DOCUMENT:
@@ -646,6 +648,9 @@ public class MongoDataConverter {
             case BOOLEAN:
                 return Schema.OPTIONAL_BOOLEAN_SCHEMA;
 
+            case REGULAR_EXPRESSION:
+                return REGULAR_EXPRESSION_SCHEMA;
+
             case ARRAY:
                 switch (arrayEncoding) {
                     case ARRAY:
@@ -692,10 +697,7 @@ public class MongoDataConverter {
                 break;
 
             case REGULAR_EXPRESSION:
-                Struct regexStruct = new Struct(schema.field(key).schema());
-                regexStruct.put("regex", value.asRegularExpression().getPattern());
-                regexStruct.put("options", value.asRegularExpression().getOptions());
-                colValue = regexStruct;
+                colValue = buildRegularExpression(value, schema.field(key).schema());
                 break;
 
             case ARRAY:
@@ -773,6 +775,13 @@ public class MongoDataConverter {
      */
     protected String arrayElementStructName(int i) {
         return "_" + i;
+    }
+
+    private Struct buildRegularExpression(BsonValue value, Schema schema) {
+        final var regexStruct = new Struct(schema);
+        regexStruct.put("regex", value.asRegularExpression().getPattern());
+        regexStruct.put("options", value.asRegularExpression().getOptions());
+        return regexStruct;
     }
 
     /**
@@ -880,6 +889,10 @@ public class MongoDataConverter {
                         buildStruct(entry, schema, struct);
                     }
                     values.add(struct);
+                    break;
+
+                case REGULAR_EXPRESSION:
+                    values.add(buildRegularExpression(value, schema));
                     break;
 
                 default:

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoArrayConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoArrayConverterTest.java
@@ -137,11 +137,77 @@ public class MongoArrayConverterTest {
               ]
             }""");
 
+    private static final String REGULAR_EXPRESSION_ARRAY = lines("""
+            {
+              "patterns": [
+                { "$regularExpression": { "pattern": "^foo", "options": "i" } },
+                { "$regularExpression": { "pattern": "bar$", "options": "m" } }
+              ]
+            }""");
+
     private SchemaBuilder builder;
 
     @BeforeEach
     void setup() throws Exception {
         builder = SchemaBuilder.struct().name("array");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2562")
+    void shouldCreateArrayOfRegularExpressions() {
+        final var converter = new MongoDataConverter(ArrayEncoding.ARRAY);
+        final var value = BsonDocument.parse(REGULAR_EXPRESSION_ARRAY);
+
+        final Map<String, Map<Object, BsonType>> schemaMap = converter.parseBsonDocument(value);
+        converter.buildSchema(schemaMap, builder);
+
+        final var schema = builder.build();
+        final var struct = new Struct(schema);
+        for (final Map.Entry<String, BsonValue> entry : value.entrySet()) {
+            converter.buildStruct(entry, schema, struct);
+        }
+
+        final var arraySchema = schema.field("patterns").schema();
+        assertThat(arraySchema.type()).isEqualTo(Schema.Type.ARRAY);
+        assertThat(arraySchema.valueSchema().name()).isEqualTo(MongoDataConverter.SCHEMA_NAME_REGEX);
+        assertThat(arraySchema.valueSchema().fields()).extracting("name").containsExactly("regex", "options");
+
+        final var patterns = struct.getArray("patterns");
+        assertThat(patterns).hasSize(2);
+        assertThat(patterns).allMatch(Struct.class::isInstance);
+
+        final var firstPattern = (Struct) patterns.get(0);
+        assertThat(firstPattern.getString("regex")).isEqualTo("^foo");
+        assertThat(firstPattern.getString("options")).isEqualTo("i");
+
+        final var secondPattern = (Struct) patterns.get(1);
+        assertThat(secondPattern.getString("regex")).isEqualTo("bar$");
+        assertThat(secondPattern.getString("options")).isEqualTo("m");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2562")
+    void shouldCreateDocumentEncodedArrayOfRegularExpressions() {
+        final var converter = new MongoDataConverter(ArrayEncoding.DOCUMENT);
+        final var value = BsonDocument.parse(REGULAR_EXPRESSION_ARRAY);
+
+        final Map<String, Map<Object, BsonType>> schemaMap = converter.parseBsonDocument(value);
+        converter.buildSchema(schemaMap, builder);
+
+        final var schema = builder.build();
+        final var struct = new Struct(schema);
+        for (final Map.Entry<String, BsonValue> entry : value.entrySet()) {
+            converter.buildStruct(entry, schema, struct);
+        }
+
+        final var patterns = struct.getStruct("patterns");
+        final var firstPattern = patterns.getStruct("_0");
+        assertThat(firstPattern.getString("regex")).isEqualTo("^foo");
+        assertThat(firstPattern.getString("options")).isEqualTo("i");
+
+        final var secondPattern = patterns.getStruct("_1");
+        assertThat(secondPattern.getString("regex")).isEqualTo("bar$");
+        assertThat(secondPattern.getString("options")).isEqualTo("m");
     }
 
     @Test


### PR DESCRIPTION
Fixes debezium/dbz#2562

## Description

BSON regular expressions are supported as scalar values by the MongoDB
`ExtractNewDocumentState` SMT, but arrays containing regular expressions fail
when the converter resolves the array element schema.

This change reuses the existing regular expression schema for array elements
and converts each element into the same `regex` and `options` structure used
for scalar values. It supports both `array` and `document` array encodings.

Regression tests cover the generated schemas and values for both encodings.

## Testing

```text
./mvnw -pl debezium-connector-mongodb -am \
  -Dtest=MongoArrayConverterTest \
  -Dsurefire.failIfNoSpecifiedTests=false test

./mvnw -pl debezium-connector-mongodb -am install -DskipITs
```

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to the change
- [x] One feature or change per PR
- [x] Rebased on the latest upstream `main`
