### PR TITLE
Fix UnsupportedOperationException on java.sql.Date and java.sql.Time in Neo4jCudConverter debezium/dbz#2566

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -880,3 +880,4 @@ Raju Surarapu
 dingqianwen
 Surya Dhaneshwar
 exgoya
+bhuvan-somisetty

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
@@ -6,6 +6,7 @@
 package io.debezium.transforms.neo4j;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -198,12 +199,41 @@ public class CudEventFactory {
             case Timestamp.SCHEMA_NAME -> IsoTimestamp.toIsoString(((Number) value).longValue(), null);
             case MicroTimestamp.SCHEMA_NAME -> IsoTimestamp.toIsoString(Conversions.toInstantFromMicros(((Number) value).longValue()), null);
             case NanoTimestamp.SCHEMA_NAME -> IsoTimestamp.toIsoString(Conversions.toInstantFromNanos(((Number) value).longValue()), null);
-            case org.apache.kafka.connect.data.Date.LOGICAL_NAME -> ((java.util.Date) value).toInstant().atOffset(ZoneOffset.UTC).toLocalDate().toString();
-            case org.apache.kafka.connect.data.Time.LOGICAL_NAME ->
-                IsoTime.toIsoString(((java.util.Date) value).toInstant().atOffset(ZoneOffset.UTC).toLocalTime(), false);
-            case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME -> IsoTimestamp.toIsoString(((java.util.Date) value).toInstant(), null);
+            case org.apache.kafka.connect.data.Date.LOGICAL_NAME -> normalizeConnectDate(value);
+            case org.apache.kafka.connect.data.Time.LOGICAL_NAME -> normalizeConnectTime(value);
+            case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME -> normalizeConnectTimestamp(value);
             default -> value;
         };
+    }
+
+    private static Object normalizeConnectDate(Object value) {
+        if (value instanceof java.util.Date d) {
+            return Instant.ofEpochMilli(d.getTime()).atOffset(ZoneOffset.UTC).toLocalDate().toString();
+        }
+        else if (value instanceof Number n) {
+            return LocalDate.ofEpochDay(n.longValue()).toString();
+        }
+        return value;
+    }
+
+    private static Object normalizeConnectTime(Object value) {
+        if (value instanceof java.util.Date d) {
+            return IsoTime.toIsoString(Instant.ofEpochMilli(d.getTime()).atOffset(ZoneOffset.UTC).toLocalTime(), false);
+        }
+        else if (value instanceof Number n) {
+            return IsoTime.toIsoString(Duration.ofMillis(n.longValue()), false);
+        }
+        return value;
+    }
+
+    private static Object normalizeConnectTimestamp(Object value) {
+        if (value instanceof java.util.Date d) {
+            return IsoTimestamp.toIsoString(Instant.ofEpochMilli(d.getTime()), null);
+        }
+        else if (value instanceof Number n) {
+            return IsoTimestamp.toIsoString(n.longValue(), null);
+        }
+        return value;
     }
 
     private Map<String, Object> extractProperties(Struct data, Set<String> excluded, TableMappingConfig mapping) {

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
@@ -206,9 +206,8 @@ public class CudEventFactory {
         };
     }
 
-    // Connect logical Date/Time/Timestamp values normally arrive as java.util.Date, but java.sql.Date and
-    // java.sql.Time (from JDBC-based converters) are also java.util.Date subclasses that override toInstant()
-    // to throw UnsupportedOperationException; going through getTime() instead avoids that for all of them.
+    // getTime() is used instead of toInstant() because java.sql.Date and java.sql.Time, which JDBC-based
+    // converters commonly produce here, override toInstant() to throw UnsupportedOperationException.
     private static Object normalizeConnectDate(Object value) {
         if (value instanceof Number n) {
             return LocalDate.ofEpochDay(n.longValue()).toString();

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
@@ -206,6 +206,9 @@ public class CudEventFactory {
         };
     }
 
+    // java.sql.Date and java.sql.Time are subclasses of java.util.Date, so the instanceof checks below
+    // also match them; we deliberately go through getTime() instead of toInstant(), since java.sql.Date
+    // and java.sql.Time override toInstant() to throw UnsupportedOperationException.
     private static Object normalizeConnectDate(Object value) {
         if (value instanceof java.util.Date d) {
             return Instant.ofEpochMilli(d.getTime()).atOffset(ZoneOffset.UTC).toLocalDate().toString();

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
@@ -206,37 +206,28 @@ public class CudEventFactory {
         };
     }
 
-    // java.sql.Date and java.sql.Time are subclasses of java.util.Date, so the instanceof checks below
-    // also match them; we deliberately go through getTime() instead of toInstant(), since java.sql.Date
-    // and java.sql.Time override toInstant() to throw UnsupportedOperationException.
+    // Connect logical Date/Time/Timestamp values normally arrive as java.util.Date, but java.sql.Date and
+    // java.sql.Time (from JDBC-based converters) are also java.util.Date subclasses that override toInstant()
+    // to throw UnsupportedOperationException; going through getTime() instead avoids that for all of them.
     private static Object normalizeConnectDate(Object value) {
-        if (value instanceof java.util.Date d) {
-            return Instant.ofEpochMilli(d.getTime()).atOffset(ZoneOffset.UTC).toLocalDate().toString();
-        }
-        else if (value instanceof Number n) {
+        if (value instanceof Number n) {
             return LocalDate.ofEpochDay(n.longValue()).toString();
         }
-        return value;
+        return Instant.ofEpochMilli(((java.util.Date) value).getTime()).atOffset(ZoneOffset.UTC).toLocalDate().toString();
     }
 
     private static Object normalizeConnectTime(Object value) {
-        if (value instanceof java.util.Date d) {
-            return IsoTime.toIsoString(Instant.ofEpochMilli(d.getTime()).atOffset(ZoneOffset.UTC).toLocalTime(), false);
-        }
-        else if (value instanceof Number n) {
+        if (value instanceof Number n) {
             return IsoTime.toIsoString(Duration.ofMillis(n.longValue()), false);
         }
-        return value;
+        return IsoTime.toIsoString(Instant.ofEpochMilli(((java.util.Date) value).getTime()).atOffset(ZoneOffset.UTC).toLocalTime(), false);
     }
 
     private static Object normalizeConnectTimestamp(Object value) {
-        if (value instanceof java.util.Date d) {
-            return IsoTimestamp.toIsoString(Instant.ofEpochMilli(d.getTime()), null);
-        }
-        else if (value instanceof Number n) {
+        if (value instanceof Number n) {
             return IsoTimestamp.toIsoString(n.longValue(), null);
         }
-        return value;
+        return IsoTimestamp.toIsoString(Instant.ofEpochMilli(((java.util.Date) value).getTime()), null);
     }
 
     private Map<String, Object> extractProperties(Struct data, Set<String> excluded, TableMappingConfig mapping) {

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventFactoryTemporalTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/CudEventFactoryTemporalTest.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.doc.FixFor;
 import io.debezium.time.Date;
 import io.debezium.time.MicroTime;
 import io.debezium.time.MicroTimestamp;
@@ -136,5 +137,56 @@ class CudEventFactoryTemporalTest {
     @DisplayName("Returns the value unchanged when the schema is null")
     void passesThroughWhenSchemaNull() {
         assertThat(CudEventFactory.normalizeTemporal(42, null)).isEqualTo(42);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2566")
+    @DisplayName("Converts a connect-mode Date from java.sql.Date to an ISO date string")
+    void convertsConnectDateFromSqlDate() {
+        final var value = new java.sql.Date(Instant.parse("2024-01-01T00:00:00Z").toEpochMilli());
+        assertThat(CudEventFactory.normalizeTemporal(value, org.apache.kafka.connect.data.Date.SCHEMA))
+                .isEqualTo("2024-01-01");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2566")
+    @DisplayName("Converts a connect-mode Date from numeric epoch days to an ISO date string")
+    void convertsConnectDateFromNumericEpochDays() {
+        assertThat(CudEventFactory.normalizeTemporal(19723, org.apache.kafka.connect.data.Date.SCHEMA))
+                .isEqualTo("2024-01-01");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2566")
+    @DisplayName("Converts a connect-mode Time from java.sql.Time to a UTC ISO time string")
+    void convertsConnectTimeFromSqlTime() {
+        final var value = new java.sql.Time(Instant.parse("1970-01-01T12:30:45.123Z").toEpochMilli());
+        assertThat(CudEventFactory.normalizeTemporal(value, org.apache.kafka.connect.data.Time.SCHEMA))
+                .isEqualTo("12:30:45.123Z");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2566")
+    @DisplayName("Converts a connect-mode Time from numeric millis since midnight to a UTC ISO time string")
+    void convertsConnectTimeFromNumericMillis() {
+        assertThat(CudEventFactory.normalizeTemporal(45045123, org.apache.kafka.connect.data.Time.SCHEMA))
+                .isEqualTo("12:30:45.123Z");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2566")
+    @DisplayName("Converts a connect-mode Timestamp from java.sql.Timestamp to a UTC ISO datetime string")
+    void convertsConnectTimestampFromSqlTimestamp() {
+        final var value = new java.sql.Timestamp(Instant.parse("2024-01-01T12:30:45.123Z").toEpochMilli());
+        assertThat(CudEventFactory.normalizeTemporal(value, org.apache.kafka.connect.data.Timestamp.SCHEMA))
+                .isEqualTo("2024-01-01T12:30:45.123Z");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2566")
+    @DisplayName("Converts a connect-mode Timestamp from numeric epoch millis to a UTC ISO datetime string")
+    void convertsConnectTimestampFromNumericEpochMillis() {
+        assertThat(CudEventFactory.normalizeTemporal(1704112245123L, org.apache.kafka.connect.data.Timestamp.SCHEMA))
+                .isEqualTo("2024-01-01T12:30:45.123Z");
     }
 }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -412,3 +412,4 @@ soepic1,Oladele Oluwaseun
 ragulshanmugam,Ragul Shanmugam
 tusharsaini18899,Tushar Saini
 tingley,Chase Tingley
+bhuvan-somisetty,bhuvan-somisetty


### PR DESCRIPTION
Fixes debezium/dbz#2566

## Description
In `Neo4jCudConverter`, `CudEventFactory.normalizeTemporal(Object, Schema)` previously cast Connect logical date/time types (`org.apache.kafka.connect.data.Date`, `Time`, and `Timestamp`) to `(java.util.Date)` and invoked `.toInstant()`. 

When records contain `java.sql.Date` or `java.sql.Time` instances (commonly produced by JDBC source connectors and database converters), calling `.toInstant()` throws `java.lang.UnsupportedOperationException` because the JDK explicitly disables `.toInstant()` on `java.sql.Date` and `java.sql.Time`. Furthermore, numeric epoch values caused a `ClassCastException`.

This change:
* Converts Connect `Date`, `Time`, and `Timestamp` values via epoch milliseconds (`d.getTime()`) using `Instant.ofEpochMilli(...)` / `Duration.ofMillis(...)`, preventing `UnsupportedOperationException` when values are instances of `java.sql.Date` or `java.sql.Time`.
* Adds support for numerical epoch representations (`Number`) for Connect logical types.
* Adds unit regression tests in `CudEventFactoryTemporalTest` covering `java.sql.Date`, `java.sql.Time`, `java.sql.Timestamp`, `java.util.Date`, and numeric epoch inputs.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
