### PR TITLE
debezium/dbz#586 Scope the streaming CapturedTables metric to each partition's database

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
@@ -6,6 +6,8 @@
 package io.debezium.connector.sqlserver.metrics;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
@@ -14,6 +16,8 @@ import io.debezium.pipeline.meters.ConnectionMeter;
 import io.debezium.pipeline.metrics.CapturedTablesSupplier;
 import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.relational.TableId;
+import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Collect;
 
 class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServerStreamingPartitionMetrics>
@@ -34,7 +38,7 @@ class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServ
                                 "context", "streaming",
                                 "database", partition.getDatabaseName()),
                         metadataProvider,
-                        capturedTablesSupplier));
+                        scopedTo(capturedTablesSupplier, partition)));
         connectionMeter = new ConnectionMeter();
     }
 
@@ -51,5 +55,21 @@ class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServ
     @Override
     public void onUnchangedEventSkipped(SqlServerPartition partition) {
         onPartitionEvent(partition, SqlServerStreamingPartitionMetrics::onUnchangedEventSkipped);
+    }
+
+    static CapturedTablesSupplier scopedTo(CapturedTablesSupplier supplier, SqlServerPartition partition) {
+        if (supplier == null) {
+            return Collections::emptyList;
+        }
+        return () -> supplier.getCapturedTables().stream()
+                .filter(id -> isTableInPartition(id, partition))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isTableInPartition(DataCollectionId dataCollectionId, SqlServerPartition partition) {
+        if (dataCollectionId instanceof TableId tableId) {
+            return partition.getDatabaseName() != null && partition.getDatabaseName().equalsIgnoreCase(tableId.catalog());
+        }
+        return false;
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetricsTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetricsTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
+import io.debezium.connector.sqlserver.SqlServerPartition;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.util.MetricsHelper;
+import io.debezium.pipeline.metrics.CapturedTablesSupplier;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.TableId;
+import io.debezium.spi.schema.DataCollectionId;
+import io.debezium.storage.kafka.history.KafkaSchemaHistory;
+
+/**
+ * Unit tests for {@link SqlServerStreamingTaskMetrics}.
+ */
+public class SqlServerStreamingTaskMetricsTest {
+
+    private final ChangeEventQueueMetrics queueMetrics = new ChangeEventQueueMetrics() {
+        @Override
+        public int totalCapacity() {
+            return 0;
+        }
+
+        @Override
+        public int remainingCapacity() {
+            return 0;
+        }
+
+        @Override
+        public long maxQueueSizeInBytes() {
+            return 0;
+        }
+
+        @Override
+        public long currentQueueSizeInBytes() {
+            return 0;
+        }
+    };
+
+    private final EventMetadataProvider metadataProvider = new EventMetadataProvider() {
+        @Override
+        public Instant getEventTimestamp(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getEventSourcePosition(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            return null;
+        }
+
+        @Override
+        public String getTransactionId(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            return null;
+        }
+    };
+
+    @Test
+    @FixFor("debezium/dbz#586")
+    public void shouldExposeOnlyPartitionSpecificCapturedTablesViaJmxInMultiPartitionMode() {
+        final CdcSourceTaskContext<SqlServerConnectorConfig> taskContext = createTaskContext("server1", "0", "db1,db2");
+        final SqlServerPartition partition1 = new SqlServerPartition("server1", "db1");
+        final SqlServerPartition partition2 = new SqlServerPartition("server1", "db2");
+
+        final List<TableId> allTables = List.of(
+                new TableId("db1", "dbo", "tableA"),
+                new TableId("db1", "dbo", "tableB"),
+                new TableId("db2", "dbo", "tableA"),
+                new TableId("db2", "dbo", "tableC"));
+
+        final SqlServerStreamingTaskMetrics taskMetrics = new SqlServerStreamingTaskMetrics(
+                taskContext,
+                queueMetrics,
+                metadataProvider,
+                List.of(partition1, partition2),
+                () -> allTables);
+
+        try {
+            taskMetrics.register();
+
+            final String[] db1Tables = MetricsHelper.getStreamingMetric("sql_server", "server1", "streaming", "0", "db1", "CapturedTables");
+            final String[] db2Tables = MetricsHelper.getStreamingMetric("sql_server", "server1", "streaming", "0", "db2", "CapturedTables");
+
+            assertThat(db1Tables).containsExactlyInAnyOrder("db1.dbo.tableA", "db1.dbo.tableB");
+            assertThat(db2Tables).containsExactlyInAnyOrder("db2.dbo.tableA", "db2.dbo.tableC");
+        }
+        finally {
+            taskMetrics.unregister();
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#586")
+    public void shouldFilterCapturedTablesToPartitionInMultiPartitionMode() {
+        final SqlServerPartition partition1 = new SqlServerPartition("server1", "db1");
+        final SqlServerPartition partition2 = new SqlServerPartition("server1", "db2");
+
+        final List<TableId> allTables = List.of(
+                new TableId("db1", "dbo", "tableA"),
+                new TableId("db1", "dbo", "tableB"),
+                new TableId("db2", "dbo", "tableA"),
+                new TableId("db2", "dbo", "tableC"));
+
+        final CapturedTablesSupplier supplier1 = SqlServerStreamingTaskMetrics.scopedTo(() -> allTables, partition1);
+        final CapturedTablesSupplier supplier2 = SqlServerStreamingTaskMetrics.scopedTo(() -> allTables, partition2);
+
+        assertThat(supplier1.getCapturedTables())
+                .extracting(DataCollectionId::toString)
+                .containsExactlyInAnyOrder("db1.dbo.tableA", "db1.dbo.tableB");
+        assertThat(supplier2.getCapturedTables())
+                .extracting(DataCollectionId::toString)
+                .containsExactlyInAnyOrder("db2.dbo.tableA", "db2.dbo.tableC");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#586")
+    public void shouldExposeCapturedTablesInSinglePartitionMode() {
+        final SqlServerPartition partition = new SqlServerPartition("server1", "db1", false);
+
+        final List<TableId> tables = List.of(
+                new TableId("db1", "dbo", "tableA"),
+                new TableId("db1", "dbo", "tableB"),
+                new TableId("otherDb", "dbo", "tableC"));
+
+        final CapturedTablesSupplier supplier = SqlServerStreamingTaskMetrics.scopedTo(() -> tables, partition);
+
+        assertThat(supplier.getCapturedTables())
+                .extracting(DataCollectionId::toString)
+                .containsExactlyInAnyOrder("db1.dbo.tableA", "db1.dbo.tableB");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#586")
+    public void shouldHandleCaseInsensitiveDatabaseNames() {
+        final SqlServerPartition partition = new SqlServerPartition("server1", "DB1");
+
+        final List<TableId> tables = List.of(
+                new TableId("db1", "dbo", "tableA"),
+                new TableId("db2", "dbo", "tableB"));
+
+        final CapturedTablesSupplier supplier = SqlServerStreamingTaskMetrics.scopedTo(() -> tables, partition);
+
+        assertThat(supplier.getCapturedTables())
+                .extracting(DataCollectionId::toString)
+                .containsExactlyInAnyOrder("db1.dbo.tableA");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#586")
+    public void shouldHandleNullOrEmptyCapturedTablesSupplier() {
+        final SqlServerPartition partition = new SqlServerPartition("server1", "db1");
+
+        final CapturedTablesSupplier nullSupplier = SqlServerStreamingTaskMetrics.scopedTo(null, partition);
+        assertThat(nullSupplier.getCapturedTables()).isEmpty();
+
+        final CapturedTablesSupplier emptySupplier = SqlServerStreamingTaskMetrics.scopedTo(Collections::emptyList, partition);
+        assertThat(emptySupplier.getCapturedTables()).isEmpty();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#586")
+    public void shouldIgnoreNonTableIdOrNullCatalog() {
+        final SqlServerPartition partition = new SqlServerPartition("server1", "db1");
+
+        final DataCollectionId nonTableId = new DataCollectionId() {
+            @Override
+            public String identifier() {
+                return "custom_id";
+            }
+
+            @Override
+            public List<String> parts() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<String> databaseParts() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<String> schemaParts() {
+                return Collections.emptyList();
+            }
+        };
+
+        final List<DataCollectionId> tables = List.of(
+                new TableId(null, "dbo", "tableNoCatalog"),
+                new TableId("db1", "dbo", "tableA"),
+                nonTableId);
+
+        final CapturedTablesSupplier supplier = SqlServerStreamingTaskMetrics.scopedTo(() -> tables, partition);
+
+        assertThat(supplier.getCapturedTables())
+                .extracting(DataCollectionId::toString)
+                .containsExactlyInAnyOrder("db1.dbo.tableA");
+    }
+
+    private CdcSourceTaskContext<SqlServerConnectorConfig> createTaskContext(String serverName, String taskId, String databaseNames) {
+        final Configuration config = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, serverName)
+                .with(SqlServerConnectorConfig.HOSTNAME, "localhost")
+                .with(SqlServerConnectorConfig.USER, "debezium")
+                .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, "localhost:9092")
+                .with(KafkaSchemaHistory.TOPIC, "history")
+                .with(SqlServerConnectorConfig.DATABASE_NAMES, databaseNames)
+                .build();
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
+        return new CdcSourceTaskContext<>(config, connectorConfig, taskId, Collections.emptyMap());
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#586.

When a SQL Server task captures more than one database, every partition's streaming MBean reports
the captured tables of all databases in the task rather than only its own.

### The problem

With one task capturing `testDB1` (containing `dbo.customers` and `dbo.orders`) and `testDB2`
(containing `dbo.products`), Debezium registers one streaming MBean per database, each correctly
tagged:

```
debezium.sql_server:type=connector-metrics,context=streaming,server=myserver,task=0,database=testDB1
debezium.sql_server:type=connector-metrics,context=streaming,server=myserver,task=0,database=testDB2
```

Reading `CapturedTables` on the `testDB1` bean returns:

```
["testDB1.dbo.customers", "testDB1.dbo.orders", "testDB2.dbo.products"]
```

The `testDB2` bean returns the same full list. The per database MBean split is therefore cosmetic
for this attribute, and a dashboard panel scoped to one database shows the task wide total.

`SqlServerStreamingTaskMetrics` creates one `SqlServerStreamingPartitionMetrics` per partition and
tags each with its own `"database"` key, but passed the same task wide `CapturedTablesSupplier` to
every one of them. `StreamingMeter.getCapturedTables()` then maps whatever that supplier returns
with no partition filtering.

Note that the snapshot path is not affected. `SnapshotMeter` keeps its own `capturedTables` set,
populated per instance through `monitoredDataCollectionsDetermined()`, so each partition only
accumulates the collections it was actually given. Only the streaming path delegates to a shared
supplier.

### What changed

`SqlServerStreamingTaskMetrics.scopedTo(supplier, partition)` wraps the task wide supplier in one
that filters to the partition's own database, and each partition now receives its own wrapper.

The filter is applied inside the returned supplier rather than when it is constructed.
`CapturedTablesSupplier` is read on every MBean access and the captured table set changes as the
schema evolves, so filtering eagerly would freeze the value at task startup.

The null supplier guard is retained deliberately. `StreamingMeter` substitutes an empty supplier
when it receives null, but since it now always receives a non null wrapper that guard can no longer
fire, so preserving the behavior has to happen in the wrapper.

### On the case insensitive comparison

`scopedTo` compares `partition.getDatabaseName()` against `TableId.catalog()` with
`equalsIgnoreCase`. This is a deliberate choice and worth calling out, because `TableId.equals` is
case sensitive and `TableId` exposes a separate `compareToIgnoreCase` for callers who want
otherwise.

The reasoning is that the two strings come from different sources. `partition.getDatabaseName()`
originates in the user supplied `database.names` configuration, while the catalog on a `TableId`
comes from JDBC metadata. SQL Server's default collation is case insensitive, so a user configuring
`database.names=TestDB` against a catalog reported as `testdb` should still see their tables. Happy
to switch to an exact match if you would rather the metric mirror `TableId` equality semantics.

### Open question on placement

When I claimed the issue I asked whether the filtering belongs in the connector or whether
`CapturedTablesSupplier` should grow a partition aware variant in core so other multi-partition
connectors inherit it. I went with the connector local version since this is currently only
observable for SQL Server.

`scopedTo` is a self contained static method, so moving it into core later is a file move rather
than a redesign. Happy to do that in this PR instead if you prefer.

### Testing

Added `SqlServerStreamingTaskMetricsTest` with six tests:

- `shouldExposeOnlyPartitionSpecificCapturedTablesViaJmxInMultiPartitionMode` registers real MBeans
  and asserts each partition's `CapturedTables` attribute through JMX
- `shouldFilterCapturedTablesToPartitionInMultiPartitionMode` asserts both partitions receive only
  their own tables
- `shouldExposeCapturedTablesInSinglePartitionMode` includes a table from another database and
  asserts it is excluded
- `shouldHandleCaseInsensitiveDatabaseNames` includes a non matching database so the assertion
  proves the match is selective, not merely permissive
- `shouldHandleNullOrEmptyCapturedTablesSupplier`
- `shouldIgnoreNonTableIdOrNullCatalog`

Run locally on JDK 21:

- `./mvnw -pl debezium-connector-sqlserver test -Dtest=SqlServerStreamingTaskMetricsTest`, 6 of 6
  passing
- `./mvnw -pl debezium-connector-sqlserver test`, the full module unit suite, 63 passing with no
  failures, plus the architecture tests
- `./mvnw -pl debezium-connector-sqlserver process-sources` leaves the sources unchanged, and
  `checkstyle:check` is clean

I have not run the SQL Server integration tests locally as they need a running Docker daemon, which
I do not currently have available. `SqlServerMetricsIT` asserts nothing about `CapturedTables`
today, so there is no existing IT expectation this could contradict.

### AI assistance

I used Claude to help trace the metrics wiring from `ChangeEventSourceCoordinator` down to
`StreamingMeter`, to check existing conventions in the codebase before choosing between idioms, and
to review the diff and run the test commands. I wrote the change, and I verified the root cause and
the resulting behavior against the source myself.
