### PR TITLE
debezium/dbz#2469 Hotfix MongoDB sink DELETE and tombstone handling

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoDbChangeEventSink.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoDbChangeEventSink.java
@@ -31,6 +31,7 @@ import io.debezium.DebeziumException;
 import io.debezium.connector.common.DebeziumTaskState;
 import io.debezium.connector.mongodb.sink.converters.SinkDocument;
 import io.debezium.connector.mongodb.sink.eventhandler.relational.RelationalEventHandler;
+import io.debezium.data.Envelope;
 import io.debezium.dlq.ErrorReporter;
 import io.debezium.metadata.CollectionId;
 import io.debezium.openlineage.ConnectorContext;
@@ -163,14 +164,30 @@ final class MongoDbChangeEventSink implements ChangeEventSink, AutoCloseable {
     }
 
     private DatasetMetadata extractDatasetMetadata(SinkDocument sinkDocument, String collectionId) {
+        final BsonDocument keyDocument = sinkDocument.getKeyDoc().orElseGet(BsonDocument::new);
+        final BsonDocument valueDocument = sinkDocument.getValueDoc().orElseGet(BsonDocument::new);
+        BsonDocument metadataValueDocument = valueDocument;
 
-        BsonDocument changeEvent = RelationalEventHandler.generateUpsertOrReplaceDoc(sinkDocument.getKeyDoc().get(), sinkDocument.getValueDoc().get(),
+        if (!hasNonEmptyDocument(valueDocument, Envelope.FieldName.AFTER)) {
+            if (!hasNonEmptyDocument(valueDocument, Envelope.FieldName.BEFORE)) {
+                return new DatasetMetadata(collectionId, OUTPUT, TABLE_DATASET_TYPE, DATABASE, List.of());
+            }
+            metadataValueDocument = new BsonDocument(Envelope.FieldName.AFTER, valueDocument.get(Envelope.FieldName.BEFORE));
+        }
+
+        BsonDocument changeEvent = RelationalEventHandler.generateUpsertOrReplaceDoc(keyDocument, metadataValueDocument,
                 new BsonDocument(), sinkConfig.getColumnNamingStrategy());
 
         List<DatasetMetadata.FieldDefinition> fieldDefinitions = changeEvent.entrySet().stream()
                 .map((entry) -> new DatasetMetadata.FieldDefinition(entry.getKey(), entry.getValue().getBsonType().toString(), ""))
                 .toList();
         return new DatasetMetadata(collectionId, OUTPUT, TABLE_DATASET_TYPE, DATABASE, fieldDefinitions);
+    }
+
+    private boolean hasNonEmptyDocument(BsonDocument document, String fieldName) {
+        return document.containsKey(fieldName)
+                && document.get(fieldName).isDocument()
+                && !document.getDocument(fieldName).isEmpty();
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoDbSinkConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoDbSinkConnectorTask.java
@@ -110,8 +110,14 @@ public class MongoDbSinkConnectorTask extends SinkTask {
                     List.of(new DatasetMetadata(record.topic(), INPUT, STREAM_DATASET_TYPE, KAFKA, datasetDataExtractor.extract(record)))));
             mongoSink.execute(records);
         }
-        catch (Exception e) {
-            DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RESTARTING, e);
+        catch (RuntimeException e) {
+            try {
+                DebeziumOpenLineageEmitter.emit(connectorContext, DebeziumTaskState.RESTARTING, e);
+            }
+            catch (RuntimeException emissionException) {
+                e.addSuppressed(emissionException);
+            }
+            throw e;
         }
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoSinkRecordProcessor.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/sink/MongoSinkRecordProcessor.java
@@ -35,6 +35,10 @@ final class MongoSinkRecordProcessor {
 
         for (SinkRecord kafkaSinkRecord : records) {
             DebeziumSinkRecord record = new KafkaDebeziumSinkRecord(kafkaSinkRecord, sinkConfig.cloudEventsSchemaNamePattern());
+            if (record.isTombstone()) {
+                LOGGER.debug("Skipping debezium tombstone event for kafka topic compaction");
+                continue;
+            }
             MongoProcessedSinkRecordData processedData = new MongoProcessedSinkRecordData(record, sinkConfig);
 
             if (processedData.getException() != null) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/sink/MongoDbSinkConnectorTaskIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/sink/MongoDbSinkConnectorTaskIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mongodb.Module;
+import io.debezium.connector.mongodb.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
+import io.debezium.openlineage.ConnectorContext;
+import io.debezium.testing.testcontainers.MongoDbReplicaSet;
+import io.debezium.testing.testcontainers.util.DockerUtils;
+
+class MongoDbSinkConnectorTaskIT {
+
+    private static final String DATABASE_NAME = "inventory";
+    private static final String TOPIC = "dbserver1.inventory.hotfix";
+
+    private static MongoDbReplicaSet mongo;
+
+    @BeforeAll
+    static void beforeAll() {
+        DockerUtils.enableFakeDnsIfRequired();
+        mongo = MongoDbReplicaSet.replicaSet()
+                .memberCount(1)
+                .namespace("sink-hotfix-mongo")
+                .build();
+        mongo.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        TestHelper.cleanDatabase(mongo, DATABASE_NAME);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (mongo != null) {
+            mongo.stop();
+        }
+        DockerUtils.disableFakeDns();
+    }
+
+    @FixFor("debezium/dbz#2469")
+    @Test
+    void shouldDeleteRecordWhenOpenLineageIsDisabled() {
+        final var config = sinkConfig();
+        final var deleteRecord = envelopeRecord(Envelope.Operation.DELETE, 77, "before", 1);
+
+        try (var client = TestHelper.connect(mongo)) {
+            final var collection = client.getDatabase(DATABASE_NAME).getCollection(collectionName(), BsonDocument.class);
+            collection.insertOne(new BsonDocument("_id", new BsonDocument("id", new BsonInt32(77)))
+                    .append("name", new BsonString("before")));
+
+            final var sink = new MongoDbChangeEventSink(config, client, MongoDbSinkConnectorTask.nopErrorReporter(), connectorContext());
+            sink.execute(List.of(deleteRecord));
+
+            assertThat(collection.countDocuments()).isZero();
+        }
+    }
+
+    @FixFor("debezium/dbz#2469")
+    @Test
+    void shouldSkipTombstoneWithoutDroppingOtherRecordsInBatch() {
+        final var config = sinkConfig();
+        final var firstRecord = envelopeRecord(Envelope.Operation.CREATE, 1, "first", 1);
+        final var tombstone = tombstoneRecord(2);
+        final var secondRecord = envelopeRecord(Envelope.Operation.CREATE, 3, "third", 3);
+
+        try (var client = TestHelper.connect(mongo)) {
+            final var sink = new MongoDbChangeEventSink(config, client, MongoDbSinkConnectorTask.nopErrorReporter(), connectorContext());
+            sink.execute(List.of(firstRecord, tombstone, secondRecord));
+
+            final var collection = client.getDatabase(DATABASE_NAME).getCollection(collectionName(), BsonDocument.class);
+            assertThat(collection.countDocuments()).isEqualTo(2);
+        }
+    }
+
+    @FixFor("debezium/dbz#2469")
+    @Test
+    void shouldPropagateRecordProcessingFailureFromTaskPut() {
+        final var task = new MongoDbSinkConnectorTask();
+        task.start(sinkConfiguration().asMap());
+        try {
+            final var invalidValueSchema = SchemaBuilder.struct()
+                    .name("invalid.CloudEvents.Envelope")
+                    .build();
+            final var invalidRecord = new SinkRecord(TOPIC, 0, null, null, invalidValueSchema, "not-a-cloud-event", 1);
+
+            assertThatThrownBy(() -> task.put(List.of(invalidRecord)))
+                    .isInstanceOf(DebeziumException.class);
+        }
+        finally {
+            task.stop();
+        }
+    }
+
+    private MongoDbSinkConnectorConfig sinkConfig() {
+        return new MongoDbSinkConnectorConfig(sinkConfiguration());
+    }
+
+    private Configuration sinkConfiguration() {
+        return Configuration.create()
+                .with("name", "mongodb-sink-hotfix-test")
+                .with(MongoDbSinkConnectorConfig.CONNECTION_STRING, mongo.getConnectionString())
+                .with(MongoDbSinkConnectorConfig.SINK_DATABASE, DATABASE_NAME)
+                .build();
+    }
+
+    private ConnectorContext connectorContext() {
+        return ConnectorContext.from(sinkConfiguration().asMap(), Module.name(), UUID.randomUUID());
+    }
+
+    private String collectionName() {
+        return TOPIC.replace('.', '_');
+    }
+
+    private SinkRecord tombstoneRecord(long offset) {
+        final var keySchema = keySchema();
+        final var key = new Struct(keySchema).put("id", 2);
+        return new SinkRecord(TOPIC, 0, keySchema, key, null, null, offset);
+    }
+
+    private SinkRecord envelopeRecord(Envelope.Operation operation, int id, String name, long offset) {
+        final var recordSchema = recordSchema();
+        final var sourceSchema = SchemaBuilder.struct()
+                .field(Envelope.FieldName.TIMESTAMP, Schema.INT64_SCHEMA)
+                .build();
+        final var envelopeSchema = SchemaBuilder.struct()
+                .name(TOPIC + ".Envelope")
+                .field(Envelope.FieldName.BEFORE, recordSchema)
+                .field(Envelope.FieldName.AFTER, recordSchema)
+                .field(Envelope.FieldName.SOURCE, sourceSchema)
+                .field(Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA)
+                .field(Envelope.FieldName.TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA)
+                .build();
+        final var keySchema = keySchema();
+        final var key = new Struct(keySchema).put("id", id);
+        final var row = new Struct(recordSchema).put("id", id).put("name", name);
+        final var envelope = new Struct(envelopeSchema)
+                .put(Envelope.FieldName.SOURCE, new Struct(sourceSchema).put(Envelope.FieldName.TIMESTAMP, Instant.now().toEpochMilli()))
+                .put(Envelope.FieldName.OPERATION, operation.code())
+                .put(Envelope.FieldName.TIMESTAMP, Instant.now().toEpochMilli());
+
+        if (Envelope.Operation.DELETE.equals(operation)) {
+            envelope.put(Envelope.FieldName.BEFORE, row);
+        }
+        else {
+            envelope.put(Envelope.FieldName.AFTER, row);
+        }
+
+        return new SinkRecord(TOPIC, 0, keySchema, key, envelopeSchema, envelope, offset);
+    }
+
+    private Schema keySchema() {
+        return SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .build();
+    }
+
+    private Schema recordSchema() {
+        return SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+    }
+}


### PR DESCRIPTION
  Fixes debezium/dbz#2469

  ## Description

  This focused hotfix addresses three related MongoDB sink problems:

  * Makes OpenLineage output metadata extraction safe for DELETE events whose
    `after` value is null.
  * Skips Kafka tombstones before MongoDB sink record conversion without
    dropping surrounding records in the batch.
  * Propagates record processing failures from `SinkTask.put()` after
    best-effort OpenLineage state emission.

  ## Regression context

  I reproduced the same schemaful MongoDB DELETE event against
  [`c346077c42`](https://github.com/debezium/debezium/commit/c346077c425a00d4f066ac3a92959087ecdcb316),
  the immediate parent of the MongoDB OpenLineage integration introduced by
  [#6744](https://github.com/debezium/debezium/pull/6744).

  On that revision, a document with `_id: { id: 77 }` was successfully deleted,
  and the collection count changed from 1 to 0.

  The current failure occurs while evaluating output dataset metadata for a
  DELETE event whose `after` value is null, before the MongoDB bulk write is
  executed.

  ## Sink framework coordination

  This PR is intended as a focused hotfix while the shared sink framework work
  tracked by [debezium/dbz#1185](https://github.com/debezium/dbz/issues/1185)
  is in progress.

  If the sink framework integration lands first and fully covers DELETE,
  tombstone, and error propagation handling, please feel free to close this PR.
  If that integration takes longer, this hotfix can be merged independently.

  cc @mfvitale for context on #6744
  cc @rk3rn3r for coordination with the sink framework work

  ## PR Checklist

  - [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
  - [x] Minimal changes to code not directly related to this change
  - [x] One feature/change per PR unless tightly coupled
  - [x] Rebased on upstream `main`
