### PR TITLE
debezium/dbz#2567 Add SingleStore ARRAY to JSON mapping

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -464,6 +464,10 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
 
     @Override
     public JdbcType getSchemaType(Schema schema) {
+        if (schema == null) {
+            throw new ConnectException("Schema is null");
+        }
+
         if (!Objects.isNull(schema.name())) {
             final JdbcType type = typeRegistry.get(schema.name());
             if (!Objects.isNull(type)) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -465,7 +465,7 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
     @Override
     public JdbcType getSchemaType(Schema schema) {
         if (schema == null) {
-            throw new ConnectException("Schema is null");
+            throw new DebeziumException("Schema is null");
         }
 
         if (!Objects.isNull(schema.name())) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/ArrayToJsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/ArrayToJsonType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.singlestore;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.connector.jdbc.type.AbstractType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code ARRAY} schema types that are mapped to
+ * a SingleStore {@code JSON} column type.
+ */
+class ArrayToJsonType extends AbstractType {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static final ArrayToJsonType INSTANCE = new ArrayToJsonType();
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ "ARRAY" };
+    }
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        // SingleStore accepts a JSON string bound to the parameter for JSON columns.
+        return "?";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return JsonType.INSTANCE.getTypeName(schema, isKey);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof List) {
+            try {
+                value = OBJECT_MAPPER.writeValueAsString(value);
+            }
+            catch (JsonProcessingException e) {
+                throw new ConnectException("Failed to serialize ARRAY data to JSON", e);
+            }
+        }
+        return JsonType.INSTANCE.bind(index, schema, value);
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
@@ -50,6 +50,7 @@ public class SingleStoreDatabaseDialect extends MariaDbDatabaseDialect {
         super.registerTypes();
 
         registerType(JsonType.INSTANCE);
+        registerType(ArrayToJsonType.INSTANCE);
         registerType(MapToJsonType.INSTANCE);
         registerType(GeometryType.INSTANCE);
         registerType(PointType.INSTANCE);

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/singlestore/ArrayToJsonTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/singlestore/ArrayToJsonTypeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.singlestore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.Json;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Unit tests for the SingleStore {@link ArrayToJsonType} handler.
+ */
+@Tag("UnitTests")
+class ArrayToJsonTypeTest {
+
+    @Test
+    @DisplayName("Should register for ARRAY logical name")
+    void testRegistrationKeys() {
+        assertThat(ArrayToJsonType.INSTANCE.getRegistrationKeys()).containsExactly("ARRAY");
+    }
+
+    @Test
+    @DisplayName("Should use a parameter binding for SingleStore JSON columns")
+    void testQueryBinding() {
+        assertThat(ArrayToJsonType.INSTANCE.getQueryBinding(null, null, null)).isEqualTo("?");
+    }
+
+    @Test
+    @DisplayName("Should serialize a list value to a JSON string before binding")
+    void testBindSerializesListToJsonString() {
+        Schema schema = SchemaBuilder.string().name(Json.LOGICAL_NAME).build();
+
+        List<ValueBindDescriptor> bindDescriptors = ArrayToJsonType.INSTANCE.bind(1, schema, List.of("a", 2, true));
+
+        assertThat(bindDescriptors).hasSize(1);
+        assertThat(bindDescriptors.get(0).getIndex()).isEqualTo(1);
+        assertThat(bindDescriptors.get(0).getValue()).isEqualTo("[\"a\",2,true]");
+    }
+
+    @Test
+    @DisplayName("Should preserve non-list values for binding")
+    void testBindPreservesNonListValues() {
+        Schema schema = SchemaBuilder.string().name(Json.LOGICAL_NAME).build();
+
+        List<ValueBindDescriptor> bindDescriptors = ArrayToJsonType.INSTANCE.bind(2, schema, "plain-value");
+
+        assertThat(bindDescriptors).hasSize(1);
+        assertThat(bindDescriptors.get(0).getIndex()).isEqualTo(2);
+        assertThat(bindDescriptors.get(0).getValue()).isEqualTo("plain-value");
+    }
+
+    @Test
+    @DisplayName("Should use the JSON type name")
+    void testTypeName() {
+        Schema schema = SchemaBuilder.string().name(Json.LOGICAL_NAME).build();
+
+        assertThat(ArrayToJsonType.INSTANCE.getTypeName(schema, false)).isEqualTo("json");
+        assertThat(ArrayToJsonType.INSTANCE.getTypeName(schema, true)).isEqualTo("json");
+    }
+
+    @Test
+    @DisplayName("Should fail fast when a list cannot be serialized")
+    void testBindFailsForUnsupportedListContent() {
+        Schema schema = SchemaBuilder.string().name(Json.LOGICAL_NAME).build();
+        Object value = List.of(new Object() {
+            public String toString() {
+                throw new IllegalStateException("boom");
+            }
+        });
+
+        assertThatThrownBy(() -> ArrayToJsonType.INSTANCE.bind(3, schema, value))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Failed to serialize ARRAY data to JSON");
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -450,7 +450,7 @@ If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, th
 Automatic table creation does not expose SingleStore-specific shard key, sort key, or other table option settings.
 If the target table requires explicit shard keys, sort keys, or other SingleStore table options, create the destination table in SingleStore before the connector writes to it.
 
-For SingleStore targets, {prodname} maps {prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values to the SingleStore `JSON` column type.
+For SingleStore targets, {prodname} maps {prodname} `io.debezium.data.Json` logical values and Kafka Connect `ARRAY` and `MAP` schema values to the SingleStore `JSON` column type.
 The connector maps {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values to the SingleStore `GEOGRAPHY` column type, and `io.debezium.data.geometry.Point` logical values to the SingleStore `GEOGRAPHYPOINT` column type.
 SingleStore supports a subset of WKT geospatial values.
 The connector writes `POINT`, `LINESTRING`, and `POLYGON` WKB values to SingleStore as WKT strings.


### PR DESCRIPTION
Fixes debezium/dbz#2567

## Description

Add support for mapping Kafka Connect `ARRAY` schema values to SingleStore `JSON` columns in the Debezium JDBC sink connector.

This change:

- Adds `ArrayToJsonType` to the SingleStore dialect
- Registers the `ARRAY` type mapping
- Serializes array values to JSON using Jackson
- Adds unit tests for serialization and binding
- Updates the JDBC connector documentation

## Validation

- Added unit tests for ARRAY serialization and binding
- Verified the documentation change
- Confirmed the PR contains only the intended JDBC and documentation files