### PR TITLE
debezium/dbz#2574 Handle missing fields in Neo4j SMT

### DIFF
--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/Neo4jCudConverter.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/Neo4jCudConverter.java
@@ -73,7 +73,8 @@ public class Neo4jCudConverter<R extends ConnectRecord<R>> implements Transforma
         // only the global output settings are statically declared here.
         Field.group(config, null,
                 Neo4jCudConverterConfig.OUTPUT_MODE,
-                Neo4jCudConverterConfig.TOMBSTONES_ENABLED);
+                Neo4jCudConverterConfig.TOMBSTONES_ENABLED,
+                Neo4jCudConverterConfig.FIELD_MISSING_BEHAVIOR);
         return config;
     }
 
@@ -101,14 +102,31 @@ public class Neo4jCudConverter<R extends ConnectRecord<R>> implements Transforma
             return record;
         }
 
-        final var op = resolveOperation(message);
-        if (op == null) {
-            return record;
+        final var op = Envelope.Operation.forCode(message.getString(Envelope.FieldName.OPERATION));
+        if (isUnrecognizedOperation(op)) {
+            throw new DataException(String.format(
+                    "Unrecognized operation '%s' for mapped table '%s'; the Neo4j CUD converter does not know how to handle it",
+                    message.getString(Envelope.FieldName.OPERATION), table));
+        }
+        if (isNoDMLOperation(op)) {
+            LOGGER.warn("Dropping non-DML operation '{}' for mapped table '{}'; the Neo4j CUD format "
+                    + "cannot represent it (no label-scoped bulk delete and the event carries no row keys)",
+                    message.getString(Envelope.FieldName.OPERATION), table);
+            return null;
         }
 
         final var data = resolveData(message, op);
+        if (data == null) {
+            return handleMissingImage(record, table, op);
+        }
+
         final var cudOp = op == Envelope.Operation.DELETE ? CudEvent.Operation.DELETE : CudEvent.Operation.MERGE;
         final var events = eventFactory.buildEvents(data, cudOp, mapping);
+        if (events.isEmpty()) {
+            // The record matched a mapping but produced no CUD event (skipped per field.missing.behavior);
+            // drop it rather than pass the raw envelope through to the Neo4j sink.
+            return null;
+        }
 
         final var serializedContent = converterConfig.outputMode() == OutputMode.ARRAY
                 ? serializer.serializeArray(events)
@@ -125,6 +143,14 @@ public class Neo4jCudConverter<R extends ConnectRecord<R>> implements Transforma
                 record.headers());
     }
 
+    private static boolean isNoDMLOperation(Envelope.Operation op) {
+        return op == Envelope.Operation.TRUNCATE || op == Envelope.Operation.MESSAGE;
+    }
+
+    private static boolean isUnrecognizedOperation(Envelope.Operation op) {
+        return op == null;
+    }
+
     private boolean isNotValidMessage(R record) {
         return !smtManager.isValidEnvelope(record);
     }
@@ -137,21 +163,30 @@ public class Neo4jCudConverter<R extends ConnectRecord<R>> implements Transforma
         return null;
     }
 
-    private Envelope.Operation resolveOperation(Struct envelope) {
-        final var op = Envelope.Operation.forCode(envelope.getString(Envelope.FieldName.OPERATION));
-
-        if (op == Envelope.Operation.TRUNCATE || op == Envelope.Operation.MESSAGE) {
-            LOGGER.debug("Skipping non-DML operation: {}", envelope.getString(Envelope.FieldName.OPERATION));
-            return null;
-        }
-        return op;
-    }
-
     private Struct resolveData(Struct envelope, Envelope.Operation op) {
         if (op == Envelope.Operation.DELETE) {
             return envelope.getStruct(Envelope.FieldName.BEFORE);
         }
         return envelope.getStruct(Envelope.FieldName.AFTER);
+    }
+
+    /**
+     * Handles a change event whose required row image is absent (for example a delete emitted without a
+     * before image because the source lacks a full replica identity), according to
+     * {@code field.missing.behavior}: {@code fail} throws, {@code warn} logs and drops the record,
+     * {@code ignore} drops it silently.
+     */
+    private R handleMissingImage(R record, String table, Envelope.Operation op) {
+        final var image = op == Envelope.Operation.DELETE ? "before" : "after";
+        final var problem = String.format(
+                "Change event for table '%s' (op=%s) has no '%s' image; cannot build a CUD event",
+                table, op.code(), image);
+        switch (converterConfig.fieldMissingBehavior()) {
+            case FAIL -> throw new DataException(problem + "; failing record (field.missing.behavior=fail)");
+            case WARN -> LOGGER.warn("{}; dropping record (field.missing.behavior=warn)", problem);
+            case IGNORE -> LOGGER.debug("{}; dropping record (field.missing.behavior=ignore)", problem);
+        }
+        return null;
     }
 
     private String getTableFromSource(Struct envelope) {

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/CudEventFactory.java
@@ -23,6 +23,8 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.time.Conversions;
 import io.debezium.time.Date;
@@ -35,17 +37,27 @@ import io.debezium.time.NanoTimestamp;
 import io.debezium.time.Time;
 import io.debezium.time.Timestamp;
 import io.debezium.transforms.neo4j.CudEvent.Operation;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.FieldMissingBehavior;
 import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.NodeMode;
 import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.OutputMode;
 
 public class CudEventFactory {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CudEventFactory.class);
+
     private final Neo4jCudConverterConfig config;
+    private final FieldMissingBehavior fieldMissingBehavior;
 
     public CudEventFactory(Neo4jCudConverterConfig config) {
         this.config = config;
+        this.fieldMissingBehavior = config.fieldMissingBehavior();
     }
 
+    /**
+     * Builds the CUD events for a single change-event record. Returns an empty list when the record
+     * cannot be converted into any valid event and the configured {@link FieldMissingBehavior} says to
+     * skip rather than fail; the caller drops such records.
+     */
     public List<CudEvent> buildEvents(Struct data, Operation cudOp, TableMappingConfig mapping) {
         if (mapping.nodeMode() == NodeMode.NODE) {
             return buildNodeModeEvents(data, cudOp, mapping);
@@ -54,21 +66,36 @@ public class CudEventFactory {
     }
 
     private List<CudEvent> buildNodeModeEvents(Struct data, Operation cudOp, TableMappingConfig mapping) {
+        final var ids = extractIdProperties(data, mapping);
+        if (!keyUsable(ids, mapping, cudOp)) {
+            return Collections.emptyList();
+        }
+
         final List<CudEvent> events = new ArrayList<>();
-        events.add(buildNodeEvent(data, cudOp, mapping));
+        events.add(buildNodeEvent(data, cudOp, mapping, ids));
 
         if (cudOp != Operation.DELETE) {
             for (final var relMapping : mapping.relationships()) {
-                columnValue(data, relMapping.fkColumn()).ifPresent(fkValue -> events.add(
-                        buildRelationshipForNodeMode(data, cudOp, mapping, relMapping, fkValue)));
+                final var fkValue = columnValue(data, relMapping.fkColumn());
+                if (fkValue.isPresent()) {
+                    events.add(buildRelationshipForNodeMode(data, cudOp, mapping, relMapping, fkValue.get(), ids));
+                }
+                else if (!hasColumn(data, relMapping.fkColumn())) {
+                    onMissingField(String.format(
+                            "Foreign key column '%s' for relationship '%s' on table '%s' is absent from the record schema",
+                            relMapping.fkColumn(), relMapping.type(), mapping.tableName()),
+                            "skipping this relationship");
+                }
+                else {
+                    LOGGER.debug("Foreign key column '{}' for relationship '{}' on table '{}' is null; skipping this relationship",
+                            relMapping.fkColumn(), relMapping.type(), mapping.tableName());
+                }
             }
         }
         return events;
     }
 
-    private CudNodeEvent buildNodeEvent(Struct data, Operation cudOp, TableMappingConfig mapping) {
-        final var ids = extractIdProperties(data, mapping);
-
+    private CudNodeEvent buildNodeEvent(Struct data, Operation cudOp, TableMappingConfig mapping, Map<String, Object> ids) {
         if (cudOp == Operation.DELETE) {
             return new CudNodeEvent(cudOp, mapping.nodeLabels(), ids, null, mapping.deleteDetach());
         }
@@ -79,8 +106,7 @@ public class CudEventFactory {
     }
 
     private CudRelationshipEvent buildRelationshipForNodeMode(Struct data, Operation cudOp, TableMappingConfig mapping,
-                                                              RelationshipMapping relMapping, Object fkValue) {
-        final var sourceIds = extractIdProperties(data, mapping);
+                                                              RelationshipMapping relMapping, Object fkValue, Map<String, Object> sourceIds) {
         final var targetIds = Map.<String, Object> of(relMapping.targetId(), fkValue);
 
         final var from = new CudRelationshipEvent.Endpoint(mapping.nodeLabels(), sourceIds, Operation.MERGE);
@@ -99,8 +125,30 @@ public class CudEventFactory {
         final var mappings = mapping.relationships();
         final var fromMapping = endpointFor(mappings, RelationshipMapping.Direction.OUTGOING);
         final var toMapping = endpointFor(mappings, RelationshipMapping.Direction.INCOMING);
-        final var fromFkValue = requiredFkValue(data, fromMapping, mapping);
-        final var toFkValue = requiredFkValue(data, toMapping, mapping);
+        final var fromFk = columnValue(data, fromMapping.fkColumn());
+        final var toFk = columnValue(data, toMapping.fkColumn());
+        if (fromFk.isEmpty() || toFk.isEmpty()) {
+            // Prefer to report an absent column (a mapping error) over a present-but-null one (ordinary data).
+            final String absentColumn = fromFk.isEmpty() && !hasColumn(data, fromMapping.fkColumn()) ? fromMapping.fkColumn()
+                    : toFk.isEmpty() && !hasColumn(data, toMapping.fkColumn()) ? toMapping.fkColumn()
+                            : null;
+            if (absentColumn != null) {
+                onMissingField(String.format(
+                        "Table '%s' is mapped as a relationship, but its foreign key column '%s' is absent from the record schema; "
+                                + "cannot build the relationship endpoint",
+                        mapping.tableName(), absentColumn),
+                        "skipping record");
+            }
+            else {
+                // Both endpoint columns exist but one is null: an incomplete join row is ordinary data,
+                final var nullColumn = fromFk.isEmpty() ? fromMapping.fkColumn() : toMapping.fkColumn();
+                LOGGER.debug("Table '{}' is mapped as a relationship, but its foreign key column '{}' is null; skipping record",
+                        mapping.tableName(), nullColumn);
+            }
+            return Collections.emptyList();
+        }
+        final var fromFkValue = fromFk.get();
+        final var toFkValue = toFk.get();
         final List<CudEvent> events = new ArrayList<>();
         final var isArray = config.outputMode() == OutputMode.ARRAY;
 
@@ -122,12 +170,51 @@ public class CudEventFactory {
                 .orElseThrow(() -> new IllegalStateException("No relationship mapping with direction " + direction));
     }
 
-    private Object requiredFkValue(Struct data, RelationshipMapping relMapping, TableMappingConfig mapping) {
-        return columnValue(data, relMapping.fkColumn())
-                .orElseThrow(() -> new DataException(String.format(
-                        "Table '%s' is mapped as a relationship, but its foreign key column '%s' is missing "
-                                + "from the record or has a null value; cannot build the relationship endpoint",
-                        mapping.tableName(), relMapping.fkColumn())));
+    /**
+     * Decides whether a node can be emitted given the id key resolved from the record.
+     * A completely empty key is never usable: an unkeyed MERGE would collapse every row of the table
+     * into one node, so such records are always dropped (and, unless behavior is {@code ignore}, reported).
+     * A partial key is dropped under MERGE (it would collapse entities sharing the resolved key into one
+     * node) but emitted under DELETE (which only over-matches nodes rather than fabricating one, and
+     * dropping it would leave stale nodes behind). Both are reported unless behavior is {@code ignore},
+     * and both fail when it is {@code fail}.
+     */
+    private boolean keyUsable(Map<String, Object> ids, TableMappingConfig mapping, Operation cudOp) {
+        final var expected = mapping.nodeIdProperties().size();
+        if (ids.size() == expected) {
+            return true;
+        }
+        if (ids.isEmpty()) {
+            onMissingField(String.format(
+                    "Record for table '%s' (op=%s) has none of the configured id properties %s present",
+                    mapping.tableName(), cudOp.value(), mapping.nodeIdProperties()),
+                    "skipping record, because an unkeyed MERGE would collapse all rows into one node");
+            return false;
+        }
+        final var problem = String.format(
+                "Record for table '%s' (op=%s) is missing some configured id properties; resolved key %s of %s",
+                mapping.tableName(), cudOp.value(), ids.keySet(), mapping.nodeIdProperties());
+        if (cudOp == Operation.DELETE) {
+            onMissingField(problem, "emitting a partial-key delete, which may match more nodes than intended");
+            return true;
+        }
+        onMissingField(problem, "skipping record, because a partial-key MERGE would collapse distinct entities into one node");
+        return false;
+    }
+
+    /**
+     * Applies the configured {@link FieldMissingBehavior} to a record that references a column absent from
+     * (or null in) the change event: {@code fail} throws, {@code warn} logs, {@code ignore} is silent.
+     *
+     * @param problem what is missing, phrased as a statement
+     * @param action what the SMT does about it under the non-failing behaviors
+     */
+    private void onMissingField(String problem, String action) {
+        switch (fieldMissingBehavior) {
+            case FAIL -> throw new DataException(problem + "; failing record (field.missing.behavior=fail)");
+            case WARN -> LOGGER.warn("{}; {} (field.missing.behavior=warn)", problem, action);
+            case IGNORE -> LOGGER.debug("{}; {} (field.missing.behavior=ignore)", problem, action);
+        }
     }
 
     private CudNodeEvent mergeNodeForEndpoint(RelationshipMapping mapping, Object fkValue) {
@@ -174,6 +261,13 @@ public class CudEventFactory {
     private static Optional<Object> columnValue(Struct data, String fieldName) {
         final var field = data.schema().field(fieldName);
         return field == null ? Optional.empty() : columnValue(data, field);
+    }
+
+    /**
+     * Whether the record's schema declares a column with this name.
+     * */
+    private static boolean hasColumn(Struct data, String fieldName) {
+        return data.schema().field(fieldName) != null;
     }
 
     /**

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConfigParser.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConfigParser.java
@@ -16,6 +16,7 @@ import java.util.function.Function;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.debezium.config.Configuration;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.FieldMissingBehavior;
 import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.NodeMode;
 import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.OutputMode;
 import io.debezium.util.Strings;
@@ -36,6 +37,7 @@ class Neo4jCudConfigParser {
     static Neo4jCudConverterConfig parse(Configuration config, Map<String, ?> rawProps) {
         final var outputMode = OutputMode.parse(config.getString(Neo4jCudConverterConfig.OUTPUT_MODE));
         final var tombstonesEnabled = config.getBoolean(Neo4jCudConverterConfig.TOMBSTONES_ENABLED);
+        final var fieldMissingBehavior = FieldMissingBehavior.parse(config.getString(Neo4jCudConverterConfig.FIELD_MISSING_BEHAVIOR));
 
         final var byTable = groupByTable(rawProps);
         final Map<String, TableMappingConfig> tableMappings = new LinkedHashMap<>();
@@ -44,7 +46,7 @@ class Neo4jCudConfigParser {
         }
 
         return new Neo4jCudConverterConfig(
-                outputMode, tombstonesEnabled, Collections.unmodifiableMap(tableMappings));
+                outputMode, tombstonesEnabled, fieldMissingBehavior, Collections.unmodifiableMap(tableMappings));
     }
 
     /**

--- a/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConverterConfig.java
+++ b/debezium-connect-plugins/src/main/java/io/debezium/transforms/neo4j/Neo4jCudConverterConfig.java
@@ -37,18 +37,33 @@ public class Neo4jCudConverterConfig {
             .withImportance(ConfigDef.Importance.LOW)
             .withDescription("Whether to pass through tombstone records.");
 
+    public static final Field FIELD_MISSING_BEHAVIOR = Field.create("field.missing.behavior")
+            .withDisplayName("Missing field behavior")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault(FieldMissingBehavior.WARN.getValue())
+            .withEnum(FieldMissingBehavior.class)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("How to react when a change event is missing a column that the mapping needs to build a "
+                    + "CUD event (an id property, a foreign key, or the before/after image): 'fail' throws so the "
+                    + "record is routed by the connector's error handling; 'warn' logs and skips the affected event "
+                    + "(or the whole record when nothing can be built); 'ignore' skips silently. A node whose entire "
+                    + "id key resolves to empty is never emitted regardless of this setting, because an unkeyed MERGE "
+                    + "would collapse every row into a single node.");
+
     // Only the global keys are statically declared. Per-table mapping keys (table.<name>.*) are
     // dynamic and parsed directly from the raw properties, like relationship.<fk>.* subkeys.
-    public static final Field.Set ALL_FIELDS = Field.setOf(OUTPUT_MODE, TOMBSTONES_ENABLED);
+    public static final Field.Set ALL_FIELDS = Field.setOf(OUTPUT_MODE, TOMBSTONES_ENABLED, FIELD_MISSING_BEHAVIOR);
 
     private final OutputMode outputMode;
     private final boolean tombstonesEnabled;
+    private final FieldMissingBehavior fieldMissingBehavior;
     private final Map<String, TableMappingConfig> tableMappings;
 
-    Neo4jCudConverterConfig(OutputMode outputMode, boolean tombstonesEnabled,
+    Neo4jCudConverterConfig(OutputMode outputMode, boolean tombstonesEnabled, FieldMissingBehavior fieldMissingBehavior,
                             Map<String, TableMappingConfig> tableMappings) {
         this.outputMode = outputMode;
         this.tombstonesEnabled = tombstonesEnabled;
+        this.fieldMissingBehavior = fieldMissingBehavior;
         this.tableMappings = tableMappings;
 
         validate();
@@ -71,6 +86,10 @@ public class Neo4jCudConverterConfig {
 
     public boolean tombstonesEnabled() {
         return tombstonesEnabled;
+    }
+
+    public FieldMissingBehavior fieldMissingBehavior() {
+        return fieldMissingBehavior;
     }
 
     public Map<String, TableMappingConfig> tableMappings() {
@@ -102,6 +121,27 @@ public class Neo4jCudConverterConfig {
 
         public static NodeMode parse(String value) {
             return EnumeratedValue.parse(NodeMode.class, value, NODE.value);
+        }
+    }
+
+    public enum FieldMissingBehavior implements EnumeratedValue {
+        FAIL("fail"),
+        WARN("warn"),
+        IGNORE("ignore");
+
+        private final String value;
+
+        FieldMissingBehavior(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public static FieldMissingBehavior parse(String value) {
+            return EnumeratedValue.parse(FieldMissingBehavior.class, value, WARN.value);
         }
     }
 

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/Neo4jCudConverterTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/Neo4jCudConverterTest.java
@@ -120,31 +120,326 @@ class Neo4jCudConverterTest {
     }
 
     @Nested
-    @DisplayName("Missing column or typo handling")
+    @DisplayName("Missing field behavior")
     class MissingColumnHandling {
 
         @Test
-        @DisplayName("A configured column absent from the record schema due to a typo is skipped")
-        void typoedIdColumnDoesNotThrow() throws Exception {
+        @DisplayName("Empty id key (typo) drops the record under the default 'warn' behavior")
+        void emptyIdKeyIsDroppedByDefault() {
             final var transform = configureTransform(Map.of(
                     "table.customers.node.labels", "Customer",
                     "table.customers.node.id.properties", "custmer_id"));
             final var record = createCustomerRecord("c", customerAfter());
 
-            final var events = parseArray(transform.apply(record));
-
-            assertThat(events).hasSize(1);
-            assertThat(events.get(0).get("type")).isEqualTo("node");
-            assertThat(asMap(events.get(0), "ids")).isEmpty();
+            // An unkeyed MERGE would collapse every row into one node, so the record is never emitted.
+            assertThat(transform.apply(record)).isNull();
 
             transform.close();
         }
 
         @Test
-        @DisplayName("A null foreign key in relationship mode fails with a clear error, not a Map NPE")
-        void nullFkInRelationshipModeThrows() {
-            final var transform = configureOrderItemTransform("array");
+        @DisplayName("Empty id key fails when field.missing.behavior=fail")
+        void emptyIdKeyFailsWhenConfigured() {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "custmer_id",
+                    "field.missing.behavior", "fail"));
+            final var record = createCustomerRecord("c", customerAfter());
 
+            assertThatThrownBy(() -> transform.apply(record))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("custmer_id");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A missing foreign key in node mode drops only the relationship, keeping the node")
+        void missingFkInNodeModeSkipsRelationship() throws Exception {
+            final var transform = configureOrderTransform();
+
+            final var nullableSchema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("customer_id", Schema.OPTIONAL_INT32_SCHEMA)
+                    .field("total", Schema.FLOAT64_SCHEMA)
+                    .field("status", Schema.STRING_SCHEMA)
+                    .build();
+            final var after = new Struct(nullableSchema);
+            after.put("id", 5001);
+            after.put("customer_id", null);
+            after.put("total", 99.95);
+            after.put("status", "pending");
+
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(nullableSchema)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.orders",
+                    envelope.schema(), envelope.create(after, createSource("orders"), Instant.now()));
+
+            final var events = parseArray(transform.apply(record));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+            assertThat(asMap(events.get(0), "ids")).containsEntry("id", 5001);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A null foreign key in node mode is not failed even when field.missing.behavior=fail")
+        void nullFkInNodeModeIsNotFailedEvenWhenConfigured() throws Exception {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.orders.relationship.customer_id.target.id", "id");
+            props.put("field.missing.behavior", "fail");
+            final var transform = configureTransform(props);
+
+            final var nullableSchema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("customer_id", Schema.OPTIONAL_INT32_SCHEMA)
+                    .field("total", Schema.FLOAT64_SCHEMA)
+                    .field("status", Schema.STRING_SCHEMA)
+                    .build();
+            final var after = new Struct(nullableSchema);
+            after.put("id", 5001);
+            after.put("customer_id", null);
+            after.put("total", 99.95);
+            after.put("status", "pending");
+
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(nullableSchema)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.orders",
+                    envelope.schema(), envelope.create(after, createSource("orders"), Instant.now()));
+
+            final var events = parseArray(transform.apply(record));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A foreign key column absent from the schema in node mode fails when field.missing.behavior=fail")
+        void absentFkColumnInNodeModeFailsWhenConfigured() {
+            final var props = new HashMap<String, String>();
+            props.put("table.orders.node.labels", "Order");
+            props.put("table.orders.node.id.properties", "id");
+            props.put("table.orders.relationship.customer_id.type", "PLACED_BY");
+            props.put("table.orders.relationship.customer_id.target.label", "Customer");
+            props.put("table.orders.relationship.customer_id.target.id", "id");
+            props.put("field.missing.behavior", "fail");
+            final var transform = configureTransform(props);
+
+            final var schemaWithoutFk = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("total", Schema.FLOAT64_SCHEMA)
+                    .field("status", Schema.STRING_SCHEMA)
+                    .build();
+            final var after = new Struct(schemaWithoutFk);
+            after.put("id", 5001);
+            after.put("total", 99.95);
+            after.put("status", "pending");
+
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(schemaWithoutFk)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.orders",
+                    envelope.schema(), envelope.create(after, createSource("orders"), Instant.now()));
+
+            assertThatThrownBy(() -> transform.apply(record))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("customer_id");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A null foreign key in relationship mode drops the record under the default 'warn' behavior")
+        void nullFkInRelationshipModeIsDroppedByDefault() {
+            final var transform = configureOrderItemTransform("array");
+            final var record = orderItemWithNullOrderId();
+
+            assertThat(transform.apply(record)).isNull();
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A null foreign key in relationship mode is not failed even when field.missing.behavior=fail")
+        void nullFkInRelationshipModeIsNotFailedEvenWhenConfigured() {
+            final var transform = configureOrderItemFailTransform();
+
+            assertThat(transform.apply(orderItemWithNullOrderId())).isNull();
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("An endpoint column absent from the schema in relationship mode fails when field.missing.behavior=fail")
+        void absentEndpointColumnInRelationshipModeFailsWhenConfigured() {
+            final var transform = configureOrderItemFailTransform();
+
+            assertThatThrownBy(() -> transform.apply(orderItemWithoutOrderIdColumn()))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("order_id");
+
+            transform.close();
+        }
+
+        private Neo4jCudConverter<SourceRecord> configureOrderItemFailTransform() {
+            final var props = new HashMap<String, String>();
+            props.put("table.order_items.node.mode", "relationship");
+            props.put("output.mode", "array");
+            props.put("table.order_items.relationship.order_id.direction", "outgoing");
+            props.put("table.order_items.relationship.order_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.order_id.target.label", "Order");
+            props.put("table.order_items.relationship.order_id.target.id", "id");
+            props.put("table.order_items.relationship.product_id.direction", "incoming");
+            props.put("table.order_items.relationship.product_id.type", "CONTAINS");
+            props.put("table.order_items.relationship.product_id.target.label", "Product");
+            props.put("table.order_items.relationship.product_id.target.id", "id");
+            props.put("field.missing.behavior", "fail");
+            return configureTransform(props);
+        }
+
+        private SourceRecord orderItemWithoutOrderIdColumn() {
+            final var schemaWithoutFk = SchemaBuilder.struct()
+                    .field("product_id", Schema.INT32_SCHEMA)
+                    .field("quantity", Schema.INT32_SCHEMA)
+                    .build();
+            final var after = new Struct(schemaWithoutFk);
+            after.put("product_id", 200);
+            after.put("quantity", 3);
+
+            final var envelope = Envelope.defineSchema()
+                    .withName("test.Envelope")
+                    .withRecord(schemaWithoutFk)
+                    .withSource(SOURCE_SCHEMA)
+                    .build();
+            return new SourceRecord(new HashMap<>(), new HashMap<>(), "test.order_items",
+                    envelope.schema(), envelope.create(after, createSource("order_items"), Instant.now()));
+        }
+
+        @Test
+        @DisplayName("A delete with no before image drops the record under the default 'warn' behavior")
+        void deleteWithoutBeforeImageIsDropped() {
+            final var transform = configureCustomerTransform();
+            final var envelope = customerEnvelope();
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.customers",
+                    envelope.schema(), envelope.delete(null, createSource("customers"), Instant.now()));
+
+            assertThat(transform.apply(record)).isNull();
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A delete with no before image fails when field.missing.behavior=fail")
+        void deleteWithoutBeforeImageFailsWhenConfigured() {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "field.missing.behavior", "fail"));
+            final var envelope = customerEnvelope();
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.customers",
+                    envelope.schema(), envelope.delete(null, createSource("customers"), Instant.now()));
+
+            assertThatThrownBy(() -> transform.apply(record))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("before");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("An empty id key is dropped silently when field.missing.behavior=ignore")
+        void emptyIdKeyDroppedSilentlyWhenIgnored() {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "custmer_id",
+                    "field.missing.behavior", "ignore"));
+            final var record = createCustomerRecord("c", customerAfter());
+
+            assertThat(transform.apply(record)).isNull();
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A partial composite id key drops a MERGE under the default 'warn' behavior")
+        void partialKeyMergeIsDropped() {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id, tenant_id"));
+            final var record = createCustomerRecord("c", customerAfter());
+
+            assertThat(transform.apply(record)).isNull();
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A partial composite id key fails a MERGE when field.missing.behavior=fail")
+        void partialKeyMergeFailsWhenConfigured() {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id, tenant_id",
+                    "field.missing.behavior", "fail"));
+            final var record = createCustomerRecord("c", customerAfter());
+
+            assertThatThrownBy(() -> transform.apply(record))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("tenant_id");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A partial composite id key still emits a DELETE under the default 'warn' behavior")
+        void partialKeyDeleteIsEmitted() throws Exception {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id, tenant_id"));
+            final var record = createDeleteRecord(customerEnvelope(), customerAfter(), "customers");
+
+            final var events = parseArray(transform.apply(record));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).get("type")).isEqualTo("node");
+            assertThat(events.get(0).get("op")).isEqualTo("delete");
+            assertThat(asMap(events.get(0), "ids")).containsOnlyKeys("id");
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("A partial composite id key fails a DELETE when field.missing.behavior=fail")
+        void partialKeyDeleteFailsWhenConfigured() {
+            final var transform = configureTransform(Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id, tenant_id",
+                    "field.missing.behavior", "fail"));
+            final var record = createDeleteRecord(customerEnvelope(), customerAfter(), "customers");
+
+            assertThatThrownBy(() -> transform.apply(record))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("tenant_id");
+
+            transform.close();
+        }
+
+        private SourceRecord orderItemWithNullOrderId() {
             final var nullableSchema = SchemaBuilder.struct()
                     .field("order_id", Schema.OPTIONAL_INT32_SCHEMA)
                     .field("product_id", Schema.INT32_SCHEMA)
@@ -160,14 +455,8 @@ class Neo4jCudConverterTest {
                     .withRecord(nullableSchema)
                     .withSource(SOURCE_SCHEMA)
                     .build();
-            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test.order_items",
+            return new SourceRecord(new HashMap<>(), new HashMap<>(), "test.order_items",
                     envelope.schema(), envelope.create(after, createSource("order_items"), Instant.now()));
-
-            assertThatThrownBy(() -> transform.apply(record))
-                    .isInstanceOf(DataException.class)
-                    .hasMessageContaining("order_id");
-
-            transform.close();
         }
     }
 
@@ -693,8 +982,8 @@ class Neo4jCudConverterTest {
         }
 
         @Test
-        @DisplayName("Truncate operation passes through unchanged")
-        void truncatePassthrough() {
+        @DisplayName("Truncate on a mapped table is dropped, not leaked as a raw envelope")
+        void truncateOnMappedTableIsDropped() {
             final var transform = configureCustomerTransform();
             final var envelope = customerEnvelope();
             final var source = createSource("customers");
@@ -703,9 +992,42 @@ class Neo4jCudConverterTest {
             final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test",
                     envelope.schema(), payload);
 
-            final var result = transform.apply(record);
+            // The CUD format has no label-scoped bulk delete and the event carries no row keys, so there
+            // is no CUD event to emit; the record is dropped rather than passed through to the Neo4j sink.
+            assertThat(transform.apply(record)).isNull();
 
-            assertThat(result).isSameAs(record);
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("Truncate on an unmapped table passes through unchanged")
+        void truncateOnUnmappedTablePassthrough() {
+            final var transform = configureCustomerTransform();
+            final var envelope = customerEnvelope();
+            final var source = createSource("products");
+            source.put("lsn", 1234);
+            final var payload = envelope.truncate(source, Instant.now());
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test",
+                    envelope.schema(), payload);
+
+            assertThat(transform.apply(record)).isSameAs(record);
+
+            transform.close();
+        }
+
+        @Test
+        @DisplayName("An unrecognized operation on a mapped table fails loudly instead of being silently dropped")
+        void unrecognizedOperationFailsLoudly() {
+            final var transform = configureCustomerTransform();
+            final var envelope = customerEnvelope();
+            final var payload = envelope.create(customerAfter(), createSource("customers"), Instant.now());
+            payload.put(Envelope.FieldName.OPERATION, "x");
+            final var record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test",
+                    envelope.schema(), payload);
+
+            assertThatThrownBy(() -> transform.apply(record))
+                    .isInstanceOf(DataException.class)
+                    .hasMessageContaining("Unrecognized operation");
 
             transform.close();
         }

--- a/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/Neo4jCudConfigParserTest.java
+++ b/debezium-connect-plugins/src/test/java/io/debezium/transforms/neo4j/Neo4jCudConfigParserTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.FieldMissingBehavior;
 import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.NodeMode;
 import io.debezium.transforms.neo4j.Neo4jCudConverterConfig.OutputMode;
 
@@ -119,6 +120,49 @@ class Neo4jCudConfigParserTest {
                     "tombstones.enabled", "false");
 
             assertThat(parse(props).tombstonesEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Defaults field.missing.behavior to warn")
+        void defaultsFieldMissingBehaviorToWarn() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id");
+
+            assertThat(parse(props).fieldMissingBehavior()).isEqualTo(FieldMissingBehavior.WARN);
+        }
+
+        @Test
+        @DisplayName("Parses field.missing.behavior=fail as a global setting")
+        void parsesFieldMissingBehaviorFail() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "field.missing.behavior", "fail");
+
+            assertThat(parse(props).fieldMissingBehavior()).isEqualTo(FieldMissingBehavior.FAIL);
+        }
+
+        @Test
+        @DisplayName("Parses field.missing.behavior=ignore as a global setting")
+        void parsesFieldMissingBehaviorIgnore() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "field.missing.behavior", "ignore");
+
+            assertThat(parse(props).fieldMissingBehavior()).isEqualTo(FieldMissingBehavior.IGNORE);
+        }
+
+        @Test
+        @DisplayName("Falls back to warn for an unrecognized field.missing.behavior value")
+        void fallsBackForUnknownFieldMissingBehavior() {
+            final var props = Map.of(
+                    "table.customers.node.labels", "Customer",
+                    "table.customers.node.id.properties", "id",
+                    "field.missing.behavior", "bogus");
+
+            assertThat(parse(props).fieldMissingBehavior()).isEqualTo(FieldMissingBehavior.WARN);
         }
 
         @Test

--- a/documentation/modules/ROOT/pages/transformations/neo4j-cud-converter.adoc
+++ b/documentation/modules/ROOT/pages/transformations/neo4j-cud-converter.adoc
@@ -166,6 +166,70 @@ The choice depends on what is already available in your infrastructure:
 |Flink job
 |===
 
+[[neo4j-cud-converter-schema-changes]]
+== Schema changes and DDL
+
+The `Neo4jCudConverter` transforms *data* change events only (the {prodname} envelope with an operation of `c`, `r`, `u`, or `d`).
+It does not translate schema changes (DDL) such as `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, or `TRUNCATE` into graph operations.
+There are two reasons for this:
+
+* {prodname} publishes DDL to a dedicated schema change topic (for connectors that support one), not to the per-table data topics that feed the Neo4j sink connector, so schema change events never reach the SMT.
+* Relational DDL has no single, safe mapping onto a graph model. For example, dropping a table does not imply the graph nodes should be deleted, and renaming a column does not imply the corresponding Neo4j property should be renamed in place.
+
+`TRUNCATE` and message events, which *can* appear on a data topic, are also not translated: the CUD format has no label-scoped bulk delete and these events carry no row keys, so there is no CUD event that could represent them.
+For a table that is mapped, such records are dropped (rather than passed through as a raw envelope, which would break the downstream split step and Neo4j sink); for an unmapped table they pass through unchanged like any other unmapped record.
+
+As a result, structural changes are a coordinated, manual operation.
+The subsections below describe how the SMT behaves for each kind of change and what you must do to keep the graph consistent.
+
+=== Column changes
+
+The SMT reads column values by name from each record according to your per-table mapping, so column-level changes are absorbed silently in most cases, but not always:
+
+[cols="30%a,70%a",options="header"]
+|===
+|Change
+|Behavior and required action
+
+|Add a column
+|No effect until you map it. With no `node.properties.include` filter, a new column is automatically emitted as a node property; with an include filter, it is ignored until you add it. Add the column to `table.<table_name>.node.properties.include` (or to `relationship.<fk_column>.properties`) and restart the connector if you want it. Existing nodes are not backfilled.
+
+|Drop a column
+|A dropped column simply stops appearing in the output. Remove it from any `node.properties.include`, `node.properties.exclude`, or `relationship.<fk_column>.properties` list to keep the configuration clean. Values already written to Neo4j remain and must be removed with Cypher (for example `MATCH (n:Label) REMOVE n.prop`) if you want them gone.
+
+|Rename a column
+|Treated as a drop of the old name plus an add of the new name. The impact depends on the column's role (see below). Update the affected mapping keys to the new name and restart the connector.
+|===
+
+[WARNING]
+====
+When a renamed or dropped column is referenced by a mapping, the SMT reacts according to the xref:neo4j-field-missing-behavior[`field.missing.behavior`] setting (default `warn`):
+
+* If an `id` property (`node.id.properties`) is missing, the resolved key is incomplete. A node whose *entire* key resolves to empty is always dropped (an unkeyed MERGE would collapse every row into one node). A *partial* key is the same corruption at a smaller blast radius: for a create/read/update (MERGE) it would collapse every entity sharing the resolved key components into one node, so it too is dropped; for a delete it only over-matches existing nodes (rather than fabricating a merged one), and dropping it would leave stale nodes behind, so the delete is emitted with the partial key. All of these cases are reported unless the behavior is `ignore`, and all throw when it is `fail`. Always update `node.id.properties` in lockstep with a rename of a key column.
+* A foreign key column that is *absent from the record schema* (a stale mapping or a typo) causes only that relationship to be skipped in `node.mode=node` (the node is still emitted), or the whole record to be skipped in `node.mode=relationship` (the relationship is the only event). This is the case governed by `field.missing.behavior`, so with `field.missing.behavior=fail` it throws a `DataException` naming the column.
+
+`field.missing.behavior` applies only to columns that are *absent from the schema*.
+
+Set `field.missing.behavior=fail` if you would rather have missing-column situations surface immediately (through the connector's `errors.tolerance` handling) than be logged and skipped.
+====
+
+=== Table changes
+
+`DROP TABLE`:: {prodname} stops producing change events for the table; it does *not* emit delete events for the rows that existed. The corresponding Neo4j nodes and relationships are therefore left in place (orphaned). To reconcile the graph, delete them with Cypher (for example `MATCH (n:Label) DETACH DELETE n`) and remove the table's `table.<table_name>.*` mapping from the SMT configuration.
+
+`TRUNCATE`:: The SMT skips truncate events, so a source truncate does not remove anything from Neo4j. Clear the affected nodes with Cypher if required.
+
+`RENAME TABLE`:: The SMT dispatches on the bare `source.table` name, so records for the renamed table no longer match the old `table.<old_name>.*` mapping and pass through unchanged. Add a `table.<new_name>.*` mapping (and remove the old one) and restart the connector.
+
+=== Recommended workflow for a schema change
+
+Because the pipeline does not propagate DDL automatically, treat a schema change as a migration performed alongside the streaming pipeline:
+
+. Apply the DDL at the source database.
+. Update the SMT per-table mappings to match the new schema (add, rename, or remove columns and tables), then restart the connector.
+. Run any one-off Cypher needed to reconcile data already in Neo4j: rename properties after a column rename, or delete orphaned nodes after a `DROP TABLE` or `TRUNCATE`.
+
+
 [[neo4j-cud-converter-type-mapping]]
 == Type mapping
 
@@ -418,6 +482,17 @@ a|Controls the output format:
 |`true`
 |low
 |Whether to pass through tombstone records (null value) emitted after delete events for Kafka log compaction.
+
+|[[neo4j-field-missing-behavior]]<<neo4j-field-missing-behavior, `field.missing.behavior`>>
+|`warn`
+|medium
+a|How to react when a change event is missing a column the mapping needs to build a CUD event (an id property, a foreign key, or the required before/after image). This applies only when the column is *absent from the record schema* (a stale mapping or typo); a column that is present but *null* for a row is ordinary data and is always dropped quietly at `DEBUG`, regardless of this setting:
+
+* `fail`: throw a `DataException` and let Kafka Connect's error handling take over. The outcome is governed by the connector's `errors.tolerance`: with the default `errors.tolerance=none` the task fails, while `errors.tolerance=all` skips the offending record and continues (logged when `errors.log.enable=true`).
+* `warn`: log a warning and skip the affected event (a single relationship in `node.mode=node`) or the whole record when nothing can be built.
+* `ignore`: skip silently (logged at debug level).
+
+A node whose entire id key resolves to empty is never emitted, regardless of this setting, because an unkeyed MERGE would collapse every row into a single node. A *partial* key (some but not all id properties resolved) is dropped for a create/read/update (a partial-key MERGE would collapse distinct entities into one node) but emitted for a delete (which only over-matches existing nodes rather than fabricating a merged one).
 |===
 
 [[example-neo4j-cud-converter]]


### PR DESCRIPTION
Fixes debezium/dbz#2574

## Description
This PR hardens the `Neo4jCudConverter` SMT so that malformed or unconvertible
change events are handled predictably instead of producing corrupt graph data,
throwing unexpected `NullPointerException`s, or leaking raw Debezium envelopes to
the Neo4j sink.

**New configuration option `field.missing.behavior`** that governs every case where a record references a column that is absent from (or null in) the change event:

| Value | Behavior |
|-------|----------|
| `fail` | Throw a `DataException`; the outcome (fail the task vs. skip the record) is then governed by Kafka Connect's `errors.tolerance`. |
| `warn` (default) | Log a `WARN` and drop/skip the offending part of the record. |
| `ignore` | Same behavior as `warn`, but logged at `DEBUG` (silent in normal operation). |


**an empty id key is never emitted**

Regardless of `field.missing.behavior`, a record whose configured id properties
are all absent is dropped. Emitting an unkeyed `MERGE` would collapse every row
of the table into a single Neo4j node, silently corrupting the graph. A *partial*
composite key is still emitted as a best effort (and reported).

**Guarded missing before/after image**

A change event without the required row image (for example a
without a before-image because the source lacks a full replica identity) no longer
risks a `NullPointerException`; it is handled via `field.miss

**Non-DML operations on mapped tables are dropped, not leaked**

`TRUNCATE` and message events cannot be represented in the Ne
is no label-scoped bulk delete and these events carry no row
table they are now dropped with a `WARN` rather than passing
through to the sink. Unmapped tables continue to pass through

### Documentation

- New "Schema changes and DDL" section explaining DML-only behavior and the
  recommended workflow for DROP/TRUNCATE/RENAME/ALTER.
- New `field.missing.behavior` row in the configuration table.
- Clarified that `fail` outcomes are governed by `errors.tolerance` (DLQ is
  sink-connector-only and does not apply to Debezium source connectors).

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
