### PR TITLE
debezium/dbz#2579 JDBCSchemaHistory: close transactions after reads

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -135,6 +135,7 @@ Chao Tian
 Choi Jang Ho
 Chungeun Choi
 Calin Laurentiu Ilie
+Chase Tingley
 Cheng Pan
 Ching Tsai
 Chirag Kava

--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/history/JdbcSchemaHistory.java
@@ -195,6 +195,8 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                                 }
                             }
                         }
+                        // RetriableConnection opens connections with autoCommit=false
+                        conn.commit();
                     }, "recover history records", false);
                 }
                 else {
@@ -220,8 +222,9 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                     if (tableExists.next()) {
                         exists = true;
                     }
-                    return exists;
                 }
+                conn.commit();
+                return exists;
             }, "history storage exists", false);
         }
         catch (SQLException e) {
@@ -245,8 +248,9 @@ public final class JdbcSchemaHistory extends AbstractSchemaHistory {
                     while (rs.next()) {
                         isExists = true;
                     }
-                    return isExists;
                 }
+                conn.commit();
+                return isExists;
             }, "history records exist check", false);
         }
         catch (SQLException e) {

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryTest.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryTest.java
@@ -12,6 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import java.time.Instant;
 import java.util.List;
@@ -207,6 +211,22 @@ public class JdbcSchemaHistoryTest {
         assertEquals(tables2.size(), 3);
         assertEquals(tables2.forTable(tableIdLarge), tableLarge);
         assertEquals(tables2.forTable(tableId2), table2);
+    }
+
+    @Test
+    public void shouldNotLeaveTransactionOpenAfterRecovery() throws SQLException, InterruptedException {
+        history.record(source, position, databaseName, schemaName, ddl, tableChanges, currentInstant);
+
+        Tables tables = new Tables();
+        history.recover(source, position, tables, ddlParser);
+        assertEquals(tables.size(), 1);
+
+        try (Connection other = DriverManager.getConnection("jdbc:sqlite:" + dbFile);
+                Statement stmt = other.createStatement()) {
+            // This will fail with SQLITE_BUSY if the recovery tx is still open
+            stmt.execute("CREATE TABLE transaction_probe (id INT)");
+            stmt.execute("DROP TABLE transaction_probe");
+        }
     }
 
 }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -411,3 +411,4 @@ Rohith,Rohith Devarshetty
 soepic1,Oladele Oluwaseun
 ragulshanmugam,Ragul Shanmugam
 tusharsaini18899,Tushar Saini
+tingley,Chase Tingley


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2579

## Description

Adds `commit()` calls to three read paths in `JDBCSchemaHistory` where transactions were opened but never closed.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
