### PR TITLE
debezium/dbz#2585 Wait for SQL Server startup recovery before running tests

### DIFF
--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -215,7 +215,9 @@
                                 </log>
                                 <wait>
                                     <time>60000</time> <!-- 60 seconds max -->
-                                    <log>SQL Server is now ready for client connections</log>
+                                    <!-- The "ready for client connections" message only signals that the TDS listener is up;
+                                         sa logins can still be rejected until startup recovery finishes. -->
+                                    <log>Recovery is complete</log>
                                 </wait>
                             </run>
                             <external>


### PR DESCRIPTION
Fixes debezium/dbz#2585

## Description

The SQL Server CI job intermittently fails with 130–172 errors: the alphabetically first integration test suites (21 classes starting with `BlockingSnapshotIT`) die in cascade with `Login failed for user 'sa'` from `TestHelper.createTestDatabase`, while all later suites pass.

The container wait in `debezium-connector-sqlserver/pom.xml` releases on the `SQL Server is now ready for client connections` log message, which only signals that the TDS listener is up — on slow runners, `sa` logins are still rejected for several seconds afterwards, until startup recovery finishes. In the failing runs the tests started inside that window and logins only began succeeding around the `Recovery is complete` message.

This change waits for `Recovery is complete` instead. During container startup it is always emitted after the ready message and appears well within the existing 60s wait limit (28s on the failing CI runs).

## Testing

- Verified with the same image, environment and volume configuration as the pom that `Recovery is complete` is always emitted after the ready message and that `sa` logins succeed from that point
- `BlockingSnapshotIT` (the first suite to fail on CI) green locally with the patched wait: 11 tests, 0 failures

## PR Checklist

- [x] I have read the contribution guidelines and governance document on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature/change per PR
- [x] Rebased on upstream main