### PR TITLE
debezium/dbz#2571 Bind Connect ARRAY<BYTES> values to PostgreSQL bytea[] columns

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
@@ -35,8 +35,11 @@ public class PreparedStatementQueryBinder implements QueryBinder {
                 switch (valueBindDescriptor.getTargetSqlType()) {
                     case Types.ARRAY -> {
                         LOGGER.trace("Binding parameter #{} as ARRAY", valueBindDescriptor.getIndex());
-                        Collection<Object> collection = (Collection<Object>) valueBindDescriptor.getValue();
-                        Array array = binder.getConnection().createArrayOf(valueBindDescriptor.getElementTypeName(), collection.toArray());
+                        final Object value = valueBindDescriptor.getValue();
+                        // A typed array (e.g. byte[][] for bytea[]) is passed as-is: converting it through a
+                        // generic collection would lose the component type the driver selects its encoder by.
+                        final Object[] elements = value instanceof Collection<?> collection ? collection.toArray() : (Object[]) value;
+                        Array array = binder.getConnection().createArrayOf(valueBindDescriptor.getElementTypeName(), elements);
                         binder.setArray(valueBindDescriptor.getIndex(), array);
                     }
                     case Types.CLOB -> {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/PreparedStatementQueryBinder.java
@@ -36,9 +36,21 @@ public class PreparedStatementQueryBinder implements QueryBinder {
                     case Types.ARRAY -> {
                         LOGGER.trace("Binding parameter #{} as ARRAY", valueBindDescriptor.getIndex());
                         final Object value = valueBindDescriptor.getValue();
-                        // A typed array (e.g. byte[][] for bytea[]) is passed as-is: converting it through a
-                        // generic collection would lose the component type the driver selects its encoder by.
-                        final Object[] elements = value instanceof Collection<?> collection ? collection.toArray() : (Object[]) value;
+                        final Object[] elements;
+                        if (value instanceof Collection<?> collection) {
+                            elements = collection.toArray();
+                        }
+                        else if (value instanceof Object[] typedArray) {
+                            // A typed array (e.g. byte[][] for bytea[]) is passed as-is: converting it through a
+                            // generic collection would lose the component type the driver selects its encoder by.
+                            elements = typedArray;
+                        }
+                        else {
+                            // This binder is shared across dialects and the enclosing catch only handles
+                            // SQLException, so reject any other representation (e.g. a primitive array) here.
+                            throw new IllegalArgumentException("Unsupported ARRAY value type: "
+                                    + (value == null ? "null" : value.getClass().getName()));
+                        }
                         Array array = binder.getConnection().createArrayOf(valueBindDescriptor.getElementTypeName(), elements);
                         binder.setArray(valueBindDescriptor.getIndex(), array);
                     }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -105,10 +105,26 @@ public class ArrayType extends AbstractType {
         }
         if (isPlainBytes(schema.valueSchema())) {
             return ((Collection<?>) value).stream()
-                    .map(element -> element == null ? null : ByteArrayUtils.getByteArrayFromValue(element))
+                    .map(ArrayType::toBinaryElement)
                     .toArray(byte[][]::new);
         }
         return value;
+    }
+
+    /**
+     * {@link ByteArrayUtils#getByteArrayFromValue} returns {@code null} for anything that is neither
+     * {@code byte[]} nor {@code ByteBuffer}; letting that through would write SQL NULL and silently
+     * lose the element value, so an unconvertible non-null element is rejected instead.
+     */
+    private static byte[] toBinaryElement(Object element) {
+        if (element == null) {
+            return null;
+        }
+        final byte[] bytes = ByteArrayUtils.getByteArrayFromValue(element);
+        if (bytes == null) {
+            throw new IllegalArgumentException("Unsupported BYTES array element type: " + element.getClass().getName());
+        }
+        return bytes;
     }
 
     /**

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -16,6 +16,7 @@ import org.apache.kafka.connect.data.Struct;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.ByteArrayUtils;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.util.SchemaUtils;
@@ -91,15 +92,31 @@ public class ArrayType extends AbstractType {
 
     /**
      * Unwraps {@link VariableScaleDecimal} elements to their {@code BigDecimal} value, which is what
-     * {@link java.sql.Connection#createArrayOf} can encode. Every other element type is passed through.
+     * {@link java.sql.Connection#createArrayOf} can encode. Plain {@code BYTES} elements are converted
+     * to a typed {@code byte[][]}: the driver rejects a {@code byte[]} element inside a generic
+     * {@code Object[]} but encodes a {@code byte[][]} as a {@code bytea[]} value. Every other element
+     * type is passed through.
      */
     static Object unwrapElements(Schema schema, Object value) {
-        if (!SchemaUtils.isVariableScaleDecimal(schema.valueSchema())) {
-            return value;
+        if (SchemaUtils.isVariableScaleDecimal(schema.valueSchema())) {
+            return ((Collection<?>) value).stream()
+                    .map(element -> element == null ? null : VariableScaleDecimal.toLogical((Struct) element).getDecimalValue().orElseThrow())
+                    .toList();
         }
-        return ((Collection<?>) value).stream()
-                .map(element -> element == null ? null : VariableScaleDecimal.toLogical((Struct) element).getDecimalValue().orElseThrow())
-                .toList();
+        if (isPlainBytes(schema.valueSchema())) {
+            return ((Collection<?>) value).stream()
+                    .map(element -> element == null ? null : ByteArrayUtils.getByteArrayFromValue(element))
+                    .toArray(byte[][]::new);
+        }
+        return value;
+    }
+
+    /**
+     * Logical BYTES types (e.g. {@code Decimal}) arrive as their converted Java value, so only a
+     * schema-less BYTES element represents raw binary data destined for {@code bytea}.
+     */
+    private static boolean isPlainBytes(Schema elementSchema) {
+        return elementSchema.type() == Schema.Type.BYTES && elementSchema.name() == null;
     }
 
     /**

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -11,13 +11,10 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
-import io.debezium.connector.jdbc.util.ByteArrayUtils;
-import io.debezium.data.VariableScaleDecimal;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.util.SchemaUtils;
 
@@ -87,52 +84,9 @@ public class ArrayType extends AbstractType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         final String elementTypeName = baseElementTypeName(getElementTypeName(this.getDialect(), schema, false));
-        return List.of(new ValueBindDescriptor(index, unwrapElements(schema, value), java.sql.Types.ARRAY, elementTypeName));
-    }
-
-    /**
-     * Unwraps {@link VariableScaleDecimal} elements to their {@code BigDecimal} value, which is what
-     * {@link java.sql.Connection#createArrayOf} can encode. Plain {@code BYTES} elements are converted
-     * to a typed {@code byte[][]}: the driver rejects a {@code byte[]} element inside a generic
-     * {@code Object[]} but encodes a {@code byte[][]} as a {@code bytea[]} value. Every other element
-     * type is passed through.
-     */
-    static Object unwrapElements(Schema schema, Object value) {
-        if (SchemaUtils.isVariableScaleDecimal(schema.valueSchema())) {
-            return ((Collection<?>) value).stream()
-                    .map(element -> element == null ? null : VariableScaleDecimal.toLogical((Struct) element).getDecimalValue().orElseThrow())
-                    .toList();
-        }
-        if (isPlainBytes(schema.valueSchema())) {
-            return ((Collection<?>) value).stream()
-                    .map(ArrayType::toBinaryElement)
-                    .toArray(byte[][]::new);
-        }
-        return value;
-    }
-
-    /**
-     * {@link ByteArrayUtils#getByteArrayFromValue} returns {@code null} for anything that is neither
-     * {@code byte[]} nor {@code ByteBuffer}; letting that through would write SQL NULL and silently
-     * lose the element value, so an unconvertible non-null element is rejected instead.
-     */
-    private static byte[] toBinaryElement(Object element) {
-        if (element == null) {
-            return null;
-        }
-        final byte[] bytes = ByteArrayUtils.getByteArrayFromValue(element);
-        if (bytes == null) {
-            throw new IllegalArgumentException("Unsupported BYTES array element type: " + element.getClass().getName());
-        }
-        return bytes;
-    }
-
-    /**
-     * Logical BYTES types (e.g. {@code Decimal}) arrive as their converted Java value, so only a
-     * schema-less BYTES element represents raw binary data destined for {@code bytea}.
-     */
-    private static boolean isPlainBytes(Schema elementSchema) {
-        return elementSchema.type() == Schema.Type.BYTES && elementSchema.name() == null;
+        final JdbcType elementJdbcType = getDialect().getSchemaType(schema.valueSchema());
+        final Object[] elements = elementJdbcType.convertArray(schema.valueSchema(), (Collection<?>) value);
+        return List.of(new ValueBindDescriptor(index, elements, java.sql.Types.ARRAY, elementTypeName));
     }
 
     /**

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BytesType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/BytesType.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.dialect.postgres;
 
 import java.sql.Types;
+import java.util.Collection;
 
 import org.apache.kafka.connect.data.Schema;
 import org.hibernate.engine.jdbc.Size;
@@ -40,5 +41,26 @@ class BytesType extends AbstractBytesType {
             return dialect.getJdbcTypeName(Types.VARBINARY, Size.length(dialect.getMaxVarbinaryLength()));
         }
         return dialect.getJdbcTypeName(Types.VARBINARY);
+    }
+
+    @Override
+    public Object[] convertArray(Schema schema, Collection<?> values) {
+        if (schema.name() != null) {
+            // A named BYTES schema can represent a logical value rather than raw binary data.
+            return super.convertArray(schema, values);
+        }
+        // PostgreSQL selects its bytea[] encoder by the runtime array type, including for empty arrays.
+        return values.stream().map(BytesType::toBinaryElement).toArray(byte[][]::new);
+    }
+
+    private static byte[] toBinaryElement(Object element) {
+        if (element == null) {
+            return null;
+        }
+        final byte[] bytes = ByteArrayUtils.getByteArrayFromValue(element);
+        if (bytes == null) {
+            throw new IllegalArgumentException("Unsupported BYTES array element type: " + element.getClass().getName());
+        }
+        return bytes;
     }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/JdbcType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/JdbcType.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.jdbc.type;
 
+import java.util.Collection;
+
 import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
@@ -37,4 +39,18 @@ public interface JdbcType extends Type {
      * @return the resolved type to be used in DDL statements
      */
     String getTypeName(Schema schema, boolean isKey);
+
+    /**
+     * Converts values of this type into an array suitable for {@link java.sql.Connection#createArrayOf}.
+     * This conversion is separate from scalar parameter binding because array elements can require
+     * a different representation. Implementations may return a typed array, whose runtime component
+     * type must be preserved when passing it to the JDBC driver.
+     *
+     * @param schema the element schema, never {@code null}
+     * @param values the array elements, never {@code null}, but may contain null elements
+     * @return the converted array, never {@code null}
+     */
+    default Object[] convertArray(Schema schema, Collection<?> values) {
+        return values.toArray();
+    }
 }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/VariableScaleDecimalType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/debezium/VariableScaleDecimalType.java
@@ -7,6 +7,7 @@ package io.debezium.connector.jdbc.type.debezium;
 
 import java.math.BigDecimal;
 import java.sql.Types;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,13 +44,21 @@ public class VariableScaleDecimalType extends AbstractType {
 
     @Override
     public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        return List.of(new ValueBindDescriptor(index, toDecimalValue(value)));
+    }
 
+    @Override
+    public Object[] convertArray(Schema schema, Collection<?> values) {
+        return values.stream().map(this::toDecimalValue).toArray();
+    }
+
+    private BigDecimal toDecimalValue(Object value) {
         if (value == null) {
-            return List.of(new ValueBindDescriptor(index, null));
+            return null;
         }
         if (value instanceof Struct) {
             Optional<BigDecimal> bigDecimalValue = VariableScaleDecimal.toLogical((Struct) value).getDecimalValue();
-            return List.of(new ValueBindDescriptor(index, bigDecimalValue.orElseThrow()));
+            return bigDecimalValue.orElseThrow();
         }
 
         throw new ConnectException(String.format("Unexpected %s value '%s' with type '%s'", getClass().getSimpleName(),

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/PreparedStatementQueryBinderTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/PreparedStatementQueryBinderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Unit tests for {@link PreparedStatementQueryBinder}.
+ */
+@Tag("UnitTests")
+class PreparedStatementQueryBinderTest {
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should pass a typed array to createArrayOf as-is")
+    void testBindsTypedArrayAsIs() throws SQLException {
+        final PreparedStatement statement = mock(PreparedStatement.class);
+        final Connection connection = mock(Connection.class);
+        when(statement.getConnection()).thenReturn(connection);
+
+        final byte[][] value = new byte[][]{ { 1, 2 }, null, { 3 } };
+        new PreparedStatementQueryBinder(statement)
+                .bind(new ValueBindDescriptor(1, value, Types.ARRAY, "bytea"));
+
+        verify(connection).createArrayOf(eq("bytea"), eq(value));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should convert a collection to Object[] for createArrayOf")
+    void testBindsCollectionAsObjectArray() throws SQLException {
+        final PreparedStatement statement = mock(PreparedStatement.class);
+        final Connection connection = mock(Connection.class);
+        when(statement.getConnection()).thenReturn(connection);
+
+        new PreparedStatementQueryBinder(statement)
+                .bind(new ValueBindDescriptor(1, List.of(1, 2, 42), Types.ARRAY, "int4"));
+
+        verify(connection).createArrayOf(eq("int4"), eq(new Object[]{ 1, 2, 42 }));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should reject an ARRAY value that is neither a collection nor an object array")
+    void testRejectsUnsupportedArrayValue() {
+        final PreparedStatement statement = mock(PreparedStatement.class);
+
+        assertThatThrownBy(() -> new PreparedStatementQueryBinder(statement)
+                .bind(new ValueBindDescriptor(1, new int[]{ 1, 2 }, Types.ARRAY, "int4")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported ARRAY value type")
+                .hasMessageContaining(int[].class.getName());
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.jdbc.dialect.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -128,6 +129,20 @@ class ArrayTypeTest {
 
         assertThat(ArrayType.unwrapElements(arraySchema, elements))
                 .isEqualTo(new byte[][]{ { 1, 2, 3 }, { 4, 5, 6 }, null });
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should reject a BYTES element that is neither byte[] nor ByteBuffer")
+    void testRejectsUnconvertibleBytesElement() {
+        // A silent SQL NULL here would turn an upstream converter bug into invisible data loss.
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build();
+        final List<Object> elements = List.of("not-binary");
+
+        assertThatThrownBy(() -> ArrayType.unwrapElements(arraySchema, elements))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported BYTES array element type")
+                .hasMessageContaining(String.class.getName());
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
@@ -8,9 +8,11 @@ package io.debezium.connector.jdbc.dialect.postgres;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.jupiter.api.DisplayName;
@@ -109,6 +111,41 @@ class ArrayTypeTest {
     void testPassesOtherElementsThrough() {
         final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
         final List<Object> elements = List.of("a", "b");
+
+        assertThat(ArrayType.unwrapElements(arraySchema, elements)).isSameAs(elements);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should convert plain BYTES elements to a typed byte[][]")
+    void testConvertsBytesElementsToTypedArray() {
+        // Connection#createArrayOf rejects a byte[] element inside a generic Object[].
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build();
+        final List<Object> elements = Arrays.asList(
+                new byte[]{ 1, 2, 3 },
+                ByteBuffer.wrap(new byte[]{ 4, 5, 6 }),
+                null);
+
+        assertThat(ArrayType.unwrapElements(arraySchema, elements))
+                .isEqualTo(new byte[][]{ { 1, 2, 3 }, { 4, 5, 6 }, null });
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should convert an empty BYTES array to an empty byte[][]")
+    void testConvertsEmptyBytesArray() {
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build();
+
+        assertThat(ArrayType.unwrapElements(arraySchema, List.of())).isEqualTo(new byte[0][]);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should pass logical BYTES elements through untouched")
+    void testPassesLogicalBytesElementsThrough() {
+        // Decimal is BYTES-based but its elements arrive as already converted BigDecimal values.
+        final Schema arraySchema = SchemaBuilder.array(Decimal.schema(2)).optional().build();
+        final List<Object> elements = List.of(new BigDecimal("1.25"));
 
         assertThat(ArrayType.unwrapElements(arraySchema, elements)).isSameAs(elements);
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/postgres/ArrayTypeTest.java
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.jdbc.type.connect.ConnectDecimalType;
+import io.debezium.connector.jdbc.type.connect.ConnectStringType;
+import io.debezium.connector.jdbc.type.debezium.VariableScaleDecimalType;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.doc.FixFor;
 
@@ -97,23 +100,23 @@ class ArrayTypeTest {
     void testUnwrapsVariableScaleDecimalElements() {
         // Connection#createArrayOf cannot encode a Struct; the driver renders it through toString().
         final Schema elementSchema = VariableScaleDecimal.optionalSchema();
-        final Schema arraySchema = SchemaBuilder.array(elementSchema).optional().build();
+        final var decimal = new BigDecimal("12345678901234567890.123456789");
         final List<Object> elements = Arrays.asList(
-                VariableScaleDecimal.fromLogical(elementSchema, new BigDecimal("1.25")),
+                VariableScaleDecimal.fromLogical(elementSchema, decimal),
                 null);
 
-        assertThat(ArrayType.unwrapElements(arraySchema, elements))
-                .isEqualTo(Arrays.asList(new BigDecimal("1.25"), null));
+        assertThat(VariableScaleDecimalType.INSTANCE.convertArray(elementSchema, elements))
+                .containsExactly(decimal, null);
     }
 
     @Test
     @FixFor("debezium/dbz#2398")
     @DisplayName("Should pass elements of other types through untouched")
     void testPassesOtherElementsThrough() {
-        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
-        final List<Object> elements = List.of("a", "b");
+        final List<Object> elements = Arrays.asList("a", null, "b");
 
-        assertThat(ArrayType.unwrapElements(arraySchema, elements)).isSameAs(elements);
+        assertThat(ConnectStringType.INSTANCE.convertArray(Schema.OPTIONAL_STRING_SCHEMA, elements))
+                .containsExactly("a", null, "b");
     }
 
     @Test
@@ -121,13 +124,13 @@ class ArrayTypeTest {
     @DisplayName("Should convert plain BYTES elements to a typed byte[][]")
     void testConvertsBytesElementsToTypedArray() {
         // Connection#createArrayOf rejects a byte[] element inside a generic Object[].
-        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build();
         final List<Object> elements = Arrays.asList(
                 new byte[]{ 1, 2, 3 },
                 ByteBuffer.wrap(new byte[]{ 4, 5, 6 }),
                 null);
 
-        assertThat(ArrayType.unwrapElements(arraySchema, elements))
+        assertThat(BytesType.INSTANCE.convertArray(Schema.OPTIONAL_BYTES_SCHEMA, elements))
+                .isInstanceOf(byte[][].class)
                 .isEqualTo(new byte[][]{ { 1, 2, 3 }, { 4, 5, 6 }, null });
     }
 
@@ -136,10 +139,9 @@ class ArrayTypeTest {
     @DisplayName("Should reject a BYTES element that is neither byte[] nor ByteBuffer")
     void testRejectsUnconvertibleBytesElement() {
         // A silent SQL NULL here would turn an upstream converter bug into invisible data loss.
-        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build();
         final List<Object> elements = List.of("not-binary");
 
-        assertThatThrownBy(() -> ArrayType.unwrapElements(arraySchema, elements))
+        assertThatThrownBy(() -> BytesType.INSTANCE.convertArray(Schema.OPTIONAL_BYTES_SCHEMA, elements))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported BYTES array element type")
                 .hasMessageContaining(String.class.getName());
@@ -149,9 +151,18 @@ class ArrayTypeTest {
     @FixFor("debezium/dbz#2571")
     @DisplayName("Should convert an empty BYTES array to an empty byte[][]")
     void testConvertsEmptyBytesArray() {
-        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build();
+        assertThat(BytesType.INSTANCE.convertArray(Schema.OPTIONAL_BYTES_SCHEMA, List.of()))
+                .isInstanceOf(byte[][].class)
+                .isEmpty();
+    }
 
-        assertThat(ArrayType.unwrapElements(arraySchema, List.of())).isEqualTo(new byte[0][]);
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should retain the binary array type when every element is null")
+    void testConvertsBytesArrayWithOnlyNulls() {
+        assertThat(BytesType.INSTANCE.convertArray(Schema.OPTIONAL_BYTES_SCHEMA, Arrays.asList(null, null)))
+                .isInstanceOf(byte[][].class)
+                .containsExactly(null, null);
     }
 
     @Test
@@ -159,10 +170,45 @@ class ArrayTypeTest {
     @DisplayName("Should pass logical BYTES elements through untouched")
     void testPassesLogicalBytesElementsThrough() {
         // Decimal is BYTES-based but its elements arrive as already converted BigDecimal values.
-        final Schema arraySchema = SchemaBuilder.array(Decimal.schema(2)).optional().build();
-        final List<Object> elements = List.of(new BigDecimal("1.25"));
+        final var decimal = new BigDecimal("1.25");
+        final List<Object> elements = List.of(decimal);
 
-        assertThat(ArrayType.unwrapElements(arraySchema, elements)).isSameAs(elements);
+        assertThat(ConnectDecimalType.INSTANCE.convertArray(Decimal.schema(2), elements))
+                .containsExactly(decimal);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2571")
+    @DisplayName("Should preserve named BYTES elements that fall back to the binary handler")
+    void testPassesNamedBytesElementsThrough() {
+        final Schema schema = SchemaBuilder.bytes().name("custom.Binary").build();
+        final var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
+
+        assertThat(BytesType.INSTANCE.convertArray(schema, List.of(value)))
+                .containsExactly(value);
+    }
+
+    @Test
+    @DisplayName("Should convert an empty decimal array")
+    void testConvertsEmptyDecimalArray() {
+        assertThat(VariableScaleDecimalType.INSTANCE.convertArray(VariableScaleDecimal.optionalSchema(), List.of()))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should preserve scalar VariableScaleDecimal binding")
+    void testPreservesScalarDecimalBinding() {
+        final Schema schema = VariableScaleDecimal.optionalSchema();
+        final var decimal = new BigDecimal("12345678901234567890.123456789");
+        final var value = VariableScaleDecimal.fromLogical(schema, decimal);
+
+        assertThat(VariableScaleDecimalType.INSTANCE.bind(3, schema, value))
+                .singleElement().satisfies(binding -> {
+                    assertThat(binding.getIndex()).isEqualTo(3);
+                    assertThat(binding.getValue()).isEqualTo(decimal);
+                });
+        assertThat(VariableScaleDecimalType.INSTANCE.bind(3, schema, null))
+                .singleElement().satisfies(binding -> assertThat(binding.getValue()).isNull());
     }
 
     @Test

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -494,6 +494,43 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     @ParameterizedTest
     @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2571")
+    public void testShouldWorkWithBytesArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build(),
+                Arrays.asList(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }), null, new byte[]{ 4, 5, 6 }),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        final String sql = "CREATE TABLE %s (id int not null, data bytea[], primary key(id))";
+        getSink().execute(String.format(sql, destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getArray(2).getArray()).isEqualTo(new byte[][]{ { 1, 2, 3 }, null, { 4, 5, 6 } });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
     @FixFor("DBZ-7752")
     public void testShouldWorkWithBoolArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
         final Map<String, String> properties = getDefaultSinkConfig();

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -527,6 +528,59 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             assertThat(rs.getArray(2).getArray()).isEqualTo(new byte[][]{ { 1, 2, 3 }, null, { 4, 5, 6 } });
             return null;
         });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2571")
+    public void testShouldWorkWithBytesArrayBatchedWrites(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        // ARRAY fields are excluded from the UNNEST batch path (hasUnnestUnsupportedField), so a
+        // multi-record batch always flushes through the row-wise PreparedStatement addBatch path.
+        // Unlike the single-record tests, the insert modes still take distinct decision paths here:
+        // with UNNEST enabled the batch reaches the exclusion check and must fall back, while with
+        // it disabled the UNNEST path is skipped outright.
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        JdbcSinkConnectorConfig config = getConfig(properties);
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build();
+        final JdbcKafkaSinkRecord record1 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 1, "data", arraySchema,
+                Arrays.asList(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }), null), config);
+        final JdbcKafkaSinkRecord record2 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 2, "data", arraySchema,
+                Arrays.asList(new byte[]{ 4, 5, 6 }), config);
+        final JdbcKafkaSinkRecord record3 = factory.createRecordWithSchemaValue(
+                topicName, (byte) 3, "data", arraySchema,
+                List.of(), config);
+
+        final String destinationTable = destinationTableName(record1);
+        final String sql = "CREATE TABLE %s (id int not null, data bytea[], primary key(id))";
+        getSink().execute(String.format(sql, destinationTable));
+
+        // Pass all records in one call so they flush as a single JDBC batch
+        consume(List.of(record1, record2, record3));
+
+        final Map<Integer, Object> rowsById = new HashMap<>();
+        getSink().assertRows(destinationTable, rs -> {
+            do {
+                rowsById.put(rs.getInt(1), rs.getArray(2).getArray());
+            } while (rs.next());
+            return null;
+        });
+
+        assertThat(rowsById).hasSize(3);
+        assertThat(rowsById.get(1)).isEqualTo(new byte[][]{ { 1, 2, 3 }, null });
+        assertThat(rowsById.get(2)).isEqualTo(new byte[][]{ { 4, 5, 6 } });
+        assertThat(rowsById.get(3)).isEqualTo(new byte[0][]);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Fixes debezium/dbz#2571

## Description

The PostgreSQL JDBC sink resolves a Connect `ARRAY<BYTES>` field to a `bytea[]` column, but binding the value fails with `UnsupportedOperationException: byte[] nested inside Object[]`. Converting the input collection to a generic `Object[]` loses the component type the PostgreSQL driver needs to select its binary-array encoder.

`ArrayType` now delegates array value conversion to the element's `JdbcType` through a default `convertArray()` method. PostgreSQL `BytesType` produces a typed `byte[][]`, preserving null elements and rejecting unconvertible non-null inputs. `VariableScaleDecimalType` converts decimal elements to `BigDecimal` using the same conversion as scalar binding. Other handlers use the default array conversion, and existing SQL type resolution is retained.

The query binder passes typed arrays directly to `Connection#createArrayOf`, continues to accept collections, and reports unsupported array representations explicitly. The delegation refactoring is a separate commit following the review feedback.

## Testing

- `ArrayTypeTest` and `PreparedStatementQueryBinderTest`: 20 tests passed, covering binary conversion, null and empty arrays, logical BYTES, decimal precision, scalar decimal binding, and unsupported inputs.
- PostgreSQL `JdbcSinkColumnTypeMappingIT#testShouldWorkWith*Array*`: 72 cases passed, including binary single-record and batched writes, numeric precision, null/empty arrays, and existing array mappings. ARRAY fields continue to use the row-wise JDBC batch fallback when UNNEST is enabled.
- Maven formatting and Checkstyle checks passed. Validation was repeated after rebasing onto upstream main.

AI assistance: Codex assisted with the `JdbcType` delegation refactoring and validation. The contributor reviewed the design and authorized the update.

## PR Checklist

- [x] I have read the contribution guidelines and governance document on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature/change per PR
- [x] Rebased on upstream main
