### PR TITLE
debezium/dbz#2569 Convert BSON Symbol, MinKey, and MaxKey values in ExtractNewDocumentState

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -294,6 +294,9 @@ public class MongoDataConverter {
             case JAVASCRIPT:
             case OBJECT_ID:
             case DECIMAL128:
+            case SYMBOL:
+            case MIN_KEY:
+            case MAX_KEY:
                 builder.field(key, Schema.OPTIONAL_STRING_SCHEMA);
                 break;
             case DOUBLE:
@@ -625,6 +628,9 @@ public class MongoDataConverter {
             case JAVASCRIPT:
             case OBJECT_ID:
             case DECIMAL128:
+            case SYMBOL:
+            case MIN_KEY:
+            case MAX_KEY:
                 return Schema.OPTIONAL_STRING_SCHEMA;
 
             case DOUBLE:
@@ -827,6 +833,19 @@ public class MongoDataConverter {
 
             case JAVASCRIPT:
                 colValue = value.asJavaScript().getCode();
+                break;
+
+            case SYMBOL:
+                colValue = value.asSymbol().getSymbol();
+                break;
+
+            // MinKey and MaxKey carry no value of their own; represent them by their canonical name.
+            case MIN_KEY:
+                colValue = "MinKey";
+                break;
+
+            case MAX_KEY:
+                colValue = "MaxKey";
                 break;
 
             default:

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -209,6 +209,72 @@ public class MongoDataConverterTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2569")
+    public void shouldProcessSymbolMinKeyAndMaxKeyValues() {
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"symbol-1\",\n" +
+                "    \"symbol_value\" : { \"$symbol\" : \"symbolic\" },\n" +
+                "    \"min_key_value\" : { \"$minKey\" : 1 },\n" +
+                "    \"max_key_value\" : { \"$maxKey\" : 1 }\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withsymbol");
+        converter = new MongoDataConverter(ArrayEncoding.ARRAY);
+
+        Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+        converter.buildSchema(entry, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (Map.Entry<String, BsonValue> bsonValueEntry : val.entrySet()) {
+            converter.buildStruct(bsonValueEntry, finalSchema, struct);
+        }
+        assertThat(finalSchema).isEqualTo(
+                SchemaBuilder.struct().name("withsymbol")
+                        .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("symbol_value", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("min_key_value", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("max_key_value", Schema.OPTIONAL_STRING_SCHEMA)
+                        .build());
+        assertThat(struct.toString()).isEqualTo(
+                "Struct{"
+                        + "_id=symbol-1,"
+                        + "symbol_value=symbolic,"
+                        + "min_key_value=MinKey,"
+                        + "max_key_value=MaxKey"
+                        + "}");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2569")
+    public void shouldProcessSymbolArray() {
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"symbol-array-1\",\n" +
+                "    \"symbols\" : [ { \"$symbol\" : \"a\" }, { \"$symbol\" : \"b\" } ]\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withsymbolarray");
+        converter = new MongoDataConverter(ArrayEncoding.ARRAY);
+
+        Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+        converter.buildSchema(entry, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (Map.Entry<String, BsonValue> bsonValueEntry : val.entrySet()) {
+            converter.buildStruct(bsonValueEntry, finalSchema, struct);
+        }
+        assertThat(finalSchema).isEqualTo(
+                SchemaBuilder.struct().name("withsymbolarray")
+                        .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("symbols", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+                        .build());
+        assertThat(struct.toString()).isEqualTo(
+                "Struct{"
+                        + "_id=symbol-array-1,"
+                        + "symbols=[a, b]"
+                        + "}");
+    }
+
+    @Test
     @FixFor("DBZ-1392")
     public void shouldProcessHeterogeneousArrayWithEmptyNestedDocument() {
         val = BsonDocument.parse("{\n" +


### PR DESCRIPTION
Fixes debezium/dbz#2569

## Description

`ExtractNewDocumentState` fails with the misleading `DataException: <field> is not a valid field name` when a document contains a BSON Symbol, MinKey, or MaxKey value: the schema conversion switches in `MongoDataConverter` have no case for these types, so no Connect field is created, while `buildStruct` still attempts to write the value. Array elements of these types fail separately in the sub-schema resolution with an `IllegalArgumentException`.

This change adds symmetric schema and value handling for the three types in all three conversion switches: Symbol is converted to its string value, and MinKey/MaxKey — which carry no value of their own — are represented by their canonical names `MinKey` and `MaxKey`, all as optional Connect STRING fields. This covers scalar values, documents, and array elements for both array encodings.

## Testing

- Unit tests covering scalar Symbol/MinKey/MaxKey documents and Symbol array elements (schema and struct output)
- `MongoDataConverterTest`, `MongoArrayConverterTest`, `ToAvroMongoDataConverterTest`, and `ExtractNewDocumentStateTest` green locally

## PR Checklist

- [x] I have read the contribution guidelines and governance document on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature/change per PR
- [x] Rebased on upstream main