### PR TITLE
debezium/dbz#2568 Emit null for fields removed by $unset in ExtractNewDocumentState

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -26,6 +26,7 @@ import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.Flatten;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
+import org.bson.BsonNull;
 import org.bson.BsonType;
 import org.bson.BsonValue;
 import org.slf4j.Logger;
@@ -236,6 +237,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
         // insert || replace || update with capture.mode="change_streams_update_full" or "change_streams_update_full_with_pre_image"
         if (newRecord.value() != null) {
             valueDocument = getFullDocument(newRecord, keyDocument);
+            applyRemovedFields(valueDocument, updateDescriptionRecord);
         }
 
         // update
@@ -374,7 +376,9 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
 
         if (removed != null) {
             for (String field : removed) {
-                valueDocument.keySet().remove(field);
+                // A field removed by $unset is represented with an explicit null value, so consumers
+                // (and relational sinks) can clear the previous value.
+                valueDocument.append(field, BsonNull.VALUE);
             }
         }
 
@@ -393,6 +397,40 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
 
     private BsonDocument getFullDocument(R record, BsonDocument key) {
         return BsonDocument.parse(record.value().toString());
+    }
+
+    /**
+     * Represents each field listed in {@code updateDescription.removedFields} with an explicit null
+     * value: a full document no longer contains a field removed by {@code $unset}, so without this
+     * the field would silently disappear from the emitted record instead of being nulled out.
+     */
+    private void applyRemovedFields(BsonDocument valueDocument, R updateDescriptionRecord) {
+        if (updateDescriptionRecord.value() == null) {
+            return;
+        }
+        final Struct updateDescription = requireStruct(updateDescriptionRecord.value(), MongoDbFieldName.UPDATE_DESCRIPTION);
+        final List<String> removed = updateDescription.getArray(MongoDbFieldName.REMOVED_FIELDS);
+        if (removed == null) {
+            return;
+        }
+        for (String path : removed) {
+            setRemovedFieldToNull(valueDocument, path);
+        }
+    }
+
+    private static void setRemovedFieldToNull(BsonDocument document, String path) {
+        final String[] segments = path.split("\\.");
+        BsonDocument current = document;
+        for (int i = 0; i < segments.length - 1; i++) {
+            final BsonValue parent = current.get(segments[i]);
+            if (parent == null || !parent.isDocument()) {
+                // The enclosing document was itself removed or the path points into an array
+                // element; there is no remaining field to represent with a null value.
+                return;
+            }
+            current = parent.asDocument();
+        }
+        current.put(segments[segments.length - 1], BsonNull.VALUE);
     }
 
     @Override

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
@@ -11,6 +11,7 @@ import static io.debezium.junit.SkipWhenKafkaVersion.KafkaVersion.KAFKA_241;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 import org.apache.kafka.connect.data.Schema;
@@ -235,6 +236,104 @@ public class ExtractNewDocumentStateTest {
 
         // when
         assertThrows(IllegalArgumentException.class, () -> transformation.apply(eventRecord));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2568")
+    public void shouldEmitNullForFieldsRemovedByUnsetWithFullDocument() {
+        Schema keySchema = SchemaBuilder.struct()
+                .name("mongo.lab.evolving.Key")
+                .field("id", Schema.STRING_SCHEMA)
+                .build();
+        Struct keyStruct = new Struct(keySchema).put("id", "\"evolution-1\"");
+
+        Schema updateDescriptionSchema = SchemaBuilder.struct()
+                .name("mongo.lab.evolving.updateDescription")
+                .field("updatedFields", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("removedFields", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                .field("truncatedArrays", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                .optional()
+                .build();
+
+        Schema valueSchema = SchemaBuilder.struct()
+                .name("mongo.lab.evolving.Envelope")
+                .field("after", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("updateDescription", updateDescriptionSchema)
+                .field("op", Schema.STRING_SCHEMA)
+                .build();
+        Struct valueStruct = new Struct(valueSchema)
+                .put("after", "{\"_id\": \"evolution-1\", \"revision\": 2, \"profile\": {\"name\": \"Alice\"}}")
+                .put("updateDescription", new Struct(updateDescriptionSchema)
+                        .put("updatedFields", "{\"revision\": 2}")
+                        .put("removedFields", Arrays.asList("removable_value", "profile.age")))
+                .put("op", "u");
+
+        final SourceRecord eventRecord = new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "mongo.lab.evolving",
+                keySchema,
+                keyStruct,
+                valueSchema,
+                valueStruct);
+
+        SourceRecord transformed = transformation.apply(eventRecord);
+        Struct value = (Struct) transformed.value();
+
+        assertThat(value.get("revision")).isEqualTo(2);
+        assertThat(transformed.valueSchema().field("removable_value")).isNotNull();
+        assertThat(value.get("removable_value")).isNull();
+
+        Struct profile = value.getStruct("profile");
+        assertThat(profile.get("name")).isEqualTo("Alice");
+        assertThat(profile.schema().field("age")).isNotNull();
+        assertThat(profile.get("age")).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2568")
+    public void shouldEmitNullForFieldsRemovedByUnsetWithPartialUpdate() {
+        Schema keySchema = SchemaBuilder.struct()
+                .name("mongo.lab.evolving.Key")
+                .field("id", Schema.STRING_SCHEMA)
+                .build();
+        Struct keyStruct = new Struct(keySchema).put("id", "\"evolution-1\"");
+
+        Schema updateDescriptionSchema = SchemaBuilder.struct()
+                .name("mongo.lab.evolving.updateDescription")
+                .field("updatedFields", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("removedFields", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                .field("truncatedArrays", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                .optional()
+                .build();
+
+        Schema valueSchema = SchemaBuilder.struct()
+                .name("mongo.lab.evolving.Envelope")
+                .field("after", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("updateDescription", updateDescriptionSchema)
+                .field("op", Schema.STRING_SCHEMA)
+                .build();
+        Struct valueStruct = new Struct(valueSchema)
+                .put("updateDescription", new Struct(updateDescriptionSchema)
+                        .put("updatedFields", "{\"revision\": 2}")
+                        .put("removedFields", Arrays.asList("removable_value")))
+                .put("op", "u");
+
+        final SourceRecord eventRecord = new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "mongo.lab.evolving",
+                keySchema,
+                keyStruct,
+                valueSchema,
+                valueStruct);
+
+        SourceRecord transformed = transformation.apply(eventRecord);
+        Struct value = (Struct) transformed.value();
+
+        assertThat(value.get("revision")).isEqualTo(2);
+        assertThat(transformed.valueSchema().field("removable_value")).isNotNull();
+        assertThat(value.get("removable_value")).isNull();
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -252,7 +252,8 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
 
         assertThat(transformedUnsetUpdate.valueSchema().field("_id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
         assertThat(transformedUnsetUpdateValue.get("_id")).isEqualTo(1);
-        assertThat(transformedUnsetUpdateValue.schema().field("newStr")).isNull();
+        assertThat(transformedUnsetUpdate.valueSchema().field("newStr").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+        assertThat(transformedUnsetUpdateValue.get("newStr")).isNull();
 
         // Test FullUpdate
         try (var client = connect()) {
@@ -744,9 +745,11 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
         assertThat(value.get("name")).isEqualTo("Sally");
-        assertThat(value.schema().field("phone")).isNull();
-        assertThat(value.schema().field("active")).isNull();
-        assertThat(value.schema().fields()).hasSize(2);
+        assertThat(value.schema().field("phone")).isNotNull();
+        assertThat(value.get("phone")).isNull();
+        assertThat(value.schema().field("active")).isNotNull();
+        assertThat(value.get("active")).isNull();
+        assertThat(value.schema().fields()).hasSize(4);
     }
 
     @Test
@@ -855,8 +858,11 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
         assertThat(value.get("name")).isEqualTo("Sally");
-        assertThat(value.schema().field("phone")).isNull();
-        assertThat(value.schema().fields()).hasSize(2);
+        assertThat(value.schema().field("phone")).isNotNull();
+        assertThat(value.get("phone")).isNull();
+        assertThat(value.schema().field("active")).isNotNull();
+        assertThat(value.get("active")).isNull();
+        assertThat(value.schema().fields()).hasSize(4);
     }
 
     @Test
@@ -906,8 +912,11 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
 
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
-        assertThat(value.schema().field("phone")).isNull();
-        assertThat(value.schema().fields()).hasSize(2);
+        assertThat(value.schema().field("phone")).isNotNull();
+        assertThat(value.get("phone")).isNull();
+        assertThat(value.schema().field("active")).isNotNull();
+        assertThat(value.get("active")).isNull();
+        assertThat(value.schema().fields()).hasSize(4);
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateFieldOperatorTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateFieldOperatorTestIT.java
@@ -127,7 +127,9 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataIntNewName")).isEqualTo(123);
 
-        assertThat(valueSchema.field("dataInt")).isNull();
+        // The renamed-away field is reported in removedFields and surfaces as a null value
+        VerifyRecord.assertConnectSchemasAreEqual("dataInt", valueSchema.field("dataInt").schema(), Schema.OPTIONAL_STRING_SCHEMA);
+        assertThat(transformedUpdateValue.get("dataInt")).isNull();
     }
 
     /**
@@ -215,7 +217,9 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
 
-        assertThat(valueSchema.field("dataStr")).isNull();
+        // The unset field is reported in removedFields and surfaces as a null value
+        VerifyRecord.assertConnectSchemasAreEqual("dataStr", valueSchema.field("dataStr").schema(), Schema.OPTIONAL_STRING_SCHEMA);
+        assertThat(transformedUpdateValue.get("dataStr")).isNull();
         // Since the field "nonExistentField" doesn't exist ensure it's not present in the schema
         assertThat(valueSchema.field("nonExistentField")).isNull();
     }


### PR DESCRIPTION
Fixes debezium/dbz#2568

## Description

The event flattening documentation states that `ExtractNewDocumentState` represents a field removed by `$unset` with a `null` value, but the transformed record currently omits the field entirely — in the full-document capture modes the update description is ignored altogether, and in the partial-update path the removed fields are dropped from the document. When such a record is consumed by the JDBC sink in upsert mode, the removed column silently keeps its previous value.

This change applies `updateDescription.removedFields` in both paths, representing each removed field with an explicit `BsonNull`:

- the full-document path resolves dotted paths (e.g. `profile.age`) to the nested field, skipping paths whose enclosing document no longer exists
- the partial-update path appends the removed field with a null value, keeping the existing `flatten.struct` delimiter substitution behavior

## Testing

- Unit tests for the full-document path (including a nested removed field) and the partial-update path
- Updated the existing `ExtractNewDocumentStateTestIT` $unset assertions to the documented null representation; affected ITs green locally against MongoDB
- `MongoDataConverter` already maps BSON null to an optional STRING field, so no schema changes were needed

## PR Checklist

- [x] I have read the contribution guidelines and governance document on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature/change per PR
- [x] Rebased on upstream main