### PR TITLE
debezium/dbz#2570 Add a lossless BSON Timestamp handling mode to ExtractNewDocumentState

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
@@ -44,9 +44,14 @@ public class MongoDbSchema implements DatabaseSchema<CollectionId> {
     public static final String SCHEMA_NAME_UPDATED_DESCRIPTION = "io.debezium.connector.mongodb.changestream.updatedescription";
     public static final String SCHEMA_NAME_TRUNCATED_ARRAY = "io.debezium.connector.mongodb.changestream.truncatedarray";
 
+    // Schema used by ExtractNewDocumentState's 'struct' BSON timestamp handling mode
+    public static final String SCHEMA_NAME_TIMESTAMP = "io.debezium.mongodb.timestamp";
+
     public static final Schema TRUNCATED_ARRAY_SCHEMA = MongoDbSchemaFactory.get().truncatedArraySchema();
 
     public static final Schema UPDATED_DESCRIPTION_SCHEMA = MongoDbSchemaFactory.get().updatedDescriptionSchema();
+
+    public static final Schema BSON_TIMESTAMP_SCHEMA = MongoDbSchemaFactory.get().bsonTimestampSchema();
 
     private final MongoDbConnectorConfig config;
     private final Filters filters;

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchemaFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchemaFactory.java
@@ -54,12 +54,15 @@ public class MongoDbSchemaFactory extends SchemaFactory {
     }
 
     public Schema bsonTimestampSchema() {
+        // A BSON Timestamp always carries both components, so neither subfield is optional. Both are
+        // unsigned 32-bit values in BSON; they are widened to (signed) INT64 because Connect has no
+        // unsigned types and the full unsigned range must stay exact.
         return SchemaBuilder.struct()
                 .name(MongoDbSchema.SCHEMA_NAME_TIMESTAMP)
                 .version(MONGODB_BSON_TIMESTAMP_SCHEMA_VERSION)
                 .optional()
-                .field("time", Schema.OPTIONAL_INT64_SCHEMA)
-                .field("increment", Schema.OPTIONAL_INT32_SCHEMA)
+                .field("time", Schema.INT64_SCHEMA)
+                .field("increment", Schema.INT64_SCHEMA)
                 .build();
     }
 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchemaFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchemaFactory.java
@@ -28,6 +28,7 @@ public class MongoDbSchemaFactory extends SchemaFactory {
      */
     private static final int MONGODB_TRUNCATED_ARRAY_SCHEMA_VERSION = 1;
     private static final int MONGODB_UPDATED_DESCRIPTION_SCHEMA_VERSION = 1;
+    private static final int MONGODB_BSON_TIMESTAMP_SCHEMA_VERSION = 1;
 
     public Schema truncatedArraySchema() {
         return SchemaBuilder.struct()
@@ -49,6 +50,16 @@ public class MongoDbSchemaFactory extends SchemaFactory {
                         Json.builder().optional().build())
                 .field(MongoDbFieldName.TRUNCATED_ARRAYS,
                         SchemaBuilder.array(MongoDbSchema.TRUNCATED_ARRAY_SCHEMA).optional().build())
+                .build();
+    }
+
+    public Schema bsonTimestampSchema() {
+        return SchemaBuilder.struct()
+                .name(MongoDbSchema.SCHEMA_NAME_TIMESTAMP)
+                .version(MONGODB_BSON_TIMESTAMP_SCHEMA_VERSION)
+                .optional()
+                .field("time", Schema.OPTIONAL_INT64_SCHEMA)
+                .field("increment", Schema.OPTIONAL_INT32_SCHEMA)
                 .build();
     }
 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -104,6 +104,41 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
         }
     }
 
+    public enum BsonTimestampHandlingMode implements EnumeratedValue {
+        CONNECT("connect"),
+        STRUCT("struct");
+
+        private final String value;
+
+        BsonTimestampHandlingMode(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static BsonTimestampHandlingMode parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (BsonTimestampHandlingMode option : BsonTimestampHandlingMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ExtractNewDocumentState.class);
 
     private static final Field ARRAY_ENCODING = Field.create("array.encoding")
@@ -114,6 +149,15 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
             .withDescription("The arrays can be encoded using 'array' schema type (the default) or as a 'document' (similar to how BSON encodes arrays). "
                     + "'array' is easier to consume but requires all elements in the array to be of the same type. "
                     + "Use 'document' if the arrays in data source mix different types together.");
+
+    private static final Field BSON_TIMESTAMP_HANDLING_MODE = Field.create("bson.timestamp.handling.mode")
+            .withDisplayName("BSON timestamp handling mode")
+            .withEnum(BsonTimestampHandlingMode.class, BsonTimestampHandlingMode.CONNECT)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("How BSON Timestamp values are represented. 'connect' (the default) converts the value to a Kafka Connect Timestamp, "
+                    + "discarding the BSON increment component. 'struct' emits a struct with 'time' and 'increment' fields, "
+                    + "preserving both components of the BSON value.");
 
     private static final Field FLATTEN_STRUCT = Field.create("flatten.struct")
             .withDisplayName("Flatten struct")
@@ -149,7 +193,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
     private String delimiter;
     private boolean rewriteTombstoneDeletesWithId;
     private SchemaNameAdjuster schemaNameAdjuster;
-    private final Field.Set configFields = CONFIG_FIELDS.with(ARRAY_ENCODING, FLATTEN_STRUCT, DELIMITER);
+    private final Field.Set configFields = CONFIG_FIELDS.with(ARRAY_ENCODING, BSON_TIMESTAMP_HANDLING_MODE, FLATTEN_STRUCT, DELIMITER);
 
     @Override
     public void configure(final Map<String, ?> configs) {
@@ -177,7 +221,8 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> extends Abstrac
         converter = new MongoDataConverter(
                 ArrayEncoding.parse(config.getString(ARRAY_ENCODING)),
                 FieldNameSelector.defaultNonRelationalSelector(fieldNameAdjuster),
-                fieldNameAdjustmentMode != FieldNameAdjustmentMode.NONE);
+                fieldNameAdjustmentMode != FieldNameAdjustmentMode.NONE,
+                BsonTimestampHandlingMode.parse(config.getString(BSON_TIMESTAMP_HANDLING_MODE)));
 
         flattenStruct = config.getBoolean(FLATTEN_STRUCT);
         delimiter = config.getString(DELIMITER);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -27,6 +27,7 @@ import org.bson.BsonType;
 import org.bson.BsonValue;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.mongodb.MongoDbSchema;
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.ArrayEncoding;
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.BsonTimestampHandlingMode;
 import io.debezium.schema.FieldNameSelector;
@@ -42,19 +43,6 @@ import io.debezium.schema.SchemaNameAdjuster;
  */
 public class MongoDataConverter {
     public static final String SCHEMA_NAME_REGEX = "io.debezium.mongodb.regex";
-    public static final String SCHEMA_NAME_TIMESTAMP = "io.debezium.mongodb.timestamp";
-
-    /**
-     * Schema used by {@link BsonTimestampHandlingMode#STRUCT} to keep both components of a BSON
-     * Timestamp; the default {@link BsonTimestampHandlingMode#CONNECT} representation retains only
-     * the time component.
-     */
-    public static final Schema BSON_TIMESTAMP_STRUCT_SCHEMA = SchemaBuilder.struct()
-            .name(SCHEMA_NAME_TIMESTAMP)
-            .optional()
-            .field("time", Schema.OPTIONAL_INT64_SCHEMA)
-            .field("increment", Schema.OPTIONAL_INT32_SCHEMA)
-            .build();
 
     private final ArrayEncoding arrayEncoding;
     private final FieldNamer<String> fieldNamer;
@@ -641,7 +629,7 @@ public class MongoDataConverter {
 
     private Schema timestampSchema() {
         return bsonTimestampHandlingMode == BsonTimestampHandlingMode.STRUCT
-                ? BSON_TIMESTAMP_STRUCT_SCHEMA
+                ? MongoDbSchema.BSON_TIMESTAMP_SCHEMA
                 : Timestamp.builder().optional().build();
     }
 
@@ -861,7 +849,7 @@ public class MongoDataConverter {
                 if (bsonTimestampHandlingMode == BsonTimestampHandlingMode.STRUCT) {
                     // The BSON components are unsigned 32-bit values; time is widened so post-2038
                     // values stay exact, increment is an ordinal that fits the signed range.
-                    Struct timestampStruct = new Struct(BSON_TIMESTAMP_STRUCT_SCHEMA);
+                    Struct timestampStruct = new Struct(MongoDbSchema.BSON_TIMESTAMP_SCHEMA);
                     timestampStruct.put("time", Integer.toUnsignedLong(value.asTimestamp().getTime()));
                     timestampStruct.put("increment", value.asTimestamp().getInc());
                     colValue = timestampStruct;

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -28,6 +28,7 @@ import org.bson.BsonValue;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.ArrayEncoding;
+import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.BsonTimestampHandlingMode;
 import io.debezium.schema.FieldNameSelector;
 import io.debezium.schema.FieldNameSelector.FieldNamer;
 import io.debezium.schema.SchemaNameAdjuster;
@@ -41,6 +42,20 @@ import io.debezium.schema.SchemaNameAdjuster;
  */
 public class MongoDataConverter {
     public static final String SCHEMA_NAME_REGEX = "io.debezium.mongodb.regex";
+    public static final String SCHEMA_NAME_TIMESTAMP = "io.debezium.mongodb.timestamp";
+
+    /**
+     * Schema used by {@link BsonTimestampHandlingMode#STRUCT} to keep both components of a BSON
+     * Timestamp; the default {@link BsonTimestampHandlingMode#CONNECT} representation retains only
+     * the time component.
+     */
+    public static final Schema BSON_TIMESTAMP_STRUCT_SCHEMA = SchemaBuilder.struct()
+            .name(SCHEMA_NAME_TIMESTAMP)
+            .optional()
+            .field("time", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("increment", Schema.OPTIONAL_INT32_SCHEMA)
+            .build();
+
     private final ArrayEncoding arrayEncoding;
     private final FieldNamer<String> fieldNamer;
 
@@ -49,10 +64,18 @@ public class MongoDataConverter {
      */
     private final boolean sanitizeValue;
 
-    public MongoDataConverter(ArrayEncoding arrayEncoding, FieldNamer<String> fieldNamer, boolean sanitizeValue) {
+    private final BsonTimestampHandlingMode bsonTimestampHandlingMode;
+
+    public MongoDataConverter(ArrayEncoding arrayEncoding, FieldNamer<String> fieldNamer, boolean sanitizeValue,
+                              BsonTimestampHandlingMode bsonTimestampHandlingMode) {
         this.arrayEncoding = arrayEncoding;
         this.fieldNamer = fieldNamer;
         this.sanitizeValue = sanitizeValue;
+        this.bsonTimestampHandlingMode = bsonTimestampHandlingMode;
+    }
+
+    public MongoDataConverter(ArrayEncoding arrayEncoding, FieldNamer<String> fieldNamer, boolean sanitizeValue) {
+        this(arrayEncoding, fieldNamer, sanitizeValue, BsonTimestampHandlingMode.CONNECT);
     }
 
     public MongoDataConverter(ArrayEncoding arrayEncoding) {
@@ -316,8 +339,11 @@ public class MongoDataConverter {
                 break;
 
             case DATE_TIME:
-            case TIMESTAMP:
                 builder.field(key, Timestamp.builder().optional().build());
+                break;
+
+            case TIMESTAMP:
+                builder.field(key, timestampSchema());
                 break;
 
             case BOOLEAN:
@@ -613,6 +639,12 @@ public class MongoDataConverter {
         map.values().iterator().next();
     }
 
+    private Schema timestampSchema() {
+        return bsonTimestampHandlingMode == BsonTimestampHandlingMode.STRUCT
+                ? BSON_TIMESTAMP_STRUCT_SCHEMA
+                : Timestamp.builder().optional().build();
+    }
+
     /**
      * Returns the schema for a given BsonType
      */
@@ -641,6 +673,8 @@ public class MongoDataConverter {
                 return Schema.OPTIONAL_INT64_SCHEMA;
 
             case TIMESTAMP:
+                return timestampSchema();
+
             case DATE_TIME:
                 return Timestamp.builder().optional().build();
 
@@ -824,6 +858,15 @@ public class MongoDataConverter {
                 break;
 
             case TIMESTAMP:
+                if (bsonTimestampHandlingMode == BsonTimestampHandlingMode.STRUCT) {
+                    // The BSON components are unsigned 32-bit values; time is widened so post-2038
+                    // values stay exact, increment is an ordinal that fits the signed range.
+                    Struct timestampStruct = new Struct(BSON_TIMESTAMP_STRUCT_SCHEMA);
+                    timestampStruct.put("time", Integer.toUnsignedLong(value.asTimestamp().getTime()));
+                    timestampStruct.put("increment", value.asTimestamp().getInc());
+                    colValue = timestampStruct;
+                    break;
+                }
                 colValue = new Date(1000L * value.asTimestamp().getTime());
                 break;
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -847,11 +847,11 @@ public class MongoDataConverter {
 
             case TIMESTAMP:
                 if (bsonTimestampHandlingMode == BsonTimestampHandlingMode.STRUCT) {
-                    // The BSON components are unsigned 32-bit values; time is widened so post-2038
-                    // values stay exact, increment is an ordinal that fits the signed range.
+                    // Both BSON components are unsigned 32-bit values, widened to signed 64-bit so the
+                    // full unsigned range stays exact (Connect has no unsigned types).
                     Struct timestampStruct = new Struct(MongoDbSchema.BSON_TIMESTAMP_SCHEMA);
                     timestampStruct.put("time", Integer.toUnsignedLong(value.asTimestamp().getTime()));
-                    timestampStruct.put("increment", value.asTimestamp().getInc());
+                    timestampStruct.put("increment", Integer.toUnsignedLong(value.asTimestamp().getInc()));
                     colValue = timestampStruct;
                     break;
                 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.mongodb.MongoDbSchema;
 import io.debezium.doc.FixFor;
 import io.debezium.junit.SkipWhenKafkaVersion;
 import io.debezium.util.Collect;
@@ -281,7 +282,7 @@ public class ExtractNewDocumentStateTest {
             Struct value = (Struct) transformed.value();
 
             Struct timestamp = value.getStruct("ts");
-            assertThat(timestamp.schema().name()).isEqualTo(MongoDataConverter.SCHEMA_NAME_TIMESTAMP);
+            assertThat(timestamp.schema().name()).isEqualTo(MongoDbSchema.SCHEMA_NAME_TIMESTAMP);
             assertThat(timestamp.get("time")).isEqualTo(1710000000L);
             assertThat(timestamp.get("increment")).isEqualTo(7);
         }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
@@ -284,7 +284,7 @@ public class ExtractNewDocumentStateTest {
             Struct timestamp = value.getStruct("ts");
             assertThat(timestamp.schema().name()).isEqualTo(MongoDbSchema.SCHEMA_NAME_TIMESTAMP);
             assertThat(timestamp.get("time")).isEqualTo(1710000000L);
-            assertThat(timestamp.get("increment")).isEqualTo(7);
+            assertThat(timestamp.get("increment")).isEqualTo(7L);
         }
         finally {
             structTransformation.close();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
@@ -237,6 +237,59 @@ public class ExtractNewDocumentStateTest {
         assertThrows(IllegalArgumentException.class, () -> transformation.apply(eventRecord));
     }
 
+    @Test
+    @FixFor("debezium/dbz#2570")
+    public void shouldEmitBsonTimestampStructWhenConfigured() {
+        ExtractNewDocumentState<SourceRecord> structTransformation = new ExtractNewDocumentState<>();
+        structTransformation.configure(Collect.hashMapOf(
+                "array.encoding", "array",
+                "bson.timestamp.handling.mode", "struct"));
+        try {
+            Schema keySchema = SchemaBuilder.struct()
+                    .name("mongo.lab.timestamps.Key")
+                    .field("id", Schema.STRING_SCHEMA)
+                    .build();
+            Struct keyStruct = new Struct(keySchema).put("id", "\"timestamp-1\"");
+
+            Schema updateDescriptionSchema = SchemaBuilder.struct()
+                    .name("mongo.lab.timestamps.updateDescription")
+                    .field("updatedFields", Schema.OPTIONAL_STRING_SCHEMA)
+                    .field("removedFields", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                    .optional()
+                    .build();
+
+            Schema valueSchema = SchemaBuilder.struct()
+                    .name("mongo.lab.timestamps.Envelope")
+                    .field("after", Schema.OPTIONAL_STRING_SCHEMA)
+                    .field("updateDescription", updateDescriptionSchema)
+                    .field("op", Schema.STRING_SCHEMA)
+                    .build();
+            Struct valueStruct = new Struct(valueSchema)
+                    .put("after", "{\"_id\": \"timestamp-1\", \"ts\": {\"$timestamp\": {\"t\": 1710000000, \"i\": 7}}}")
+                    .put("op", "c");
+
+            final SourceRecord eventRecord = new SourceRecord(
+                    new HashMap<>(),
+                    new HashMap<>(),
+                    "mongo.lab.timestamps",
+                    keySchema,
+                    keyStruct,
+                    valueSchema,
+                    valueStruct);
+
+            SourceRecord transformed = structTransformation.apply(eventRecord);
+            Struct value = (Struct) transformed.value();
+
+            Struct timestamp = value.getStruct("ts");
+            assertThat(timestamp.schema().name()).isEqualTo(MongoDataConverter.SCHEMA_NAME_TIMESTAMP);
+            assertThat(timestamp.get("time")).isEqualTo(1710000000L);
+            assertThat(timestamp.get("increment")).isEqualTo(7);
+        }
+        finally {
+            structTransformation.close();
+        }
+    }
+
     /**
      * Verifies that when {@code field.name.adjustment.mode} is set to {@code avro},
      * schema names containing dot-separated segments that start with a digit

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -351,9 +351,9 @@ public class MongoDataConverterTest {
         final Struct tsA = (Struct) struct.get("ts_a");
         final Struct tsB = (Struct) struct.get("ts_b");
         assertThat(tsA.get("time")).isEqualTo(1710000000L);
-        assertThat(tsA.get("increment")).isEqualTo(7);
+        assertThat(tsA.get("increment")).isEqualTo(7L);
         assertThat(tsB.get("time")).isEqualTo(1710000000L);
-        assertThat(tsB.get("increment")).isEqualTo(8);
+        assertThat(tsB.get("increment")).isEqualTo(8L);
         // Two BSON values with the same time and a different increment must stay distinguishable
         assertThat(tsA).isNotEqualTo(tsB);
     }
@@ -382,8 +382,8 @@ public class MongoDataConverterTest {
         @SuppressWarnings("unchecked")
         final List<Struct> timestamps = (List<Struct>) struct.get("ts_values");
         assertThat(timestamps).hasSize(2);
-        assertThat(timestamps.get(0).get("increment")).isEqualTo(7);
-        assertThat(timestamps.get(1).get("increment")).isEqualTo(8);
+        assertThat(timestamps.get(0).get("increment")).isEqualTo(7L);
+        assertThat(timestamps.get(1).get("increment")).isEqualTo(8L);
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mongodb.transforms;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -28,6 +29,7 @@ import org.bson.BsonValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.DebeziumException;
 import io.debezium.connector.mongodb.MongoDbSchema;
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.ArrayEncoding;
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.BsonTimestampHandlingMode;
@@ -384,6 +386,91 @@ public class MongoDataConverterTest {
         assertThat(timestamps).hasSize(2);
         assertThat(timestamps.get(0).get("increment")).isEqualTo(7L);
         assertThat(timestamps.get(1).get("increment")).isEqualTo(8L);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2570")
+    public void shouldPreserveNestedBsonTimestampInStructMode() {
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"nested-timestamp-1\",\n" +
+                "    \"meta\" : { \"ts\" : { \"$timestamp\" : { \"t\": 1710000000, \"i\": 7 } }, \"label\": \"x\" }\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withnestedtimestamp");
+        converter = new MongoDataConverter(ArrayEncoding.ARRAY,
+                FieldNameSelector.defaultNonRelationalSelector(SchemaNameAdjuster.NO_OP), false,
+                BsonTimestampHandlingMode.STRUCT);
+
+        Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+        converter.buildSchema(entry, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (Map.Entry<String, BsonValue> bsonValueEntry : val.entrySet()) {
+            converter.buildStruct(bsonValueEntry, finalSchema, struct);
+        }
+
+        final Struct nestedTimestamp = struct.getStruct("meta").getStruct("ts");
+        assertThat(nestedTimestamp.schema().name()).isEqualTo(MongoDbSchema.SCHEMA_NAME_TIMESTAMP);
+        assertThat(nestedTimestamp.get("time")).isEqualTo(1710000000L);
+        assertThat(nestedTimestamp.get("increment")).isEqualTo(7L);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2570")
+    public void shouldEncodeMixedDateAndTimestampArrayAsDocumentInStructMode() {
+        // In struct mode a BSON timestamp no longer shares a schema with a date/time value, so an
+        // array mixing the two cannot be encoded as 'array'; 'document' encoding indexes each element
+        // under its own field and preserves both types.
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"mixed-1\",\n" +
+                "    \"times\" : [ { \"$timestamp\" : { \"t\": 1710000000, \"i\": 7 } }, { \"$date\": 1710000000000 } ]\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withmixedarray");
+        converter = new MongoDataConverter(ArrayEncoding.DOCUMENT,
+                FieldNameSelector.defaultNonRelationalSelector(SchemaNameAdjuster.NO_OP), false,
+                BsonTimestampHandlingMode.STRUCT);
+
+        Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+        converter.buildSchema(entry, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (Map.Entry<String, BsonValue> bsonValueEntry : val.entrySet()) {
+            converter.buildStruct(bsonValueEntry, finalSchema, struct);
+        }
+
+        final Struct times = struct.getStruct("times");
+
+        // The timestamp element keeps the struct schema with both components...
+        final Struct ts0 = times.getStruct("_0");
+        assertThat(ts0.schema().name()).isEqualTo(MongoDbSchema.SCHEMA_NAME_TIMESTAMP);
+        assertThat(ts0.get("time")).isEqualTo(1710000000L);
+        assertThat(ts0.get("increment")).isEqualTo(7L);
+
+        // ...while the date/time element stays a Connect Timestamp (java.util.Date).
+        assertThat(times.get("_1")).isInstanceOf(Date.class);
+        assertThat(((Date) times.get("_1")).getTime()).isEqualTo(1710000000000L);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2570")
+    public void shouldRejectMixedDateAndTimestampArrayInArrayModeInStructMode() {
+        // Documented side effect: in struct mode a timestamp and a date/time no longer share a schema,
+        // so 'array' encoding cannot represent an array that mixes them (use 'document' encoding instead).
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"mixed-array-fail-1\",\n" +
+                "    \"times\" : [ { \"$timestamp\" : { \"t\": 1710000000, \"i\": 7 } }, { \"$date\": 1710000000000 } ]\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withmixedarrayfail");
+        converter = new MongoDataConverter(ArrayEncoding.ARRAY,
+                FieldNameSelector.defaultNonRelationalSelector(SchemaNameAdjuster.NO_OP), false,
+                BsonTimestampHandlingMode.STRUCT);
+
+        assertThatThrownBy(() -> {
+            Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+            converter.buildSchema(entry, builder);
+        }).isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("different Bson types");
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -28,6 +28,7 @@ import org.bson.BsonValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.mongodb.MongoDbSchema;
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.ArrayEncoding;
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.BsonTimestampHandlingMode;
 import io.debezium.doc.FixFor;
@@ -346,7 +347,7 @@ public class MongoDataConverterTest {
             converter.buildStruct(bsonValueEntry, finalSchema, struct);
         }
 
-        assertThat(finalSchema.field("ts_a").schema().name()).isEqualTo(MongoDataConverter.SCHEMA_NAME_TIMESTAMP);
+        assertThat(finalSchema.field("ts_a").schema().name()).isEqualTo(MongoDbSchema.SCHEMA_NAME_TIMESTAMP);
         final Struct tsA = (Struct) struct.get("ts_a");
         final Struct tsB = (Struct) struct.get("ts_b");
         assertThat(tsA.get("time")).isEqualTo(1710000000L);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -13,6 +13,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -27,7 +29,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.ArrayEncoding;
+import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState.BsonTimestampHandlingMode;
 import io.debezium.doc.FixFor;
+import io.debezium.schema.FieldNameSelector;
+import io.debezium.schema.SchemaNameAdjuster;
 
 /**
  * Unit test for {@code MongoDataConverter}.
@@ -317,6 +322,93 @@ public class MongoDataConverterTest {
                         + "_id=symbol-array-1,"
                         + "symbols=[a, b]"
                         + "}");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2570")
+    public void shouldPreserveBsonTimestampComponentsInStructMode() {
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"timestamp-1\",\n" +
+                "    \"ts_a\" : { \"$timestamp\" : { \"t\": 1710000000, \"i\": 7 } },\n" +
+                "    \"ts_b\" : { \"$timestamp\" : { \"t\": 1710000000, \"i\": 8 } }\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withtimestamp");
+        converter = new MongoDataConverter(ArrayEncoding.ARRAY,
+                FieldNameSelector.defaultNonRelationalSelector(SchemaNameAdjuster.NO_OP), false,
+                BsonTimestampHandlingMode.STRUCT);
+
+        Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+        converter.buildSchema(entry, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (Map.Entry<String, BsonValue> bsonValueEntry : val.entrySet()) {
+            converter.buildStruct(bsonValueEntry, finalSchema, struct);
+        }
+
+        assertThat(finalSchema.field("ts_a").schema().name()).isEqualTo(MongoDataConverter.SCHEMA_NAME_TIMESTAMP);
+        final Struct tsA = (Struct) struct.get("ts_a");
+        final Struct tsB = (Struct) struct.get("ts_b");
+        assertThat(tsA.get("time")).isEqualTo(1710000000L);
+        assertThat(tsA.get("increment")).isEqualTo(7);
+        assertThat(tsB.get("time")).isEqualTo(1710000000L);
+        assertThat(tsB.get("increment")).isEqualTo(8);
+        // Two BSON values with the same time and a different increment must stay distinguishable
+        assertThat(tsA).isNotEqualTo(tsB);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2570")
+    public void shouldPreserveBsonTimestampComponentsInArraysInStructMode() {
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"timestamp-array-1\",\n" +
+                "    \"ts_values\" : [ { \"$timestamp\" : { \"t\": 1710000000, \"i\": 7 } }, { \"$timestamp\" : { \"t\": 1710000000, \"i\": 8 } } ]\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withtimestamparray");
+        converter = new MongoDataConverter(ArrayEncoding.ARRAY,
+                FieldNameSelector.defaultNonRelationalSelector(SchemaNameAdjuster.NO_OP), false,
+                BsonTimestampHandlingMode.STRUCT);
+
+        Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+        converter.buildSchema(entry, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (Map.Entry<String, BsonValue> bsonValueEntry : val.entrySet()) {
+            converter.buildStruct(bsonValueEntry, finalSchema, struct);
+        }
+
+        @SuppressWarnings("unchecked")
+        final List<Struct> timestamps = (List<Struct>) struct.get("ts_values");
+        assertThat(timestamps).hasSize(2);
+        assertThat(timestamps.get(0).get("increment")).isEqualTo(7);
+        assertThat(timestamps.get(1).get("increment")).isEqualTo(8);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2570")
+    public void shouldConvertBsonTimestampToConnectTimestampByDefault() {
+        val = BsonDocument.parse("{\n" +
+                "    \"_id\" : \"timestamp-2\",\n" +
+                "    \"ts_a\" : { \"$timestamp\" : { \"t\": 1710000000, \"i\": 7 } },\n" +
+                "    \"ts_b\" : { \"$timestamp\" : { \"t\": 1710000000, \"i\": 8 } }\n" +
+                "}");
+        builder = SchemaBuilder.struct().name("withtimestampdefault");
+        converter = new MongoDataConverter(ArrayEncoding.ARRAY);
+
+        Map<String, Map<Object, BsonType>> entry = converter.parseBsonDocument(val);
+        converter.buildSchema(entry, builder);
+
+        final Schema finalSchema = builder.build();
+        final Struct struct = new Struct(finalSchema);
+        for (Map.Entry<String, BsonValue> bsonValueEntry : val.entrySet()) {
+            converter.buildStruct(bsonValueEntry, finalSchema, struct);
+        }
+
+        assertThat(finalSchema.field("ts_a").schema()).isEqualTo(Timestamp.builder().optional().build());
+        assertThat(struct.get("ts_a")).isEqualTo(new Date(1710000000000L));
+        // The default representation retains only the time component
+        assertThat(struct.get("ts_a")).isEqualTo(struct.get("ts_b"));
     }
 
     @Test

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -477,6 +477,18 @@ The SMT populates each of these index fields with the value that it retrieves fr
 
 For more information about the `array.coding` option, see the xref:mongodb-event-flattening-array-encoding[options for encoding arrays in MongoDB event messages].
 
+|[[mongodb-extract-new-record-state-bson-timestamp-handling-mode]]<<mongodb-extract-new-record-state-bson-timestamp-handling-mode, `bson.timestamp.handling.mode`>>
+|`connect`
+|Specifies how the SMT represents BSON Timestamp values.
+Set one of the following options:
+
+`connect`::
+The SMT converts the value into a Kafka Connect Timestamp that is based on the time component of the BSON value.
+The increment component that MongoDB uses to order operations that occur during the same second is discarded, so distinct BSON values can result in the same output value.
+
+`struct`::
+The SMT emits a structure with the fields `time` and `increment`, preserving both components of the BSON value.
+
 |[[mongodb-extract-new-record-state-flatten-struct]]<<mongodb-extract-new-record-state-flatten-struct, `flatten.struct`>>
 |`false`
 |The SMT flattens structures (structs) in the original event message by concatenating the names of nested properties in the message, separated by a configurable delimiter, to form a simple field name.

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -488,6 +488,15 @@ The increment component that MongoDB uses to order operations that occur during 
 
 `struct`::
 The SMT emits a structure with the fields `time` and `increment`, preserving both components of the BSON value.
++
+[NOTE]
+.Mixed Array Types in Struct Mode
+====
+BSON Timestamp values have a different schema than BSON date/time values.
+Using `array.encoding=array` with an array that mixes both types will trigger an `Array elements with different Bson types are not supported` SMT error.
+
+Workaround: Set `array.encoding=document` to capture arrays with mixed types.
+====
 
 |[[mongodb-extract-new-record-state-flatten-struct]]<<mongodb-extract-new-record-state-flatten-struct, `flatten.struct`>>
 |`false`


### PR DESCRIPTION
Fixes debezium/dbz#2570

## Description

`ExtractNewDocumentState` converts a BSON Timestamp into a Kafka Connect Timestamp using only the BSON `time` component, silently discarding the `increment` component — distinct BSON values such as `Timestamp(1710000000, 7)` and `Timestamp(1710000000, 8)` collapse into the same transformed value.

Since existing consumers may depend on the current representation, this change adds an opt-in option instead of changing the default:

```properties
transforms.unwrap.bson.timestamp.handling.mode=connect  # default, existing behavior
transforms.unwrap.bson.timestamp.handling.mode=struct   # lossless {time, increment} struct
```

In `struct` mode the value is emitted as an `io.debezium.mongodb.timestamp` struct with `time` (INT64, unsigned-widened seconds) and `increment` (INT32) fields, covering scalar values, nested documents, and array elements for both array encodings. The default `connect` mode is unchanged, as is the outbox event router, which keeps using the default.

## Testing

- Unit tests proving that two values with the same `time` and different `increment` stay distinguishable in `struct` mode (scalar and array elements), and that the default mode still emits the Connect Timestamp
- An SMT-level test wiring the new option through `configure()`
- Existing `ExtractNewDocumentStateTestIT` timestamp assertions (default mode) green locally against MongoDB
- Documentation entry added to the event flattening options table

## PR Checklist

- [x] I have read the contribution guidelines and governance document on PR expectations.
- [x] Minimal changes to code not directly related to this change
- [x] One feature/change per PR
- [x] Rebased on upstream main