### PR TITLE
debezium/dbz#2573 Map unhandled STRUCT schema types to JSON column types in JDBC sink

### DIFF
--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -65,6 +65,7 @@ import io.debezium.connector.jdbc.type.connect.ConnectInt64Type;
 import io.debezium.connector.jdbc.type.connect.ConnectInt8Type;
 import io.debezium.connector.jdbc.type.connect.ConnectMapToConnectStringType;
 import io.debezium.connector.jdbc.type.connect.ConnectStringType;
+import io.debezium.connector.jdbc.type.connect.ConnectStructToConnectStringType;
 import io.debezium.connector.jdbc.type.connect.ConnectTimeType;
 import io.debezium.connector.jdbc.type.connect.ConnectTimestampType;
 import io.debezium.connector.jdbc.type.debezium.DateType;
@@ -710,6 +711,7 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         registerType(ConnectTimestampType.INSTANCE);
         registerType(ConnectTimeType.INSTANCE);
         registerType(ConnectMapToConnectStringType.INSTANCE);
+        registerType(ConnectStructToConnectStringType.INSTANCE);
     }
 
     protected void registerType(JdbcType type) {

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialect.java
@@ -53,6 +53,7 @@ import io.debezium.connector.jdbc.naming.ColumnNamingStrategy;
 import io.debezium.connector.jdbc.relational.TableDescriptor;
 import io.debezium.connector.jdbc.type.JdbcType;
 import io.debezium.connector.jdbc.type.connect.AbstractConnectSchemaType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectStructType;
 import io.debezium.connector.jdbc.type.connect.ConnectBooleanType;
 import io.debezium.connector.jdbc.type.connect.ConnectBytesType;
 import io.debezium.connector.jdbc.type.connect.ConnectDateType;
@@ -497,7 +498,9 @@ public class GeneralDatabaseDialect implements DatabaseDialect {
         }
 
         final JdbcType type = typeRegistry.get(schema.type().name());
-        if (!Objects.isNull(type)) {
+        final boolean unsupportedSparseVector = type instanceof AbstractConnectStructType
+                && SparseDoubleVector.LOGICAL_NAME.equals(schema.name());
+        if (!Objects.isNull(type) && !unsupportedSparseVector) {
             LOGGER.trace("Schema type '{}' resolved by name from registry to type '{}'", schema.type().name(), type);
             return type;
         }

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/MySqlDatabaseDialect.java
@@ -120,6 +120,7 @@ public class MySqlDatabaseDialect extends GeneralDatabaseDialect {
         registerType(YearType.INSTANCE);
         registerType(JsonType.INSTANCE);
         registerType(MapToJsonType.INSTANCE);
+        registerType(StructToJsonType.INSTANCE);
         registerType(GeometryType.INSTANCE);
         registerType(PointType.INSTANCE);
         registerType(ZonedTimestampType.INSTANCE);

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructToJsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/mysql/StructToJsonType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.mysql;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectStructType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code STRUCT} schema types that no dedicated handler
+ * is registered for. MySQL cannot create a column for an arbitrary Connect STRUCT, so the value is
+ * serialized to JSON and stored in a native {@code json} column, mirroring how {@code MAP} schema
+ * types are handled. Types registered by schema name (e.g. geometry) keep resolving through their
+ * dedicated handlers first.
+ */
+class StructToJsonType extends AbstractConnectStructType {
+
+    public static final StructToJsonType INSTANCE = new StructToJsonType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return JsonType.INSTANCE.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return JsonType.INSTANCE.getTypeName(schema, isKey);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            value = structToJsonString(struct);
+        }
+        return JsonType.INSTANCE.bind(index, schema, value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleDatabaseDialect.java
@@ -80,6 +80,12 @@ public class OracleDatabaseDialect extends GeneralDatabaseDialect {
         registerType(StructuredZonedTimeType.INSTANCE);
         registerType(StructuredDurationType.INSTANCE);
         registerType(GeometryType.INSTANCE);
+
+        // Oracle 21c and later provide a native JSON column type; route STRUCT values there instead
+        // of the inherited string/CLOB fallback registered by GeneralDatabaseDialect.
+        if (getDatabaseVersion().isSameOrAfter(21)) {
+            registerType(OracleStructToJsonType.INSTANCE);
+        }
     }
 
     @Override

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleStructToJsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/oracle/OracleStructToJsonType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.oracle;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectStructType;
+import io.debezium.connector.jdbc.type.connect.ConnectStringType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code STRUCT} schema types that no dedicated,
+ * schema-named handler is registered for, targeting the native Oracle {@code JSON} column type that
+ * is available in Oracle 21c and later. The struct is serialized to JSON and stored in a
+ * {@code JSON} column; the serialized value is bound exactly as the string-based fallback binds it.
+ * On Oracle 19 and earlier the dialect keeps using {@code ConnectStructToConnectStringType}, which
+ * stores the same JSON text in a string/CLOB column.
+ */
+class OracleStructToJsonType extends AbstractConnectStructType {
+
+    public static final OracleStructToJsonType INSTANCE = new OracleStructToJsonType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return ConnectStringType.INSTANCE.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "json";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            value = structToJsonString(struct);
+        }
+        return ConnectStringType.INSTANCE.bind(index, schema, value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/ArrayType.java
@@ -16,6 +16,7 @@ import org.apache.kafka.connect.data.Struct;
 import io.debezium.connector.jdbc.dialect.DatabaseDialect;
 import io.debezium.connector.jdbc.type.AbstractType;
 import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.StructToJsonConverter;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.sink.valuebinding.ValueBindDescriptor;
 import io.debezium.util.SchemaUtils;
@@ -86,7 +87,19 @@ public class ArrayType extends AbstractType {
             return List.of(new ValueBindDescriptor(index, null));
         }
         final String elementTypeName = baseElementTypeName(getElementTypeName(this.getDialect(), schema, false));
-        return List.of(new ValueBindDescriptor(index, unwrapElements(schema, value), java.sql.Types.ARRAY, elementTypeName));
+        Object elements = unwrapElements(schema, value);
+        if (getDialect().getSchemaType(schema.valueSchema()) instanceof StructToJsonbType) {
+            // Struct elements resolve to a jsonb[] column; serialize each element to a JSON string,
+            // which the driver encodes as a jsonb array value.
+            elements = structElementsToJson((Collection<?>) elements);
+        }
+        return List.of(new ValueBindDescriptor(index, elements, java.sql.Types.ARRAY, elementTypeName));
+    }
+
+    private static List<Object> structElementsToJson(Collection<?> elements) {
+        return elements.stream()
+                .map(element -> element instanceof Struct struct ? (Object) StructToJsonConverter.structToJsonString(struct) : element)
+                .toList();
     }
 
     /**

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/PostgresDatabaseDialect.java
@@ -323,6 +323,7 @@ public class PostgresDatabaseDialect extends GeneralDatabaseDialect {
         registerType(XmlType.INSTANCE);
         registerType(LtreeType.INSTANCE);
         registerType(MapToHstoreType.INSTANCE);
+        registerType(StructToJsonbType.INSTANCE);
         registerType(ArrayType.INSTANCE);
 
         // Allows binding string-based types if column type propagation is enabled

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructToJsonbType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/postgres/StructToJsonbType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.postgres;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectStructType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code STRUCT} schema types that no dedicated handler
+ * is registered for. PostgreSQL cannot create a column for an arbitrary Connect STRUCT, so the
+ * value is serialized to JSON and stored in a native {@code jsonb} column, mirroring how {@code MAP}
+ * schema types are handled. Types registered by schema name (e.g. geometry) keep resolving through
+ * their dedicated handlers first.
+ */
+class StructToJsonbType extends AbstractConnectStructType {
+
+    public static final StructToJsonbType INSTANCE = new StructToJsonbType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return "cast(? as jsonb)";
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return "jsonb";
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            value = structToJsonString(struct);
+        }
+        return List.of(new ValueBindDescriptor(index, value));
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/SingleStoreDatabaseDialect.java
@@ -52,6 +52,7 @@ public class SingleStoreDatabaseDialect extends MariaDbDatabaseDialect {
         registerType(JsonType.INSTANCE);
         registerType(ArrayToJsonType.INSTANCE);
         registerType(MapToJsonType.INSTANCE);
+        registerType(StructToJsonType.INSTANCE);
         registerType(GeometryType.INSTANCE);
         registerType(PointType.INSTANCE);
         registerType(FloatVectorType.INSTANCE);

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/StructToJsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/singlestore/StructToJsonType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.singlestore;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectStructType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code STRUCT} schema types that no dedicated handler
+ * is registered for. The value is serialized to JSON and stored in a SingleStore {@code JSON}
+ * column, mirroring how {@code MAP} schema types are handled. SingleStore binds JSON values
+ * without a cast, so this delegates to the SingleStore {@link JsonType} rather than inheriting
+ * the MySQL {@code STRUCT} handler.
+ */
+class StructToJsonType extends AbstractConnectStructType {
+
+    public static final StructToJsonType INSTANCE = new StructToJsonType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return JsonType.INSTANCE.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return JsonType.INSTANCE.getTypeName(schema, isKey);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            value = structToJsonString(struct);
+        }
+        return JsonType.INSTANCE.bind(index, schema, value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StarRocksDatabaseDialect.java
@@ -159,6 +159,7 @@ public class StarRocksDatabaseDialect extends GeneralDatabaseDialect {
         registerType(YearType.INSTANCE);
         registerType(JsonType.INSTANCE);
         registerType(MapToJsonType.INSTANCE);
+        registerType(StructToJsonType.INSTANCE);
         registerType(TimeType.INSTANCE);
         registerType(MicroTimeType.INSTANCE);
         registerType(NanoTimeType.INSTANCE);

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StructToJsonType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/dialect/starrocks/StructToJsonType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.starrocks;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.AbstractConnectStructType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code STRUCT} schema types that no dedicated handler
+ * is registered for. StarRocks cannot create a column for an arbitrary Connect STRUCT, so the
+ * value is serialized to JSON and stored in a StarRocks {@code JSON} column, mirroring how
+ * {@code MAP} schema types are handled by {@link MapToJsonType}.
+ */
+class StructToJsonType extends AbstractConnectStructType {
+
+    public static final StructToJsonType INSTANCE = new StructToJsonType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return JsonType.INSTANCE.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return JsonType.INSTANCE.getTypeName(schema, isKey);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            value = structToJsonString(struct);
+        }
+        return JsonType.INSTANCE.bind(index, schema, value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/AbstractConnectStructType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/AbstractConnectStructType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type.connect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.util.StructToJsonConverter;
+
+/**
+ * An implementation of {@link JdbcType} for {@code STRUCT} schema types that no dedicated,
+ * schema-named handler is registered for. This is created as an abstract implementation as it is
+ * expected that each dialect will create its own implementation as the logic to handle struct-based
+ * schema types differs by dialect.
+ */
+public abstract class AbstractConnectStructType extends AbstractConnectSchemaType {
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{ "STRUCT" };
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        // No default value is permitted
+        return null;
+    }
+
+    protected String structToJsonString(Struct struct) {
+        return StructToJsonConverter.structToJsonString(struct);
+    }
+
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectStructToConnectStringType.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/type/connect/ConnectStructToConnectStringType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.type.connect;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.sink.column.ColumnDescriptor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * An implementation of {@link JdbcType} for {@code STRUCT} schema types that no dedicated handler
+ * is registered for, mapped to the dialect's connect string-based type as a JSON text value,
+ * mirroring how {@code MAP} schema types fall back to {@link ConnectMapToConnectStringType}.
+ * Dialects with a native JSON column type override this with their own {@code STRUCT} handler,
+ * and types registered by schema name (e.g. geometry) keep resolving through their dedicated
+ * handlers first.
+ */
+public class ConnectStructToConnectStringType extends AbstractConnectStructType {
+
+    public static final ConnectStructToConnectStringType INSTANCE = new ConnectStructToConnectStringType();
+
+    @Override
+    public String getQueryBinding(ColumnDescriptor column, Schema schema, Object value) {
+        return ConnectStringType.INSTANCE.getQueryBinding(column, schema, value);
+    }
+
+    @Override
+    public String getTypeName(Schema schema, boolean isKey) {
+        return ConnectStringType.INSTANCE.getTypeName(schema, isKey);
+    }
+
+    @Override
+    public String getDefaultValueBinding(Schema schema, Object value) {
+        return ConnectStringType.INSTANCE.getDefaultValueBinding(schema, value);
+    }
+
+    @Override
+    public List<ValueBindDescriptor> bind(int index, Schema schema, Object value) {
+        if (value instanceof Struct struct) {
+            value = structToJsonString(struct);
+        }
+        return ConnectStringType.INSTANCE.bind(index, schema, value);
+    }
+}

--- a/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/util/StructToJsonConverter.java
+++ b/debezium-connector-jdbc/src/main/java/io/debezium/connector/jdbc/util/StructToJsonConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.util;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility helper that serializes a Kafka Connect {@link Struct} to a JSON string, so the value can
+ * be stored in the dialect's JSON or string column type. Nested structs, collections, and maps are
+ * converted recursively; scalar values keep Jackson's default representation (binary data as
+ * Base64, decimals as numbers, dates as epoch milliseconds).
+ */
+public class StructToJsonConverter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private StructToJsonConverter() {
+    }
+
+    /**
+     * Serializes the given struct to a JSON string.
+     *
+     * @param struct the struct to serialize; may not be null
+     * @return the JSON representation of the struct
+     */
+    public static String structToJsonString(Struct struct) {
+        try {
+            return MAPPER.writeValueAsString(toJsonValue(struct));
+        }
+        catch (JsonProcessingException e) {
+            throw new ConnectException("Failed to serialize STRUCT data to JSON", e);
+        }
+    }
+
+    private static Object toJsonValue(Object value) {
+        if (value instanceof Struct struct) {
+            final Map<String, Object> result = new LinkedHashMap<>();
+            for (Field field : struct.schema().fields()) {
+                result.put(field.name(), toJsonValue(struct.get(field)));
+            }
+            return result;
+        }
+        if (value instanceof List<?> list) {
+            final List<Object> result = new ArrayList<>(list.size());
+            for (Object element : list) {
+                result.add(toJsonValue(element));
+            }
+            return result;
+        }
+        if (value instanceof Map<?, ?> map) {
+            final Map<Object, Object> result = new LinkedHashMap<>();
+            map.forEach((key, mapValue) -> result.put(key, toJsonValue(mapValue)));
+            return result;
+        }
+        if (value instanceof ByteBuffer buffer) {
+            // Unwrap to byte[], which Jackson serializes as Base64 like any other binary value.
+            final ByteBuffer slice = buffer.slice();
+            final byte[] bytes = new byte[slice.remaining()];
+            slice.get(bytes);
+            return bytes;
+        }
+        return value;
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialectTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/GeneralDatabaseDialectTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.engine.jdbc.connections.internal.UserSuppliedConnectionProviderImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.dialect.postgres.PostgresDatabaseDialect;
+import io.debezium.connector.jdbc.type.connect.ConnectStructToConnectStringType;
+import io.debezium.connector.jdbc.type.debezium.VariableScaleDecimalType;
+import io.debezium.data.VariableScaleDecimal;
+import io.debezium.data.vector.DoubleVector;
+import io.debezium.data.vector.FloatVector;
+import io.debezium.data.vector.SparseDoubleVector;
+import io.debezium.doc.FixFor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+@Tag("UnitTests")
+class GeneralDatabaseDialectTest {
+
+    private StandardServiceRegistry registry;
+    private SessionFactory sessionFactory;
+    private JdbcSinkConnectorConfig config;
+    private GeneralDatabaseDialect dialect;
+
+    @BeforeEach
+    void beforeEach() {
+        // Type resolution needs real Hibernate metadata, but no database connection.
+        registry = new StandardServiceRegistryBuilder()
+                .applySetting(AvailableSettings.DIALECT, PostgreSQLDialect.class.getName())
+                .applySetting(AvailableSettings.ALLOW_METADATA_ON_BOOT, false)
+                .applySetting(AvailableSettings.CONNECTION_PROVIDER, UserSuppliedConnectionProviderImpl.class.getName())
+                .build();
+        sessionFactory = new MetadataSources(registry).buildMetadata().buildSessionFactory();
+        config = new JdbcSinkConnectorConfig(Map.of(
+                "connection.url", "jdbc:postgresql://localhost/unused",
+                "connection.username", "unused"));
+        dialect = new GeneralDatabaseDialect(config, sessionFactory);
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (sessionFactory != null) {
+            sessionFactory.close();
+        }
+        StandardServiceRegistryBuilder.destroy(registry);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "com.example.Order")
+    @FixFor("debezium/dbz#2573")
+    void shouldSerializeAnonymousAndNamedStructs(String schemaName) {
+        final var builder = SchemaBuilder.struct().field("sku", Schema.STRING_SCHEMA);
+        if (schemaName != null) {
+            builder.name(schemaName);
+        }
+        final var schema = builder.build();
+        final var type = dialect.getSchemaType(schema);
+
+        assertThat(type).isSameAs(ConnectStructToConnectStringType.INSTANCE);
+        assertThat(type.bind(1, schema, new Struct(schema).put("sku", "A")))
+                .extracting(ValueBindDescriptor::getValue)
+                .containsExactly("{\"sku\":\"A\"}");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    @FixFor("debezium/dbz#2573")
+    void shouldRejectUnsupportedSparseVector(boolean propagateColumnType) {
+        final var builder = SparseDoubleVector.builder();
+        if (propagateColumnType) {
+            builder.parameter("__debezium.source.column.type", "sparsevec");
+        }
+        assertThatThrownBy(() -> dialect.getSchemaType(builder.build()))
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Dialect does not support schema type " + SparseDoubleVector.LOGICAL_NAME)
+                .hasMessageContaining("VectorToJsonConverter");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2573")
+    void shouldKeepDedicatedLogicalTypeMappings() {
+        assertThat(dialect.getSchemaType(VariableScaleDecimal.schema()))
+                .isSameAs(VariableScaleDecimalType.INSTANCE);
+
+        final var postgres = new PostgresDatabaseDialect.PostgresDatabaseDialectProvider().instantiate(config, sessionFactory);
+        final var schema = SparseDoubleVector.schema();
+        assertThat(postgres.getSchemaType(schema).getTypeName(schema, false)).isEqualTo("sparsevec");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2573")
+    void shouldKeepUnsupportedDenseVectorErrors() {
+        for (Schema schema : List.of(FloatVector.schema(), DoubleVector.schema())) {
+            assertThatThrownBy(() -> dialect.getSchemaType(schema))
+                    .isInstanceOf(ConnectException.class)
+                    .hasMessageContaining("Dialect does not support schema type " + schema.name());
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/oracle/OracleStructToJsonTypeTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/dialect/oracle/OracleStructToJsonTypeTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.dialect.oracle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.engine.jdbc.connections.internal.UserSuppliedConnectionProviderImpl;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.jdbc.JdbcSinkConnectorConfig;
+import io.debezium.connector.jdbc.dialect.DatabaseDialect;
+import io.debezium.connector.jdbc.type.JdbcType;
+import io.debezium.connector.jdbc.type.connect.ConnectStructToConnectStringType;
+import io.debezium.doc.FixFor;
+import io.debezium.sink.valuebinding.ValueBindDescriptor;
+
+/**
+ * Verifies that {@link OracleDatabaseDialect} routes {@code STRUCT} schema types to the native Oracle
+ * {@code JSON} column type on Oracle 21c and later, and to the string/CLOB fallback on Oracle 19 and
+ * earlier. The dialect version is forced through Hibernate, so no database connection is required.
+ *
+ * @author minleejae
+ */
+class OracleStructToJsonTypeTest {
+
+    private static final Schema STRUCT_SCHEMA = SchemaBuilder.struct()
+            .field("sku", Schema.STRING_SCHEMA)
+            .field("quantity", Schema.INT32_SCHEMA)
+            .build();
+
+    @Test
+    @FixFor("debezium/dbz#2573")
+    void shouldMapStructToNativeJsonOnOracle21OrLater() {
+        final JdbcType type = resolveStructType(21);
+        assertThat(type).isSameAs(OracleStructToJsonType.INSTANCE);
+        assertThat(type.getTypeName(STRUCT_SCHEMA, false)).isEqualTo("json");
+        // The serialized value is bound exactly as the string fallback binds it.
+        assertThat(type.bind(1, STRUCT_SCHEMA, new Struct(STRUCT_SCHEMA).put("sku", "A").put("quantity", 1)))
+                .extracting(ValueBindDescriptor::getValue)
+                .containsExactly("{\"sku\":\"A\",\"quantity\":1}");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2573")
+    void shouldMapStructToStringFallbackBeforeOracle21() {
+        final JdbcType type = resolveStructType(19);
+        assertThat(type).isSameAs(ConnectStructToConnectStringType.INSTANCE);
+        assertThat(type.getTypeName(STRUCT_SCHEMA, false)).isNotEqualTo("json");
+    }
+
+    private static JdbcType resolveStructType(int majorVersion) {
+        StandardServiceRegistry registry = null;
+        SessionFactory sessionFactory = null;
+        try {
+            // Type resolution needs real Hibernate metadata, but no database connection; forcing the
+            // OracleDialect version drives the version-conditional type registration.
+            registry = new StandardServiceRegistryBuilder()
+                    .applySetting(AvailableSettings.DIALECT, new OracleDialect(DatabaseVersion.make(majorVersion)))
+                    .applySetting(AvailableSettings.ALLOW_METADATA_ON_BOOT, false)
+                    .applySetting(AvailableSettings.CONNECTION_PROVIDER, UserSuppliedConnectionProviderImpl.class.getName())
+                    .build();
+            sessionFactory = new MetadataSources(registry).buildMetadata().buildSessionFactory();
+            final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(Map.of(
+                    "connection.url", "jdbc:oracle:thin:@localhost:1521/unused",
+                    "connection.username", "unused"));
+            final DatabaseDialect dialect = new OracleDatabaseDialect.OracleDatabaseDialectProvider()
+                    .instantiate(config, sessionFactory);
+            return dialect.getSchemaType(STRUCT_SCHEMA);
+        }
+        finally {
+            if (sessionFactory != null) {
+                sessionFactory.close();
+            }
+            if (registry != null) {
+                StandardServiceRegistryBuilder.destroy(registry);
+            }
+        }
+    }
+}

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/cockroachdb/JdbcSinkColumnTypeMappingIT.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -291,6 +292,45 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         getSink().assertRows(destinationTable, rs -> {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getArray(2).getArray()).isEqualTo(new Boolean[]{ false, true });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldWorkWithStructAsJsonb(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                structSchema,
+                new Struct(structSchema).put("sku", "A").put("quantity", 1),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "jsonb");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).contains("\"sku\": \"A\"").contains("\"quantity\": 1");
             return null;
         });
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/mysql/JdbcSinkColumnTypeMappingIT.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,6 +51,46 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
 
     public JdbcSinkColumnTypeMappingIT(Sink sink) {
         super(sink);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldWorkWithStructAsJson(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server1", "schema", tableName);
+
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                structSchema,
+                new Struct(structSchema).put("sku", "A").put("quantity", 1),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "json");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo("{\"sku\": \"A\", \"quantity\": 1}");
+            return null;
+        });
     }
 
     @ParameterizedTest

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/oracle/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/oracle/JdbcSinkColumnTypeMappingIT.java
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -129,4 +130,43 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             return null;
         });
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldWorkWithStructAsJsonText(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                structSchema,
+                new Struct(structSchema).put("sku", "A").put("quantity", 1),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo("{\"sku\":\"A\",\"quantity\":1}");
+            return null;
+        });
+    }
+
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/postgres/JdbcSinkColumnTypeMappingIT.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -488,6 +489,96 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
         getSink().assertRows(destinationTable, rs -> {
             assertThat(rs.getInt(1)).isEqualTo(1);
             assertThat(rs.getArray(2).getArray()).isEqualTo(new Integer[]{ 1, 2, 42 });
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldWorkWithStructAsJsonb(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                structSchema,
+                new Struct(structSchema).put("sku", "A").put("quantity", 1),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "data", "jsonb");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo("{\"sku\": \"A\", \"quantity\": 1}");
+            return null;
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PostgresInsertModeArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldWorkWithStructArrayAsJsonbArray(SinkRecordFactory factory, PostgresInsertMode insertMode) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.NONE.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        properties.put(JdbcSinkConnectorConfig.POSTGRES_UNNEST_INSERT, String.valueOf(insertMode.isUnnestEnabled()));
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                SchemaBuilder.array(structSchema).optional().build(),
+                Arrays.asList(
+                        new Struct(structSchema).put("sku", "A").put("quantity", 1),
+                        null,
+                        new Struct(structSchema).put("sku", "B").put("quantity", 2)),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        final String sql = "CREATE TABLE %s (id int not null, data jsonb[], primary key(id))";
+        getSink().execute(String.format(sql, destinationTable));
+
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getArray(2).getArray()).isEqualTo(new String[]{
+                    "{\"sku\": \"A\", \"quantity\": 1}",
+                    null,
+                    "{\"sku\": \"B\", \"quantity\": 2}" });
             return null;
         });
     }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkJsonTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/singlestore/JdbcSinkJsonTypeMappingIT.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +26,7 @@ import io.debezium.connector.jdbc.junit.jupiter.Sink;
 import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.data.Json;
+import io.debezium.doc.FixFor;
 
 /**
  * JSON type mappings for SingleStore.
@@ -74,4 +76,44 @@ public class JdbcSinkJsonTypeMappingIT extends AbstractJdbcSinkTest {
             return null;
         });
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldCreateAndWriteStructAsJsonColumnType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("struct_data"),
+                List.of(structSchema),
+                List.of(new Struct(structSchema).put("sku", "A").put("quantity", 1)),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "struct_data", "JSON");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("struct_data")).contains("\"sku\"").contains("\"quantity\"");
+            return null;
+        });
+    }
+
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/sqlserver/JdbcSinkColumnTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/sqlserver/JdbcSinkColumnTypeMappingIT.java
@@ -11,6 +11,8 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,4 +83,43 @@ public class JdbcSinkColumnTypeMappingIT extends AbstractJdbcSinkTest {
             return null;
         });
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldWorkWithStructAsJsonText(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        final JdbcSinkConnectorConfig config = getConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                "data",
+                structSchema,
+                new Struct(structSchema).put("sku", "A").put("quantity", 1),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+        consume(createRecord);
+
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getString(2)).isEqualTo("{\"sku\":\"A\",\"quantity\":1}");
+            return null;
+        });
+    }
+
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkJsonTypeMappingIT.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/integration/starrocks/JdbcSinkJsonTypeMappingIT.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +26,7 @@ import io.debezium.connector.jdbc.junit.jupiter.SinkRecordFactoryArgumentsProvid
 import io.debezium.connector.jdbc.junit.jupiter.StarRocksSinkDatabaseContextProvider;
 import io.debezium.connector.jdbc.util.SinkRecordFactory;
 import io.debezium.data.Json;
+import io.debezium.doc.FixFor;
 
 /**
  * JSON type mappings for StarRocks.
@@ -74,4 +76,44 @@ public class JdbcSinkJsonTypeMappingIT extends AbstractJdbcSinkTest {
             return null;
         });
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(SinkRecordFactoryArgumentsProvider.class)
+    @FixFor("debezium/dbz#2573")
+    public void testShouldCreateAndWriteStructAsJsonColumnType(SinkRecordFactory factory) throws Exception {
+        final Map<String, String> properties = getDefaultSinkConfig();
+        properties.put(JdbcSinkConnectorConfig.SCHEMA_EVOLUTION, JdbcSinkConnectorConfig.SchemaEvolutionMode.BASIC.getValue());
+        properties.put(JdbcSinkConnectorConfig.PRIMARY_KEY_MODE, JdbcSinkConnectorConfig.PrimaryKeyMode.RECORD_KEY.getValue());
+        properties.put(JdbcSinkConnectorConfig.INSERT_MODE, JdbcSinkConnectorConfig.InsertMode.UPSERT.getValue());
+        startSinkConnector(properties);
+        assertSinkConnectorIsRunning();
+
+        final String tableName = randomTableName();
+        final String topicName = topicName("server2", "schema", tableName);
+        final Schema structSchema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .optional()
+                .build();
+
+        final JdbcSinkConnectorConfig config = new JdbcSinkConnectorConfig(properties);
+        final JdbcKafkaSinkRecord createRecord = factory.createRecordWithSchemaValue(
+                topicName,
+                (byte) 1,
+                List.of("struct_data"),
+                List.of(structSchema),
+                List.of(new Struct(structSchema).put("sku", "A").put("quantity", 1)),
+                config);
+
+        final String destinationTable = destinationTableName(createRecord);
+
+        consume(createRecord);
+
+        getSink().assertColumn(destinationTable, "struct_data", "JSON");
+        getSink().assertRows(destinationTable, rs -> {
+            assertThat(rs.getString("struct_data")).contains("\"sku\"").contains("\"quantity\"");
+            return null;
+        });
+    }
+
 }

--- a/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/util/StructToJsonConverterTest.java
+++ b/debezium-connector-jdbc/src/test/java/io/debezium/connector/jdbc/util/StructToJsonConverterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.jdbc.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit tests for the {@link StructToJsonConverter} helper.
+ */
+@Tag("UnitTests")
+class StructToJsonConverterTest {
+
+    @Test
+    @FixFor("debezium/dbz#2573")
+    @DisplayName("Should serialize scalar, decimal, binary, and null fields")
+    void testSerializesScalarFields() {
+        final Schema schema = SchemaBuilder.struct()
+                .field("sku", Schema.STRING_SCHEMA)
+                .field("quantity", Schema.INT32_SCHEMA)
+                .field("price", Decimal.schema(2))
+                .field("payload", Schema.OPTIONAL_BYTES_SCHEMA)
+                .field("missing", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        final Struct struct = new Struct(schema)
+                .put("sku", "A")
+                .put("quantity", 1)
+                .put("price", new BigDecimal("1.25"))
+                .put("payload", ByteBuffer.wrap(new byte[]{ 1, 2 }));
+
+        assertThat(StructToJsonConverter.structToJsonString(struct))
+                .isEqualTo("{\"sku\":\"A\",\"quantity\":1,\"price\":1.25,\"payload\":\"AQI=\",\"missing\":null}");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2573")
+    @DisplayName("Should serialize nested structs, arrays, and maps recursively")
+    void testSerializesNestedValues() {
+        final Schema profileSchema = SchemaBuilder.struct()
+                .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+                .optional()
+                .build();
+        final Schema schema = SchemaBuilder.struct()
+                .field("profile", profileSchema)
+                .field("tags", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+                .field("attributes", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA).optional().build())
+                .build();
+        final Struct struct = new Struct(schema)
+                .put("profile", new Struct(profileSchema).put("name", "Alice"))
+                .put("tags", List.of("a", "b"))
+                .put("attributes", Map.of("height", 42));
+
+        assertThat(StructToJsonConverter.structToJsonString(struct))
+                .isEqualTo("{\"profile\":{\"name\":\"Alice\"},\"tags\":[\"a\",\"b\"],\"attributes\":{\"height\":42}}");
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -124,6 +124,17 @@ In addition, the payload of the source message must be a `Struct` that has eithe
 
 If the structure of the events in the Kafka topic do not adhere to these rules, you must implement a custom single message transformation to convert the structure of the source events into a usable format.
 
+When an event field is a Kafka Connect `STRUCT` for which no dedicated column type is registered, the connector serializes the structure to JSON and stores it in a JSON-capable column:
+
+* **Native JSON dialects** (MySQL, PostgreSQL, SingleStore, StarRocks, CockroachDB, Oracle 21c+): Written directly to native `JSON` or `jsonb` columns.
+* **Non-native JSON dialects** (Oracle 19c and earlier, Db2, SQL Server): Stored as JSON text in a large character column, such as `CLOB` or `LONGTEXT`.
+
+[NOTE]
+====
+Large character types such as `CLOB` and `LONGTEXT` are typically stored out-of-row, which can reduce write performance.
+If you can guarantee that the serialized `STRUCT` value does not exceed a fixed length, you can improve write performance by pre-creating the target column ahead of time as an in-row bounded type, such as `VARCHAR(n)`.
+====
+
 // Type: concept
 // Title: Description of how the {prodname} JDBC connector handles primary keys in source events
 // ModuleID: debezium-jdbc-connector-description-of-how-the-connector-handles-primary-keys-in-source-events
@@ -495,7 +506,10 @@ StarRocks `VARCHAR` lengths are byte lengths rather than character lengths, so t
 When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to `LARGEINT` columns, preserving the full unsigned 64-bit range.
 
 {prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` and `STRUCT` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
-The StarRocks dialect does not support geospatial or vector logical types, and the Kafka Connect `ARRAY` schema type is not mapped to the StarRocks `ARRAY` column type; `STRUCT` values are stored as `JSON` rather than as the StarRocks `STRUCT` column type.
+The StarRocks dialect does not map geospatial or vector logical types to native StarRocks column types.
+Because geospatial values are struct-based, they are serialized to `JSON` like other `STRUCT` values rather than being rejected.
+
+The Kafka Connect `ARRAY` schema type is not mapped to the StarRocks `ARRAY` column type, and `STRUCT` values are stored as `JSON` rather than as the native StarRocks `STRUCT` column type.
 
 [[jdbc-cockroachdb-targets]]
 === CockroachDB sink targets

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -450,7 +450,7 @@ If xref:jdbc-property-schema-evolution[`schema.evolution`] is set to `basic`, th
 Automatic table creation does not expose SingleStore-specific shard key, sort key, or other table option settings.
 If the target table requires explicit shard keys, sort keys, or other SingleStore table options, create the destination table in SingleStore before the connector writes to it.
 
-For SingleStore targets, {prodname} maps {prodname} `io.debezium.data.Json` logical values and Kafka Connect `ARRAY` and `MAP` schema values to the SingleStore `JSON` column type.
+For SingleStore targets, {prodname} maps {prodname} `io.debezium.data.Json` logical values and Kafka Connect `ARRAY`, `MAP`, and `STRUCT` schema values to the SingleStore `JSON` column type.
 The connector maps {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values to the SingleStore `GEOGRAPHY` column type, and `io.debezium.data.geometry.Point` logical values to the SingleStore `GEOGRAPHYPOINT` column type.
 SingleStore supports a subset of WKT geospatial values.
 The connector writes `POINT`, `LINESTRING`, and `POLYGON` WKB values to SingleStore as WKT strings.
@@ -494,8 +494,8 @@ StarRocks `VARCHAR` lengths are byte lengths rather than character lengths, so t
 `DECIMAL` columns support a maximum precision of 38; the connector caps larger propagated precisions at 38, and values that exceed the capped precision fail on write.
 When column type propagation is enabled, `BIGINT UNSIGNED` source columns map to `LARGEINT` columns, preserving the full unsigned 64-bit range.
 
-{prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
-The StarRocks dialect does not support geospatial or vector logical types, and Kafka Connect `ARRAY` and `STRUCT` schema types are not mapped to the StarRocks `ARRAY` and `STRUCT` column types.
+{prodname} `io.debezium.data.Json` logical values and Kafka Connect `MAP` and `STRUCT` schema values map to the StarRocks `JSON` column type, `ENUM` and `SET` values map to `STRING` columns, and `YEAR` values map to `INT` columns.
+The StarRocks dialect does not support geospatial or vector logical types, and the Kafka Connect `ARRAY` schema type is not mapped to the StarRocks `ARRAY` column type; `STRUCT` values are stored as `JSON` rather than as the StarRocks `STRUCT` column type.
 
 [[jdbc-cockroachdb-targets]]
 === CockroachDB sink targets
@@ -513,7 +513,7 @@ Setting `flush.max.retries` to `0` disables the retries so that a conflicting fl
 
 For CockroachDB targets, {prodname} uses PostgreSQL-compatible mappings for most data types, with the following exceptions:
 
-* `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to the CockroachDB `jsonb` column type.
+* `io.debezium.data.Json` logical values and Kafka Connect `MAP` and `STRUCT` schema values are written to the CockroachDB `jsonb` column type.
 * `io.debezium.data.Xml` logical values and propagated range, `macaddr`, and `cidr` column types are written as `text`, because CockroachDB does not provide those types.
 * Propagated `money` column types are written as `decimal(19,2)` types.
 * `io.debezium.data.geometry.Geometry`, `io.debezium.data.geometry.Geography`, and `io.debezium.data.geometry.Point` logical values are written to the built-in CockroachDB `geometry` and `geography` types; no PostGIS extension schema is required.
@@ -943,13 +943,13 @@ ifdef::community[]
 For SingleStore targets, {prodname} uses MySQL/MariaDB-compatible mappings for most dialect-specific logical types.
 SingleStore maps {prodname} `io.debezium.data.Json` logical values to `json`.
 
-Kafka Connect `MAP` schema values are also written to SingleStore `json` columns.
+Kafka Connect `MAP` and `STRUCT` schema values are also written to SingleStore `json` columns.
 {prodname} `io.debezium.data.geometry.Geometry` and `io.debezium.data.geometry.Geography` logical values are written to SingleStore `geography` columns, and `io.debezium.data.geometry.Point` logical values are written to SingleStore `geographypoint` columns.
 
 When you configure the JDBC connector to use CockroachDB as a sink target, {prodname} uses the PostgreSQL-compatible mappings for most dialect-specific logical types.
 For example, the connector uses the following mappings:
 
-* `io.debezium.data.Json` logical values and Kafka Connect `MAP` schema values are written to CockroachDB `jsonb` columns.
+* `io.debezium.data.Json` logical values and Kafka Connect `MAP` and `STRUCT` schema values are written to CockroachDB `jsonb` columns.
 * `io.debezium.data.Xml` logical values are written to `text` columns because CockroachDB has no XML type.
 * Geometry, geography, and point values are written to the built-in CockroachDB `geometry` and `geography` types without a PostGIS extension schema.
 * `io.debezium.data.FloatVector` logical values are written to `vector` columns; sparse double vectors are not supported.


### PR DESCRIPTION
Fixes debezium/dbz#2573

## Description

The JDBC sink has no handler registered for the Connect `STRUCT` schema type. A field with an anonymous struct schema (one not registered by schema name, e.g. a nested document flattened out of a MongoDB source event or a struct produced by an SMT) fails schema resolution and stops the connector task. `MAP` schema values are already serialized to JSON and stored in each dialect's JSON or string column type; this change gives `STRUCT` values the same default treatment.

- A new `AbstractConnectStructType` base (mirroring `AbstractConnectMapType`) registers the `STRUCT` schema type and serializes the value to a JSON string through a shared converter: nested structs, collections, and maps are converted recursively, and scalars keep Jackson's default representation (binary as Base64, decimals as numbers).
- Dialects with a native JSON column type register their own handler: PostgreSQL `jsonb` (inherited by CockroachDB), MySQL `json` (inherited by MariaDB), SingleStore `JSON` (bound without a cast, like its `MAP` handler), StarRocks `JSON`, and Oracle 21c and later `JSON`.
- Oracle versions before 21c use the `ConnectStructToConnectStringType` fallback and store JSON text in `CLOB` columns. Other dialects without a native handler use the same fallback, mirroring `ConnectMapToConnectStringType`, with their connect string-based column type.
- On PostgreSQL, `ARRAY<STRUCT>` fields resolve to `jsonb[]` columns and the `ArrayType` handler serializes each struct element before binding.
- Types registered by schema name (geometry, vector, structured temporal types, ...) keep resolving through their dedicated handlers first, so only struct schemas that previously failed resolution are affected.

## Testing

- `StructToJsonConverterTest` unit tests for the JSON serialization (scalar, decimal, binary, null, and nested struct/array/map fields)
- `JdbcSinkColumnTypeMappingIT` additions per dialect: PostgreSQL (`jsonb` scalar and `jsonb[]` array across all four insert modes), MySQL, SQL Server, Oracle, and CockroachDB; `JdbcSinkJsonTypeMappingIT` additions for StarRocks and SingleStore
- `OracleStructToJsonTypeTest` unit tests for Oracle 21c native JSON routing and the earlier-version string/CLOB fallback
- `JdbcSinkGeometricTypesIT` run to verify schema-named STRUCT types keep their dedicated mappings

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

