### PR TITLE
debezium/dbz#2439 Add version.tidb.driver property for central driver maintenance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
         <version.postgresql.driver>42.7.13</version.postgresql.driver>
         <version.mysql.driver>9.1.0</version.mysql.driver>
         <version.mysql.binlog>0.41.3</version.mysql.binlog>
+        <version.tidb.driver>9.4.0</version.tidb.driver> <!-- MySQL driver used by the TiDB connector, may diverge from version.mysql.driver -->
         <version.singlestore.driver>1.2.11</version.singlestore.driver>
         <version.starrocks.driver>1.1.1</version.starrocks.driver>
         <version.mongo.driver>5.9.2</version.mongo.driver>


### PR DESCRIPTION
Follow up to a review suggestion by @Naros on debezium/debezium-connector-tidb#5: maintain the TiDB connector's driver version centrally in debezium-parent like the other database drivers, with a `tidb` specifier so it can diverge from `version.mysql.driver` if needed.

The TiDB connector uses the MySQL driver to reach TiDB's MySQL compatible SQL endpoint for snapshots. Once this property ships in the parent, the local property in the connector repo will be removed.