### PR TITLE
debezium/dbz#2537 Add captured tables in initial snapshot new notification

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationService.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationService.java
@@ -60,11 +60,23 @@ public class IncrementalSnapshotNotificationService<P extends Partition, O exten
 
     public <T extends DataCollectionId> void notifyStarted(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext) {
 
+        @Deprecated(forRemoval = true)
         String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
                 .map(DataCollectionId::identifier)
                 .collect(Collectors.joining(LIST_DELIMITER));
 
         notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.STARTED,
+                Map.of(DATA_COLLECTIONS, dataCollections), offsetContext), Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyDataCollectionsResolved(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition,
+                                                                           OffsetContext offsetContext) {
+
+        String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
+                .map(DataCollectionId::identifier)
+                .collect(Collectors.joining(LIST_DELIMITER));
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.DATA_COLLECTIONS_RESOLVED,
                 Map.of(DATA_COLLECTIONS, dataCollections), offsetContext), Offsets.of(partition, offsetContext));
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/InitialSnapshotNotificationService.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/InitialSnapshotNotificationService.java
@@ -155,7 +155,7 @@ public class InitialSnapshotNotificationService<P extends Partition, O extends O
                 .map(DataCollectionId::identifier)
                 .collect(Collectors.joining(LIST_DELIMITER));
 
-        notificationService.notify(buildNotificationWith("DATA_COLLECTIONS_RESOLVED",
+        notificationService.notify(buildNotificationWith(SnapshotStatus.DATA_COLLECTIONS_RESOLVED.name(),
                 Map.of(DATA_COLLECTIONS, dataCollections)), Offsets.of(partition, offsetContext));
     }
 

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/InitialSnapshotNotificationService.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/InitialSnapshotNotificationService.java
@@ -149,6 +149,16 @@ public class InitialSnapshotNotificationService<P extends Partition, O extends O
                 Map.of()), Offsets.of(partition, offsetContext));
     }
 
+    public <T extends DataCollectionId> void notifyDataCollectionsResolved(P partition, OffsetContext offsetContext, Set<T> capturedDataCollections) {
+
+        String dataCollections = capturedDataCollections.stream()
+                .map(DataCollectionId::identifier)
+                .collect(Collectors.joining(LIST_DELIMITER));
+
+        notificationService.notify(buildNotificationWith("DATA_COLLECTIONS_RESOLVED",
+                Map.of(DATA_COLLECTIONS, dataCollections)), Offsets.of(partition, offsetContext));
+    }
+
     public <T extends DataCollectionId> void notifyAborted(P partition, OffsetContext offsetContext) {
 
         notificationService.notify(buildNotificationWith(SnapshotResult.SnapshotResultStatus.ABORTED.name(),

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/SnapshotStatus.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/notification/SnapshotStatus.java
@@ -7,6 +7,7 @@ package io.debezium.pipeline.notification;
 
 public enum SnapshotStatus {
     STARTED,
+    DATA_COLLECTIONS_RESOLVED,
     PAUSED,
     RESUMED,
     ABORTED,

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -531,6 +531,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             notificationService.incrementalSnapshotNotificationService().notifyStarted(context, partition, offsetContext);
 
             progressListener.monitoredDataCollectionsDetermined(partition, monitoredDataCollections);
+            notificationService.incrementalSnapshotNotificationService().notifyDataCollectionsResolved(context, partition, offsetContext);
             readChunk(partition, offsetContext);
         }
     }

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/SnapshotResult.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/spi/SnapshotResult.java
@@ -45,10 +45,9 @@ public class SnapshotResult<O extends OffsetContext> {
 
     public enum SnapshotResultStatus {
         STARTED,
-
         COMPLETED,
         ABORTED,
-        SKIPPED
+        SKIPPED;
     }
 
     @Override

--- a/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ConcurrentHashMap;
@@ -157,7 +158,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
             // Note that there's a minor race condition here: a new table matching the filters could be created between
             // this call and the determination of the initial snapshot position below; this seems acceptable, though
-            determineCapturedTables(ctx, dataCollectionsToBeSnapshotted, snapshottingTask);
+            determineCapturedTables(ctx, previousOffset, dataCollectionsToBeSnapshotted, snapshottingTask);
             snapshotProgressListener.monitoredDataCollectionsDetermined(snapshotContext.partition, ctx.capturedTables);
             // Init jdbc connection pool for reading table schema and data
             connectionPool = createConnectionPool(ctx);
@@ -377,7 +378,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    private void determineCapturedTables(RelationalSnapshotContext<P, O> ctx, Set<Pattern> dataCollectionsToBeSnapshotted, SnapshottingTask snapshottingTask)
+    private void determineCapturedTables(RelationalSnapshotContext<P, O> ctx, O previousOffset, Set<Pattern> dataCollectionsToBeSnapshotted,
+                                         SnapshottingTask snapshottingTask)
             throws Exception {
 
         Set<TableId> allTableIds = getAllTableIds(ctx);
@@ -402,6 +404,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                 LOGGER.trace("Ignoring table {} for data snapshotting as it's not included in the filter configuration", tableId);
             }
         }
+
+        notificationService.initialSnapshotNotificationService().notifyDataCollectionsResolved(ctx.partition, previousOffset, new TreeSet<>(capturedTables));
 
         ctx.capturedTables = addSignalingCollectionAndSort(capturedTables);
         ctx.capturedSchemaTables = snapshottingTask.isOnDemand() ? ctx.capturedTables

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationServiceTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.doc.FixFor;
 import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -73,6 +74,19 @@ public class IncrementalSnapshotNotificationServiceTest {
         incrementalSnapshotNotificationService.notifyStarted(incrementalSnapshotContext, partition, offsetContext);
 
         Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "STARTED", Map.of(
+                "connector_name", "connector-test",
+                "data_collections", "db.inventory.product,db.inventory.customer"), clock.millis());
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    @FixFor("debezium/dbx#2537")
+    public void notifyDataCollectionsResolved() {
+
+        incrementalSnapshotNotificationService.notifyDataCollectionsResolved(incrementalSnapshotContext, partition, offsetContext);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "DATA_COLLECTIONS_RESOLVED", Map.of(
                 "connector_name", "connector-test",
                 "data_collections", "db.inventory.product,db.inventory.customer"), clock.millis());
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -7,6 +7,7 @@ package io.debezium.connector.mongodb;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -95,8 +96,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
     protected SnapshotResult<MongoDbOffsetContext> doExecute(ChangeEventSourceContext context,
                                                              MongoDbOffsetContext prevOffsetCtx,
                                                              SnapshotContext<MongoDbPartition, MongoDbOffsetContext> snapshotContext,
-                                                             SnapshottingTask snapshottingTask)
-            throws Exception {
+                                                             SnapshottingTask snapshottingTask) {
         final MongoDbSnapshotContext mongoDbSnapshotContext = (MongoDbSnapshotContext) snapshotContext;
 
         LOGGER.info("Snapshot step 1 - Preparing");
@@ -109,7 +109,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
 
         LOGGER.info("Snapshot step 3 - Snapshotting data");
         try {
-            doSnapshot(context, mongoDbSnapshotContext, snapshottingTask);
+            doSnapshot(context, prevOffsetCtx, mongoDbSnapshotContext, snapshottingTask);
         }
         catch (Throwable t) {
             LOGGER.error("Snapshot failed", t);
@@ -162,14 +162,14 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
         return new MongoDbSnapshotContext(partition);
     }
 
-    private void doSnapshot(ChangeEventSourceContext sourceCtx, MongoDbSnapshotContext snapshotCtx, SnapshottingTask snapshottingTask)
+    private void doSnapshot(ChangeEventSourceContext sourceCtx, MongoDbOffsetContext prevOffsetCtx, MongoDbSnapshotContext snapshotCtx, SnapshottingTask snapshottingTask)
             throws Throwable {
         try (MongoDbConnection mongo = MongoDbConnections.create(taskContext.getRawConfig(), dispatcher, snapshotCtx.partition)) {
             initSnapshotStartOffsets(snapshotCtx, mongo);
             SnapshotReceiver<MongoDbPartition> snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
             snapshotCtx.offset.preSnapshotStart(snapshottingTask.isOnDemand());
 
-            createDataEvents(sourceCtx, snapshotCtx, snapshotReceiver, mongo, snapshottingTask);
+            createDataEvents(sourceCtx, prevOffsetCtx, snapshotCtx, snapshotReceiver, mongo, snapshottingTask);
 
             snapshotCtx.offset.preSnapshotCompletion();
             snapshotReceiver.completeSnapshot();
@@ -197,7 +197,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
      * Dispatches the data change events for the records of a single replica-set.
      */
     private void createDataEvents(ChangeEventSourceContext sourceContext,
-                                  MongoDbSnapshotContext snapshotContext,
+                                  MongoDbOffsetContext prevOffsetCtx, MongoDbSnapshotContext snapshotContext,
                                   SnapshotReceiver<MongoDbPartition> snapshotReceiver,
                                   MongoDbConnection mongo,
                                   SnapshottingTask snapshottingTask)
@@ -214,6 +214,8 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
                 .collect(Collectors.toList());
         final List<CollectionId> collections = determineDataCollectionsToBeSnapshotted(allCollections, dataCollectionPattern)
                 .collect(Collectors.toList());
+        notificationService.initialSnapshotNotificationService().notifyDataCollectionsResolved(snapshotContext.partition, prevOffsetCtx,
+                new LinkedHashSet<>(collections));
         snapshotProgressListener.monitoredDataCollectionsDetermined(snapshotContext.partition, collections);
 
         // Since multiple snapshot threads are to be used, create a thread pool and initiate the snapshot.

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -441,6 +441,7 @@ public class MongoDbIncrementalSnapshotChangeEventSource
             notificationService.incrementalSnapshotNotificationService().notifyStarted(context, partition, offsetContext);
 
             progressListener.monitoredDataCollectionsDetermined(partition, monitoredDataCollections);
+            notificationService.incrementalSnapshotNotificationService().notifyDataCollectionsResolved(context, partition, offsetContext);
             readChunk(partition, offsetContext);
         }
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/NotificationsIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/NotificationsIT.java
@@ -47,6 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig.SnapshotMode;
+import io.debezium.doc.FixFor;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.pipeline.notification.AbstractNotificationsIT;
@@ -133,10 +134,10 @@ public class NotificationsIT extends AbstractMongoConnectorIT {
                     notifications.add(r);
                 }
             });
-            return notifications.size() == 6;
+            return notifications.size() == 7;
         });
 
-        assertThat(notifications).hasSize(6);
+        assertThat(notifications).hasSize(7);
         SourceRecord sourceRecord = notifications.get(0);
         Assertions.assertThat(sourceRecord.topic()).isEqualTo("io.debezium.notification");
         Assertions.assertThat(((Struct) sourceRecord.value()).getString("aggregate_type")).isEqualTo("Initial Snapshot");
@@ -206,7 +207,7 @@ public class NotificationsIT extends AbstractMongoConnectorIT {
         notifications
                 .forEach(notification -> System.out.println("[notificationCorrectlySentOnJmx]:" + notification.toString()));
 
-        assertThat(notifications).hasSize(6);
+        assertThat(notifications).hasSize(7);
         assertThat(notifications.get(0))
                 .hasFieldOrPropertyWithValue("aggregateType", "Initial Snapshot")
                 .hasFieldOrPropertyWithValue("type", "STARTED")
@@ -248,7 +249,7 @@ public class NotificationsIT extends AbstractMongoConnectorIT {
 
         assertThat(notifications).allSatisfy(mBeanNotificationInfo -> assertThat(mBeanNotificationInfo.getName()).isEqualTo(Notification.class.getName()));
 
-        assertThat(jmxNotifications).hasSize(2);
+        assertThat(jmxNotifications).hasSize(3);
         assertThat(jmxNotifications.get(0)).hasFieldOrPropertyWithValue("message", "Initial Snapshot generated a notification");
 
         Notification notification = mapper.readValue(jmxNotifications.get(0).getUserData().toString(), Notification.class);
@@ -258,13 +259,51 @@ public class NotificationsIT extends AbstractMongoConnectorIT {
                 .hasFieldOrPropertyWithValue("additionalData", Map.of("connector_name", "mongo1"));
         assertThat(notification.getTimestamp()).isCloseTo(Instant.now().toEpochMilli(), Percentage.withPercentage(1));
 
-        assertThat(jmxNotifications.get(1)).hasFieldOrPropertyWithValue("message", "Initial Snapshot generated a notification");
-        notification = mapper.readValue(jmxNotifications.get(1).getUserData().toString(), Notification.class);
+        assertThat(jmxNotifications.get(2)).hasFieldOrPropertyWithValue("message", "Initial Snapshot generated a notification");
+        notification = mapper.readValue(jmxNotifications.get(2).getUserData().toString(), Notification.class);
         assertThat(notification)
                 .hasFieldOrPropertyWithValue("aggregateType", "Initial Snapshot")
                 .hasFieldOrPropertyWithValue("type", "COMPLETED")
                 .hasFieldOrPropertyWithValue("additionalData", Map.of("connector_name", "mongo1"));
         assertThat(notification.getTimestamp()).isCloseTo(Instant.now().toEpochMilli(), Percentage.withPercentage(1));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2537")
+    void initialSnapshotSentDataCollectionResolvedNotificationThatContainsDataCollections() {
+        // Testing.Print.enable();
+
+        storeDocuments("dbA", "c1", "simple_objects.json");
+        storeDocuments("dbA", "c2", "simple_objects.json");
+
+        startConnector(config -> config
+                .with(SinkNotificationChannel.NOTIFICATION_TOPIC, "io.debezium.notification")
+                .with(CommonConnectorConfig.NOTIFICATION_ENABLED_CHANNELS, "sink"));
+
+        assertConnectorIsRunning();
+
+        waitForAvailableRecords(500, TimeUnit.MILLISECONDS);
+
+        List<SourceRecord> notifications = new ArrayList<>();
+
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> {
+
+            consumeAvailableRecords(r -> {
+                if (r.topic().equals("io.debezium.notification")) {
+                    notifications.add(r);
+                }
+            });
+            return notifications.size() == 7;
+        });
+
+        assertThat(notifications).hasSize(7);
+        SourceRecord sourceRecord = notifications.get(1);
+        Assertions.assertThat(sourceRecord.topic()).isEqualTo("io.debezium.notification");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getString("aggregate_type")).isEqualTo("Initial Snapshot");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getString("type")).isEqualTo("DATA_COLLECTIONS_RESOLVED");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getInt64("timestamp")).isCloseTo(Instant.now().toEpochMilli(), Percentage.withPercentage(1));
+        Assertions.assertThat(((Struct) sourceRecord.value()).getMap("additional_data")).containsEntry("data_collections", "dbA.c1,dbA.c2");
+
     }
 
     private void assertTableNotificationsSentToJmx(List<Notification> notifications, String tableName) {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/NotificationsIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/NotificationsIT.java
@@ -124,11 +124,11 @@ public class NotificationsIT extends AbstractNotificationsIT<SqlServerConnector>
                     notifications.add(r);
                 }
             });
-            return notifications.size() == 3;
+            return notifications.size() == 4;
         });
 
-        Assertions.assertThat(notifications).hasSize(3);
-        SourceRecord sourceRecord = notifications.get(2);
+        Assertions.assertThat(notifications).hasSize(4);
+        SourceRecord sourceRecord = notifications.get(3);
         Assertions.assertThat(sourceRecord.topic()).isEqualTo("io.debezium.notification");
         Struct value = (Struct) sourceRecord.value();
         Assertions.assertThat(value.getString("aggregate_type")).isEqualTo("Capture Instance");

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/notification/AbstractNotificationsIT.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/notification/AbstractNotificationsIT.java
@@ -277,6 +277,42 @@ public abstract class AbstractNotificationsIT<T extends SourceConnector> extends
         waitForStreamingRunning(connector(), server(), "streaming", task());
     }
 
+    @Test
+    @FixFor("debezium/dbz#2537")
+    public void initialSnapshotStartNotificationMustContainsDataCollections() throws InterruptedException {
+        // Testing.Print.enable();
+
+        startConnector(config -> config.with("slot.drop.on.stop", "false")
+                .with(SinkNotificationChannel.NOTIFICATION_TOPIC, "io.debezium.notification")
+                .with(CommonConnectorConfig.NOTIFICATION_ENABLED_CHANNELS, "sink"));
+
+        assertConnectorIsRunning();
+
+        waitForSnapshotToBeCompleted(connector(), server(), task(), database());
+
+        List<SourceRecord> notifications = new ArrayList<>();
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> {
+
+            consumeAvailableRecords(r -> {
+                if (r.topic().equals("io.debezium.notification")) {
+                    notifications.add(r);
+                }
+            });
+            return notifications.size() == calculateNotificationSize();
+        });
+
+        assertThat(notifications).hasSize(calculateNotificationSize());
+        SourceRecord sourceRecord = notifications.get(1);
+        Assertions.assertThat(sourceRecord.topic()).isEqualTo("io.debezium.notification");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getString("aggregate_type")).isEqualTo("Initial Snapshot");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getString("type")).isEqualTo("DATA_COLLECTIONS_RESOLVED");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getInt64("timestamp")).isCloseTo(Instant.now().toEpochMilli(), Percentage.withPercentage(1));
+        Assertions.assertThat(((Struct) sourceRecord.value()).getMap("additional_data")).containsEntry("data_collections",
+                String.join(",", collections().stream().sorted().toList()));
+
+        stopConnector();
+    }
+
     private void assertTableNotificationsSentToJmx(List<Notification> notifications, String tableName) {
         // For debugging purposes
         Optional<Notification> tableNotification;
@@ -383,7 +419,7 @@ public abstract class AbstractNotificationsIT<T extends SourceConnector> extends
     }
 
     private int calculateNotificationSize() {
-        return (collections().size() * 2) + 2;
+        return (collections().size() * 2) + 3;
     }
 
     public static class ClientListener implements NotificationListener {


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2537

## Description
This pull request enhances the Debezium notification system by ensuring that the list of data collections (tables or collections) included in an initial snapshot is reported in the "STARTED" notification. This provides better observability for users, allowing them to see exactly which data collections are being snapshotted. The changes also add comprehensive tests to verify this behavior for both MongoDB and relational connectors.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
