### PR TITLE
debezium/dbz#2534 Support include.schema.comments for PostgreSQL conn…

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -783,6 +783,7 @@ Tom Bentley
 Tom Billiet
 Tom Flenner
 Tom Sharp
+Tomas Finnøy
 Tomasz Gawęda
 Tomaz Lemos Fernandes
 Tommy Karlsson

--- a/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1240,7 +1240,10 @@ public class JdbcConnection implements AutoCloseable {
                     if (tableFilter == null || tableFilter.isIncluded(tableId)) {
                         tableIds.add(tableId);
                         attributesByTable.putAll(getAttributeDetails(tableId, tableType));
-                        commentsByTable.put(tableId, readTableComment(rs));
+                        final String comment = readTableComment(rs);
+                        if (!Strings.isNullOrBlank(comment)) {
+                            commentsByTable.put(tableId, comment);
+                        }
                     }
                 }
                 else {

--- a/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-connector-common/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1224,6 +1224,7 @@ public class JdbcConnection implements AutoCloseable {
         final Set<TableId> tableIds = new HashSet<>();
 
         Map<TableId, List<Attribute>> attributesByTable = new HashMap<>();
+        Map<TableId, String> commentsByTable = new HashMap<>();
 
         int totalTables = 0;
         String schemaNamePattern = createPatternFromName(schemaName, metadata.getSearchStringEscape());
@@ -1239,6 +1240,7 @@ public class JdbcConnection implements AutoCloseable {
                     if (tableFilter == null || tableFilter.isIncluded(tableId)) {
                         tableIds.add(tableId);
                         attributesByTable.putAll(getAttributeDetails(tableId, tableType));
+                        commentsByTable.put(tableId, readTableComment(rs));
                     }
                 }
                 else {
@@ -1280,7 +1282,8 @@ public class JdbcConnection implements AutoCloseable {
             Collections.sort(columns);
             String defaultCharsetName = null; // JDBC does not expose character sets
             List<Attribute> attributes = attributesByTable.getOrDefault(tableEntry.getKey(), Collections.emptyList());
-            tables.overwriteTable(tableEntry.getKey(), columns, pkColumnNames, defaultCharsetName, attributes);
+            String comment = commentsByTable.get(tableEntry.getKey());
+            tables.overwriteTable(tableEntry.getKey(), columns, pkColumnNames, defaultCharsetName, comment, attributes);
         }
 
         if (removeTablesNotFoundInJdbc) {
@@ -1296,6 +1299,10 @@ public class JdbcConnection implements AutoCloseable {
 
     protected boolean isTableType(String tableType) {
         return "TABLE".equals(tableType);
+    }
+
+    protected String readTableComment(ResultSet tableMetadata) throws SQLException {
+        return null;
     }
 
     protected String resolveCatalogName(String catalogName) {

--- a/debezium-connector-common/src/main/java/io/debezium/relational/Tables.java
+++ b/debezium-connector-common/src/main/java/io/debezium/relational/Tables.java
@@ -236,12 +236,29 @@ public final class Tables {
      */
     public Table overwriteTable(TableId tableId, List<Column> columnDefs, List<String> primaryKeyColumnNames,
                                 String defaultCharsetName, List<Attribute> attributes) {
+        return overwriteTable(tableId, columnDefs, primaryKeyColumnNames, defaultCharsetName, null, attributes);
+    }
+
+    /**
+     * Add or update the definition for the identified table.
+     *
+     * @param tableId the identifier for the table
+     * @param columnDefs the list of column definitions; may not be null or empty
+     * @param primaryKeyColumnNames the list of the column names that make up the primary key; may be null or empty
+     * @param defaultCharsetName the name of the character set that should be used by default
+     * @param comment the table comment; may be null
+     * @param attributes the list of attribute definitions; may not be null or empty
+     * @return the previous table definition, or null if there was no prior table definition
+     */
+    public Table overwriteTable(TableId tableId, List<Column> columnDefs, List<String> primaryKeyColumnNames,
+                                String defaultCharsetName, String comment, List<Attribute> attributes) {
         return lock.write(() -> {
             Table updated = Table.editor()
                     .tableId(tableId)
                     .addColumns(columnDefs)
                     .setPrimaryKeyNames(primaryKeyColumnNames)
                     .setDefaultCharsetName(defaultCharsetName)
+                    .setComment(comment)
                     .addAttributes(attributes)
                     .create();
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -406,9 +406,11 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
 
                             // as long as default value is not added to the decoded message metadata, we must apply
                             // the current default read from the database
-                            Optional.ofNullable(table.columnWithName(column.getName()))
-                                    .flatMap(Column::defaultValueExpression)
-                                    .ifPresent(columnEditor::defaultValueExpression);
+                            final Column databaseColumn = table.columnWithName(column.getName());
+                            if (databaseColumn != null) {
+                                databaseColumn.defaultValueExpression().ifPresent(columnEditor::defaultValueExpression);
+                                columnEditor.comment(databaseColumn.comment());
+                            }
 
                             return columnEditor.create();
                         })

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -130,7 +130,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                 typeRegistry);
 
         MainConnectionProvidingConnectionFactory<PostgresConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
-                () -> new PostgresConnection(connectorConfig.getJdbcConfig(), sharedTypeRegistry, valueConverterBuilder, PostgresConnection.CONNECTION_GENERAL));
+                () -> new PostgresConnection(connectorConfig, sharedTypeRegistry, PostgresConnection.CONNECTION_GENERAL));
         // Global JDBC connection used both for snapshotting and streaming.
         // Must be able to resolve datatypes.
         jdbcConnection = connectionFactory.mainConnection();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -1008,18 +1008,24 @@ public class PostgresConnection extends JdbcConnection {
             return null;
         }
 
-        final DatabaseMetaData databaseMetaData = connection().getMetaData();
-        final String schemaNamePattern = createPatternFromName(tableId.schema(), databaseMetaData.getSearchStringEscape());
-        final String tableNamePattern = createPatternFromName(tableId.table(), databaseMetaData.getSearchStringEscape());
+        try {
+            final DatabaseMetaData databaseMetaData = connection().getMetaData();
+            final String schemaNamePattern = createPatternFromName(tableId.schema(), databaseMetaData.getSearchStringEscape());
+            final String tableNamePattern = createPatternFromName(tableId.table(), databaseMetaData.getSearchStringEscape());
 
-        try (ResultSet tableMetadata = databaseMetaData.getTables(null, schemaNamePattern, tableNamePattern, supportedTableTypes())) {
-            while (tableMetadata.next()) {
-                if (isTableType(tableMetadata.getString(4))) {
-                    return readTableComment(tableMetadata);
+            try (ResultSet tableMetadata = databaseMetaData.getTables(null, schemaNamePattern, tableNamePattern, supportedTableTypes())) {
+                while (tableMetadata.next()) {
+                    if (isTableType(tableMetadata.getString(4))) {
+                        return readTableComment(tableMetadata);
+                    }
                 }
             }
+            return null;
         }
-        return null;
+        catch (SQLException e) {
+            LOGGER.error("Failed to read table comment metadata for '{}.{}'", tableId.schema(), tableId.table());
+            throw e;
+        }
     }
 
     @FunctionalInterface

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -97,6 +97,7 @@ public class PostgresConnection extends JdbcConnection {
 
     private final TypeRegistry typeRegistry;
     private final PostgresDefaultValueConverter defaultValueConverter;
+    private final boolean includeSchemaComments;
 
     /**
      * Creates a Postgres connection using the supplied configuration.
@@ -110,6 +111,7 @@ public class PostgresConnection extends JdbcConnection {
      */
     public PostgresConnection(JdbcConfiguration config, TypeRegistry typeRegistry, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {
         super(addDefaultSettings(config, connectionUsage), FACTORY, PostgresConnection::validateServerVersion, "\"", "\"");
+        this.includeSchemaComments = false;
 
         if (Objects.isNull(typeRegistry) || Objects.isNull(valueConverterBuilder)) {
             this.typeRegistry = null;
@@ -156,6 +158,7 @@ public class PostgresConnection extends JdbcConnection {
                 FACTORY,
                 PostgresConnection::validateServerVersion,
                 "\"", "\"");
+        this.includeSchemaComments = config.isSchemaCommentsHistoryEnabled();
 
         if (Objects.isNull(typeRegistry)) {
             this.typeRegistry = null;
@@ -690,6 +693,11 @@ public class PostgresConnection extends JdbcConnection {
         return doReadTableColumn(columnMetadata, tableId, columnFilter);
     }
 
+    @Override
+    protected String readTableComment(ResultSet tableMetadata) throws SQLException {
+        return includeSchemaComments ? tableMetadata.getString(5) : null;
+    }
+
     public Optional<Column> readColumnForDecoder(ResultSet columnMetadata, TableId tableId, Tables.ColumnNameFilter columnNameFilter)
             throws SQLException {
         return doReadTableColumn(columnMetadata, tableId, columnNameFilter).map(ColumnEditor::create);
@@ -711,6 +719,9 @@ public class PostgresConnection extends JdbcConnection {
             }
 
             column.optional(isNullable(columnMetadata.getInt(11)));
+            if (includeSchemaComments) {
+                column.comment(columnMetadata.getString(12));
+            }
             column.position(columnMetadata.getInt(17));
             column.autoIncremented("YES".equalsIgnoreCase(columnMetadata.getString(23)));
 
@@ -990,6 +1001,25 @@ public class PostgresConnection extends JdbcConnection {
             LOGGER.error("Failed to read column metadata for '{}.{}'", tableId.schema(), tableId.table());
             throw e;
         }
+    }
+
+    public String getTableCommentForDecoder(TableId tableId) throws SQLException {
+        if (!includeSchemaComments) {
+            return null;
+        }
+
+        final DatabaseMetaData databaseMetaData = connection().getMetaData();
+        final String schemaNamePattern = createPatternFromName(tableId.schema(), databaseMetaData.getSearchStringEscape());
+        final String tableNamePattern = createPatternFromName(tableId.table(), databaseMetaData.getSearchStringEscape());
+
+        try (ResultSet tableMetadata = databaseMetaData.getTables(null, schemaNamePattern, tableNamePattern, supportedTableTypes())) {
+            while (tableMetadata.next()) {
+                if (isTableType(tableMetadata.getString(4))) {
+                    return readTableComment(tableMetadata);
+                }
+            }
+        }
+        return null;
     }
 
     @FunctionalInterface

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
@@ -24,6 +24,7 @@ public class ColumnMetaData {
     private final boolean optional;
     private final boolean hasDefaultValue;
     private final String defaultValueExpression;
+    private final String comment;
     private final int length;
     private final int scale;
     private final String typeName;
@@ -38,17 +39,19 @@ public class ColumnMetaData {
      * @param optional {@code true} if the column is considered optional, {@code false} otherwise
      * @param hasDefaultValue {@code true} if the column has a default value specified, {@code false} otherwise
      * @param defaultValueExpression the parsed default value literal for the column
+    * @param comment the column comment, or {@code null} if comments are not included or no comment is defined
      * @param typeModifier the attribute type modifier
      * @param driverTypeName the type name the JDBC driver reports for the column, {@code null} when unavailable
      */
     ColumnMetaData(String columnName, PostgresType postgresType, boolean key, boolean optional, boolean hasDefaultValue, String defaultValueExpression,
-                   int typeModifier, String driverTypeName) {
+                   String comment, int typeModifier, String driverTypeName) {
         this.columnName = columnName;
         this.postgresType = postgresType;
         this.key = key;
         this.optional = optional;
         this.hasDefaultValue = hasDefaultValue;
         this.defaultValueExpression = defaultValueExpression;
+        this.comment = comment;
 
         // todo: investigate whether this can be removed and PostgresType updated to always delegate
         // Currently PostgresType only delegates calls to length and scale with an attribute modifier
@@ -110,6 +113,10 @@ public class ColumnMetaData {
 
     public String getDefaultValueExpression() {
         return defaultValueExpression;
+    }
+
+    public String getComment() {
+        return comment;
     }
 
     public int getLength() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
@@ -39,7 +39,7 @@ public class ColumnMetaData {
      * @param optional {@code true} if the column is considered optional, {@code false} otherwise
      * @param hasDefaultValue {@code true} if the column has a default value specified, {@code false} otherwise
      * @param defaultValueExpression the parsed default value literal for the column
-    * @param comment the column comment, or {@code null} if comments are not included or no comment is defined
+     * @param comment the column comment, or {@code null} if comments are not included or no comment is defined
      * @param typeModifier the attribute type modifier
      * @param driverTypeName the type name the JDBC driver reports for the column, {@code null} when unavailable
      */

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.annotation.VisibleForTesting;
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.PgConnectionSupplier;
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.TypeRegistry;
@@ -693,6 +694,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
      * @param metadata The relation metadata collected from previous 'R' replication stream messages
      * @return table based on a prior replication relation message
      */
+    @VisibleForTesting
     static Table resolveRelationFromMetadata(PgOutputRelationMetaData metadata) {
         List<io.debezium.relational.Column> columns = new ArrayList<>();
         for (ColumnMetaData columnMetadata : metadata.getColumns()) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -338,6 +338,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         Map<String, Optional<String>> columnDefaults;
         Map<String, Boolean> columnOptionality;
         Map<String, String> columnTypeNames;
+        Map<String, String> columnComments;
         List<String> primaryKeyColumns;
 
         final DatabaseMetaData databaseMetadata = connection.connection().getMetaData();
@@ -345,12 +346,16 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
         final List<io.debezium.relational.Column> readColumns = connection.getTableColumnsForDecoder(
                 tableId, decoderContext.getConfig().getColumnFilter());
+        final String tableComment = connection.getTableCommentForDecoder(tableId);
         columnDefaults = readColumns.stream()
                 .filter(io.debezium.relational.Column::hasDefaultValue)
                 .collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::defaultValueExpression));
 
         columnOptionality = readColumns.stream().collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::isOptional));
         columnTypeNames = readColumns.stream().collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::typeName));
+        columnComments = readColumns.stream()
+                .filter(column -> column.comment() != null)
+                .collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::comment));
         primaryKeyColumns = connection.readPrimaryKeyNames(databaseMetadata, tableId);
         if (primaryKeyColumns == null || primaryKeyColumns.isEmpty()) {
             LOGGER.warn("Primary keys are not defined for table '{}', defaulting to unique indices", tableName);
@@ -391,7 +396,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
             final boolean hasDefault = columnDefaults.containsKey(columnName);
             final String defaultValueExpression = columnDefaults.getOrDefault(columnName, Optional.empty()).orElse(null);
 
-            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, hasDefault, defaultValueExpression, attypmod,
+            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, hasDefault, defaultValueExpression, columnComments.get(columnName), attypmod,
                     columnTypeNames.get(columnName)));
             columnNames.add(columnName);
         }
@@ -413,7 +418,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // to reflect the actual primary key state at time `t0`.
         primaryKeyColumns.retainAll(columnNames);
 
-        Table table = resolveRelationFromMetadata(new PgOutputRelationMetaData(relationId, schemaName, tableName, columns, primaryKeyColumns));
+        Table table = resolveRelationFromMetadata(new PgOutputRelationMetaData(relationId, schemaName, tableName, tableComment, columns, primaryKeyColumns));
         decoderContext.getSchema().applySchemaChangesForTable(relationId, table);
     }
 
@@ -688,7 +693,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
      * @param metadata The relation metadata collected from previous 'R' replication stream messages
      * @return table based on a prior replication relation message
      */
-    private Table resolveRelationFromMetadata(PgOutputRelationMetaData metadata) {
+    static Table resolveRelationFromMetadata(PgOutputRelationMetaData metadata) {
         List<io.debezium.relational.Column> columns = new ArrayList<>();
         for (ColumnMetaData columnMetadata : metadata.getColumns()) {
             ColumnEditor editor = io.debezium.relational.Column.editor()
@@ -698,7 +703,8 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                     .optional(columnMetadata.isOptional())
                     .type(columnMetadata.getDriverTypeName(), columnMetadata.getTypeName())
                     .length(columnMetadata.getLength())
-                    .scale(columnMetadata.getScale());
+                    .scale(columnMetadata.getScale())
+                    .comment(columnMetadata.getComment());
 
             if (columnMetadata.hasDefaultValue()) {
                 editor.defaultValueExpression(columnMetadata.getDefaultValueExpression());
@@ -711,6 +717,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                 .addColumns(columns)
                 .setPrimaryKeyNames(metadata.getPrimaryKeyNames())
                 .tableId(metadata.getTableId())
+                .setComment(metadata.getComment())
                 .create();
 
         LOGGER.trace("Resolved '{}' as '{}'", table.id(), table);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputRelationMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputRelationMetaData.java
@@ -20,6 +20,7 @@ public class PgOutputRelationMetaData {
     private final int relationId;
     private final String schema;
     private final String name;
+    private final String comment;
     private final List<ColumnMetaData> columns;
     private final List<String> primaryKeyNames;
 
@@ -29,13 +30,15 @@ public class PgOutputRelationMetaData {
      * @param relationId the postgres relation identifier, unique provided by the pgoutput stream
      * @param schema the schema the table exists within; should never be null
      * @param name the name of the table; should never be null
+     * @param comment the table comment; may be null
      * @param columns list of column metadata instances describing the state of each column
      * @param primaryKeyNames ordered list of primary key column names
      */
-    PgOutputRelationMetaData(int relationId, String schema, String name, List<ColumnMetaData> columns, List<String> primaryKeyNames) {
+    PgOutputRelationMetaData(int relationId, String schema, String name, String comment, List<ColumnMetaData> columns, List<String> primaryKeyNames) {
         this.relationId = relationId;
         this.schema = schema;
         this.name = name;
+        this.comment = comment;
         this.columns = columns;
         this.primaryKeyNames = primaryKeyNames;
     }
@@ -50,6 +53,10 @@ public class PgOutputRelationMetaData {
 
     public String getName() {
         return name;
+    }
+
+    public String getComment() {
+        return comment;
     }
 
     public List<ColumnMetaData> getColumns() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -80,6 +80,63 @@ public class PostgresSchemaIT {
     }
 
     @Test
+    @FixFor("debezium/dbz#2534")
+    void shouldLoadAndRefreshSchemaComments() throws Exception {
+        final TableId tableId = TableId.parse("public.schema_comments_test", false);
+        TestHelper.execute(
+                "CREATE TABLE schema_comments_test (id INTEGER PRIMARY KEY, description TEXT);",
+                "COMMENT ON TABLE schema_comments_test IS 'Initial table comment';",
+                "COMMENT ON COLUMN schema_comments_test.description IS 'Initial column comment';");
+
+        final PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.INCLUDE_SCHEMA_COMMENTS, true)
+                .build());
+        final var typeRegistry = PostgresConnection.createTypeRegistry(config.getJdbcConfig());
+        schema = TestHelper.getSchema(config, typeRegistry);
+
+        try (PostgresConnection connection = new PostgresConnection(config, typeRegistry, TestHelper.CONNECTION_TEST)) {
+            assertThat(connection.getTableCommentForDecoder(tableId)).isEqualTo("Initial table comment");
+            schema.refresh(connection, false);
+            assertSchemaComments(tableId, "Initial table comment", "Initial column comment");
+
+            TestHelper.execute(
+                    "COMMENT ON TABLE schema_comments_test IS 'Updated table comment';",
+                    "COMMENT ON COLUMN schema_comments_test.description IS 'Updated column comment';");
+
+            assertThat(connection.getTableCommentForDecoder(tableId)).isEqualTo("Updated table comment");
+            schema.refresh(connection, tableId, false);
+            assertSchemaComments(tableId, "Updated table comment", "Updated column comment");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2534")
+    void shouldExcludeSchemaCommentsByDefault() throws Exception {
+        final TableId tableId = TableId.parse("public.schema_comments_test", false);
+        TestHelper.execute(
+                "CREATE TABLE schema_comments_test (id INTEGER PRIMARY KEY, description TEXT);",
+                "COMMENT ON TABLE schema_comments_test IS 'Table comment';",
+                "COMMENT ON COLUMN schema_comments_test.description IS 'Column comment';");
+
+        final PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig().build());
+        final var typeRegistry = PostgresConnection.createTypeRegistry(config.getJdbcConfig());
+        schema = TestHelper.getSchema(config, typeRegistry);
+
+        try (PostgresConnection connection = new PostgresConnection(config, typeRegistry, TestHelper.CONNECTION_TEST)) {
+            assertThat(connection.getTableCommentForDecoder(tableId)).isNull();
+            schema.refresh(connection, false);
+            assertSchemaComments(tableId, null, null);
+        }
+    }
+
+    private void assertSchemaComments(TableId tableId, String tableComment, String columnComment) {
+        final Table table = schema.tableFor(tableId);
+        assertThat(table).isNotNull();
+        assertThat(table.comment()).isEqualTo(tableComment);
+        assertThat(table.columnWithName("description").comment()).isEqualTo(columnComment);
+    }
+
+    @Test
     void shouldLoadSchemaForBuiltinPostgresTypes() throws Exception {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -102,6 +102,36 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#2534")
+    void shouldIncludeColumnCommentsInSnapshotSchema() throws Exception {
+        final String comment = "Description of the record";
+
+        assertThat(snapshotColumnDocumentation(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.INCLUDE_SCHEMA_COMMENTS, true), comment)).isEqualTo(comment);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2534")
+    void shouldExcludeColumnCommentsFromSnapshotSchemaByDefault() throws Exception {
+        assertThat(snapshotColumnDocumentation(TestHelper.defaultConfig(), "Description of the record")).isNull();
+    }
+
+    private String snapshotColumnDocumentation(Configuration.Builder config, String comment) throws Exception {
+        TestHelper.execute(
+                "CREATE TABLE schema_comments_test (id INTEGER PRIMARY KEY, description TEXT);",
+                "COMMENT ON COLUMN schema_comments_test.description IS '" + comment + "';",
+                "INSERT INTO schema_comments_test VALUES (1, 'record');");
+
+        buildNoStreamProducer(config.with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.schema_comments_test"));
+
+        final TestConsumer consumer = testConsumer(1, "public.schema_comments_test");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        final SourceRecord record = consumer.remove();
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER).schema().field("description").schema().doc();
+    }
+
+    @Test
     @FixFor("debezium/dbz#2025")
     public void shouldGenerateSnapshotForVarbit1Datatype() throws Exception {
         TestHelper.dropAllSchemas();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -870,6 +870,26 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 Collections.singletonList(new SchemaAndValueField("modtype", SchemaBuilder.OPTIONAL_INT16_SCHEMA, (short) 2)), updatedRecord, Envelope.FieldName.AFTER);
     }
 
+    @Test
+    @FixFor("debezium/dbz#2534")
+    void shouldUpdateColumnCommentsAfterSchemaRefresh() throws Exception {
+        final String initialComment = "Initial description";
+        final String updatedComment = "Updated description";
+        TestHelper.execute("COMMENT ON COLUMN test_table.text IS '" + initialComment + "';");
+
+        startConnector(config -> config.with(PostgresConnectorConfig.INCLUDE_SCHEMA_COMMENTS, true));
+
+        consumer = testConsumer(1);
+        executeAndWait(
+                "COMMENT ON COLUMN test_table.text IS '" + updatedComment + "';" +
+                        "ALTER TABLE test_table ADD COLUMN added INTEGER;" +
+                        "INSERT INTO test_table(text, added) VALUES ('after refresh', 1);");
+
+        final SourceRecord insertedRecord = consumer.remove();
+        final Schema afterSchema = ((Struct) insertedRecord.value()).getStruct(Envelope.FieldName.AFTER).schema();
+        assertThat(afterSchema.field("text").schema().doc()).isEqualTo(updatedComment);
+    }
+
     private Header getPKUpdateNewKeyHeader(SourceRecord record) {
         return this.getHeaderField(record, RelationalChangeRecordEmitter.PK_UPDATE_NEWKEY_FIELD);
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaDataTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaDataTest.java
@@ -34,7 +34,7 @@ public class ColumnMetaDataTest {
     @Test
     @FixFor("debezium/dbz#2220")
     public void shouldReadPgVectorDimensionFromModifier() {
-        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, 3, "vector");
+        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, null, 3, "vector");
         assertThat(column.getLength()).isEqualTo(3);
         assertThat(column.getScale()).isEqualTo(0);
         // Single dimension modifier: vector(3), not vector(3,0).
@@ -44,7 +44,7 @@ public class ColumnMetaDataTest {
     @Test
     @FixFor("debezium/dbz#2220")
     public void shouldLeavePgVectorWithoutDimensionUnset() {
-        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, TypeRegistry.NO_TYPE_MODIFIER, "vector");
+        final ColumnMetaData column = new ColumnMetaData("v", vectorType(), false, true, false, null, null, TypeRegistry.NO_TYPE_MODIFIER, "vector");
         assertThat(column.getLength()).isEqualTo(Column.UNSET_INT_VALUE);
         assertThat(column.getTypeName()).isEqualTo("vector");
     }
@@ -52,7 +52,7 @@ public class ColumnMetaDataTest {
     @Test
     @FixFor("debezium/dbz#2232")
     public void shouldKeepSerialTypeNameReportedByDriver() {
-        final ColumnMetaData column = new ColumnMetaData("pk", int4Type(), true, false, false, null, TypeRegistry.NO_TYPE_MODIFIER, "serial");
+        final ColumnMetaData column = new ColumnMetaData("pk", int4Type(), true, false, false, null, null, TypeRegistry.NO_TYPE_MODIFIER, "serial");
         assertThat(column.getDriverTypeName()).isEqualTo("serial");
         assertThat(column.getTypeName()).startsWith("serial");
     }
@@ -60,7 +60,7 @@ public class ColumnMetaDataTest {
     @Test
     @FixFor("debezium/dbz#2232")
     public void shouldFallBackToTypeNameOfOidWhenDriverReportsNone() {
-        final ColumnMetaData column = new ColumnMetaData("pk", int4Type(), true, false, false, null, TypeRegistry.NO_TYPE_MODIFIER, null);
+        final ColumnMetaData column = new ColumnMetaData("pk", int4Type(), true, false, false, null, null, TypeRegistry.NO_TYPE_MODIFIER, null);
         assertThat(column.getDriverTypeName()).isEqualTo("int4");
         assertThat(column.getTypeName()).startsWith("int4");
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoderTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.pgoutput;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.doc.FixFor;
+import io.debezium.relational.Table;
+
+public class PgOutputMessageDecoderTest {
+
+    @Test
+    @FixFor("debezium/dbz#2534")
+    void shouldPreserveSchemaCommentsWhenResolvingRelationMetadata() {
+        final PostgresType postgresType = new PostgresType.Builder(
+                null, "int4", 23, Types.INTEGER, TypeRegistry.NO_TYPE_MODIFIER, null).build();
+        final ColumnMetaData column = new ColumnMetaData(
+                "id", postgresType, true, false, false, null, "Column comment", TypeRegistry.NO_TYPE_MODIFIER, "int4");
+        final PgOutputRelationMetaData metadata = new PgOutputRelationMetaData(
+                1, "public", "comment_test", "Table comment", List.of(column), List.of("id"));
+
+        final Table table = PgOutputMessageDecoder.resolveRelationFromMetadata(metadata);
+
+        assertThat(table.comment()).isEqualTo("Table comment");
+        assertThat(table.columnWithName("id").comment()).isEqualTo("Column comment");
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3544,6 +3544,8 @@ The built-in system schemas `pg_catalog` and `information_schema` are always pre
 |`false`
 |Specifies whether the connector includes PostgreSQL table and column comments in its relational schema metadata.
 Column comments are also included in the `doc` attribute of the corresponding field schema.
+Comments are captured during snapshots and schema refreshes.
+Because a standalone `COMMENT ON` statement does not produce a WAL event, the connector does not capture the updated comment until a subsequent schema refresh occurs.
 Enabling this option can increase the connector's memory usage if the database contains many comments or comments that are large.
 
 |[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `+schema.exclude.list+`>>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3540,6 +3540,12 @@ If you include this property in the configuration, do not also set the `schema.e
 *Performance note:* {prodname} uses `schema.include.list` (and `schema.exclude.list`) to restrict which PostgreSQL custom types are pre-loaded into memory at startup, reducing heap usage in databases with many schemas or custom types (for example, multi-tenant deployments).
 The built-in system schemas `pg_catalog` and `information_schema` are always pre-loaded.
 
+|[[postgresql-property-include-schema-comments]]<<postgresql-property-include-schema-comments, `+include.schema.comments+`>>
+|`false`
+|Specifies whether the connector includes PostgreSQL table and column comments in its relational schema metadata.
+Column comments are also included in the `doc` attribute of the corresponding field schema.
+Enabling this option can increase the connector's memory usage if the database contains many comments or comments that are large.
+
 |[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `+schema.exclude.list+`>>
 |No default
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes.

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -365,6 +365,7 @@ TimurRakhmatullin86,Timur Rakhmatullin
 tingley,Chase Tingley
 tjwornjs,Seo Jae-kwon
 Tlinian,林石培
+TomasSaite,Tomas Finnøy
 tomaz.fernandes,Tomaz Lemos Fernandes
 TomBillietKlarrio,Tom Billiet
 Tony N,Tony Nyurkin


### PR DESCRIPTION
Fixes debezium/dbz#2534

## Description

Adds support for `include.schema.comments` to the PostgreSQL connector.

PostgreSQL stores table and column comments as catalog metadata. Logical
decoding, including the built-in `pgoutput` plugin, does not include comments
in replication messages. This remains the case in current PostgreSQL versions.

The connector therefore retrieves comments through the PostgreSQL JDBC
metadata API during schema discovery and refresh. The JDBC driver exposes
table and column comments through the corresponding `REMARKS` fields.

When enabled, table comments are stored in the relational schema metadata and
column comments are exposed through the Kafka Connect field schema's `doc`
attribute. Comments are preserved when relation metadata is reconstructed
during streaming.

The option remains disabled by default. Tests cover enabled and
default-disabled behavior, schema refreshes, and pgoutput relation
reconstruction.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`