### PR TITLE
debezium/dbz#1862 Fix DataException by making MongoDB source collection field optional

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSourceInfoStructMaker.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSourceInfoStructMaker.java
@@ -20,7 +20,7 @@ public class MongoDbSourceInfoStructMaker extends AbstractSourceInfoStructMaker<
         super.init(connector, version, connectorConfig);
         schema = commonSchemaBuilder()
                 .name(connectorConfig.schemaNameAdjuster().adjust("io.debezium.connector.mongo.Source"))
-                .field(SourceInfo.COLLECTION, Schema.STRING_SCHEMA)
+                .field(SourceInfo.COLLECTION, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(SourceInfo.ORDER, Schema.INT32_SCHEMA)
                 .field(SourceInfo.LSID, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(SourceInfo.TXN_NUMBER, Schema.OPTIONAL_INT64_SCHEMA)
@@ -35,10 +35,14 @@ public class MongoDbSourceInfoStructMaker extends AbstractSourceInfoStructMaker<
 
     @Override
     public Struct struct(SourceInfo sourceInfo) {
-        String collectionName = sourceInfo.collectionId() != null ? sourceInfo.collectionId().name() : null;
         Struct struct = super.commonStruct(sourceInfo)
-                .put(SourceInfo.COLLECTION, collectionName)
                 .put(SourceInfo.ORDER, sourceInfo.position().getInc());
+
+        // The collection is unknown for no-event positions (e.g. heartbeats or the streaming start
+        // offset), where CollectionId.parse("") resets it to null. The field is optional, so omit it.
+        if (sourceInfo.collectionId() != null) {
+            struct.put(SourceInfo.COLLECTION, sourceInfo.collectionId().name());
+        }
 
         if (sourceInfo.position().getChangeStreamSessionTxnId() != null) {
             struct.put(SourceInfo.LSID, sourceInfo.position().getChangeStreamSessionTxnId().lsid)

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbOffsetContextTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbOffsetContextTest.java
@@ -7,17 +7,16 @@ package io.debezium.connector.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.kafka.connect.errors.DataException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
 
 /**
  * Unit tests for {@link MongoDbOffsetContext} and its {@link MongoDbOffsetContext.Loader}.
@@ -101,16 +100,14 @@ public class MongoDbOffsetContextTest {
     }
 
     /**
-     * Bug 2 demonstration: When collectionId is null (as it is during an incomplete
-     * snapshot), calling getSourceInfo() throws DataException because the "collection"
-     * field is required (non-optional) in the schema but the value is null.
-     *
-     * This documents why MongoDbConnectorTask.validate() uses getOffset() instead of
-     * getSourceInfo() for error messages — getSourceInfo() is unsafe when collectionId
-     * is null.
+     * When collectionId is null (as it is during an incomplete snapshot), calling
+     * getSourceInfo() must not throw: the "collection" field is optional in the schema, so
+     * the struct is built with the field omitted. This is the root-cause fix for the crash
+     * reported in debezium/dbz#1862.
      */
     @Test
-    public void getSourceInfoThrowsWhenCollectionIsNull() {
+    @FixFor("debezium/dbz#1862")
+    public void getSourceInfoDoesNotThrowWhenCollectionIsNull() {
         Map<String, Object> offset = new HashMap<>();
         offset.put(SourceInfo.INITIAL_SYNC, true);
         offset.put(SourceInfo.TIMESTAMP, 0);
@@ -118,17 +115,15 @@ public class MongoDbOffsetContextTest {
 
         MongoDbOffsetContext context = loader.load(offset);
 
-        // getSourceInfo() builds a Struct with required "collection" field = null → crash
-        assertThatThrownBy(() -> context.getSourceInfo())
-                .as("getSourceInfo() should throw when collectionId is null (required field)")
-                .isInstanceOf(DataException.class)
-                .hasMessageContaining("collection");
+        assertThatNoException()
+                .as("getSourceInfo() should not throw when collectionId is null (optional field)")
+                .isThrownBy(() -> assertThat(context.getSourceInfo().getString(SourceInfo.COLLECTION)).isNull());
     }
 
     /**
-     * Bug 2 fix verification: getOffset() should work even when collectionId is null,
-     * providing a safe alternative for error messages. This is used in
-     * MongoDbConnectorTask.validate() instead of the unsafe getSourceInfo().
+     * getOffset() works even when collectionId is null. Now that getSourceInfo() is also safe,
+     * both are usable for error messages; getOffset() remains the choice in
+     * MongoDbConnectorTask.validate().
      */
     @Test
     public void getOffsetWorksWhenCollectionIsNull() {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.mongodb;
 
 import static io.debezium.data.VerifyRecord.assertConnectSchemasAreEqual;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +31,7 @@ import com.mongodb.client.model.changestream.OperationType;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
 import io.debezium.schema.SchemaFactory;
 
 /**
@@ -202,6 +204,21 @@ public class SourceInfoTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#1862")
+    void shouldProduceStructWithoutCollectionWhenNoEventPositionIsRecorded() {
+        // A no-event position (e.g. a heartbeat or the streaming start offset) records a position but
+        // resets the collection to null via CollectionId.parse(""). Building the source struct in that
+        // state must not fail: the collection field is optional and is simply omitted. This is the
+        // root cause behind the crash reported in debezium/dbz#1862.
+        source.noEvent(new BsonTimestamp(1666193824, 1));
+
+        assertThatCode(() -> {
+            Struct struct = source.struct();
+            assertThat(struct.getString(SourceInfo.COLLECTION)).isNull();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
     void shouldReturnOffsetForUnusedReplicaNameDuringInitialSnapshot() {
         source.startInitialSnapshot();
         assertSourceInfoContents(source, false, null, new BsonTimestamp(0), "true");
@@ -253,7 +270,7 @@ public class SourceInfoTest {
         assertThat(schema.version()).isEqualTo(SchemaFactory.SOURCE_INFO_DEFAULT_SCHEMA_VERSION);
         assertThat(schema.field(SourceInfo.SERVER_NAME_KEY).schema()).isEqualTo(Schema.STRING_SCHEMA);
         assertThat(schema.field(SourceInfo.DATABASE_NAME_KEY).schema()).isEqualTo(Schema.STRING_SCHEMA);
-        assertThat(schema.field(SourceInfo.COLLECTION).schema()).isEqualTo(Schema.STRING_SCHEMA);
+        assertThat(schema.field(SourceInfo.COLLECTION).schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
         assertThat(schema.field(SourceInfo.TIMESTAMP_KEY).schema()).isEqualTo(Schema.INT64_SCHEMA);
         assertThat(schema.field(SourceInfo.ORDER).schema()).isEqualTo(Schema.INT32_SCHEMA);
         assertThat(schema.field(SourceInfo.SNAPSHOT_KEY).schema()).isEqualTo(SchemaFactory.get().snapshotRecordSchema());
@@ -273,7 +290,7 @@ public class SourceInfoTest {
                 .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("ts_us", Schema.OPTIONAL_INT64_SCHEMA)
                 .field("ts_ns", Schema.OPTIONAL_INT64_SCHEMA)
-                .field("collection", Schema.STRING_SCHEMA)
+                .field("collection", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("ord", Schema.INT32_SCHEMA)
                 .field("lsid", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("txnNumber", Schema.OPTIONAL_INT64_SCHEMA)

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -842,7 +842,7 @@ The following example shows the value portion of a change event that the connect
             },
             {
               "type": "string",
-              "optional": false,
+              "optional": true,
               "field": "collection"
             },
             {


### PR DESCRIPTION
Fixes debezium/dbz#1862.

This PR addresses the null `source.collection` crash during connector startup/offset validation reported in that issue. The separately reported event-loss/key-concatenation symptoms are outside the scope of this change.

## Problem

The MongoDB connector declares `source.collection` as a required `STRING` schema field, but populates it with `null` during no-event positions (such as heartbeats or streaming start offsets). This causes Kafka Connect to throw a `DataException`:

```
org.apache.kafka.connect.errors.DataException: Invalid value: null used for required field: "collection", schema type: STRING
```

For historical context, the earlier work under debezium/dbz#1708 added a workaround in `MongoDbConnectorTask.validate()` by falling back to `getOffset()`, but left the required schema untouched. Other callers invoking `getSourceInfo()` (such as startup or offset validation after a restart) remained vulnerable to the null-collection crash reported in debezium/dbz#1862. This PR is tracked under debezium/dbz#1862; debezium/dbz#1708 is referenced only as background.

## Solution

- **Updated Schema Definition:** Changed `SourceInfo.COLLECTION` to `OPTIONAL_STRING_SCHEMA`.
- **Omitted Null Fields:** Updated the struct-building logic to omit the `collection` field entirely when `collectionId` is `null` (matching `BinlogSourceInfoStructMaker`).
- **Root-Cause Fix:** Resolves the schema contradiction at the definition level so no `getSourceInfo()` call site can trigger a `DataException`.

## Compatibility

- **Backward Compatible:** Changing a schema field from required to optional is fully backward-compatible.
- **Data Integrity:** Real CDC events continue to populate `collection` exactly as before. Only the schema definition changes to allow the field to be absent during no-event positions.

## Testing & Verification

### Unit Tests

- `SourceInfoTest#shouldProduceStructWithoutCollectionWhenNoEventPositionIsRecorded`: Verifies that streaming no-event positions build structs with `collection` omitted (failed prior to fix).
- `MongoDbOffsetContextTest#getSourceInfoDoesNotThrowWhenCollectionIsNull`: Replaces `getSourceInfoThrowsWhenCollectionIsNull` (which previously pinned the crash as expected behavior) to verify restart/offset-reload paths.
- Updated `shouldHaveSchemaForSource` and `schemaIsCorrect` to reflect `optional: true`.
- Passed full `debezium-connector-mongodb` test suite.

### Manual Runtime Verification

Tested on Kafka Connect 3.6.1.Final:

- Emitted `source.collection` values remain identical across read/create/delete events.
- Schema correctly reflects `optional: true`.
- Connector successfully streams, emits heartbeats, and recovers from restarts without `DataException`.
