### PR TITLE
[docs] Fix typos in connector docs

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -62,7 +62,7 @@ The {prodname} JDBC connector provides the following features:
 * xref:jdbc-schema-evolution[Schema evolution]
 * xref:jdbc-quoting-case-sensitivity[JDBC quoting and case-sensitivity]
 * xref:jdbc-connection-idle-timeouts[Connection idle timeouts]
-ifdef::community
+ifdef::community[]
 * xref:jdbc-singlestore-targets[SingleStore sink targets]
 * xref:jdbc-starrocks-targets[StarRocks sink targets]
 * xref:jdbc-cockroachdb-targets[CockroachDB sink targets]

--- a/documentation/modules/ROOT/pages/connectors/jdbc.adoc
+++ b/documentation/modules/ROOT/pages/connectors/jdbc.adoc
@@ -482,8 +482,7 @@ The connector writes {prodname} `io.debezium.time.Time`, `io.debezium.time.Micro
 MySQL `TIME` values outside of the 24-hour clock range retain the MySQL `[-]HHH:mm:ss.ffffff` notation, and `io.debezium.time.ZonedTime` values are stored verbatim with their original offset.
 
 `io.debezium.time.ZonedTimestamp` values are normalized to the database time zone and written to `DATETIME` columns; the original offset is not preserved.
-S
-tarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
+StarRocks `DATETIME` columns do not accept a precision argument; StarRocks retains fractional seconds up to microsecond precision.
 
 Note that the StarRocks JDBC driver reports `DATETIME` columns without fractional second precision, so although values are stored with microsecond precision, reading them through the JDBC driver truncates the fraction unless the value is explicitly cast, for example, to `VARCHAR`.
 


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
[docs] Fix typos

## Description

**`jdbc.adoc`**

* **L65**: Fixes an error introduced in DBZ-9958 to conditionalize a list of features available in the JDBC connector.
The original change omitted the required pair of trailing square brackets at the end of the opening `ifdef` statement.
As a result of the error, Antora reports an error and the conditionalization markup is rendered literally in the output.

* **L485**: Removes a stray newline that was placed in the middle of a string.

**`mongodb.adoc`**

* **L1**:  Removes characters inadvertently inserted before the initial annotation comment, which results in the following Antora build error:
`ERROR (asciidoctor): level 0 sections can only be used when doctype is book
    file: /home/broldan/git/debezium/documentation/modules/ROOT/pages/connectors/mongodb.adoc:4`

Tested in a local Antora build.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
