### PR TITLE
[docs] Remove stray characters prefixed to mongodb.adoc first line

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1,4 +1,4 @@
-brolda// Category: debezium-using
+// Category: debezium-using
 // Type: assembly
 [id="debezium-connector-for-mongodb"]
 = {prodname} connector for MongoDB


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
[docs] Fix typo that inserted stray characters before metadata comment on `mongodb.adoc` L1

## Description
Stray character preceded the modularization comment on L1 of mongodb.adoc, resulting in Antora reporting the following error when building the docs:

```
ERROR (asciidoctor): level 0 sections can only be used when doctype is book
    file: ... documentation/modules/ROOT/pages/connectors/mongodb.adoc:4
```

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.6`
