### PR TITLE
debezium/dbz#2599 Document CdcDirectoryTotalBytes streaming metric

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -882,3 +882,4 @@ Surya Dhaneshwar
 exgoya
 bhuvan-somisetty
 Akshat Sapra
+Paulo Silva

--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -1113,6 +1113,10 @@ The following table lists the streaming metrics that are available.
 |`long`
 |The number of unrecoverable errors while processing commit logs.
 
+|`CdcDirectoryTotalBytes`
+|`long`
+|The total size in bytes of the CDC directory on disk, sampled each time the connector scans the directory for new commit logs.
+
 |===
 
 [[cassandra-tracing]]

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -414,3 +414,4 @@ tusharsaini18899,Tushar Saini
 tingley,Chase Tingley
 bhuvan-somisetty,bhuvan-somisetty
 akshat08,Akshat Sapra
+cezarpaulo16,Paulo Silva


### PR DESCRIPTION
  Fixes debezium/dbz#2599
  
  ## Description
  
  The Cassandra connector exposes a `CdcDirectoryTotalBytes` JMX attribute on its
  streaming MBean (`debezium.cassandra:type=connector-metrics,context=streaming,server=<topic.prefix>`),
  but the streaming metrics table in the connector documentation never listed it.
  
  The metric was added in debezium/debezium-connector-cassandra commit `09e73ca`
  (debezium/dbz#1618) and first shipped in v3.5.0.Beta2. It is populated by
  `updateCdcDirectorySizeMetric()` in both `CommitLogProcessor` and
  `CommitLogIdxProcessor` via `FileUtils.sizeOfDirectory(cdcDir)`, once per
  processing cycle — so it is a point-in-time gauge of the CDC directory size,
  not a cumulative counter. The description is worded to make that clear.
  
  This adds the missing row to the streaming metrics table. Documentation only,
  no code changes.
  
  ## PR Checklist
  - [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
  - [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
  - [x] One feature/change per PR unless tightly coupled
  - [x] Do a rebase on upstream `main`
