### PR TITLE
DBZ-10036 Add missing documentation for PostgreSQL lsn.flush.timeout.* props to 3.6

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -4414,6 +4414,26 @@ For more information about the support scope of Red{nbsp}Hat Technology Preview 
 If you use an ephemeral offset store such as `org.apache.kafka.connect.storage.MemoryOffsetBackingStore`, no additional configuration is needed because the connector always defers to the replication slot position on startup.
 ====
 
+|[[postgresql-property-lsn-flush-timeout-action]]<<postgresql-property-lsn-flush-timeout-action, `+lsn.flush.timeout.action+`>>
+|`fail`
+|Specifies the action to take when an LSN flush operation times out.
+
+Set one of the following options:
+
+`fail`::
+Fails the connector.
+
+`warn`::
+Logs a warning and continues processing.
+
+`ignore`::
+Continues processing and ignores the timeout.
+
+|[[postgresql-property-lsn-flush-timeout-ms]]<<postgresql-property-lsn-flush-timeout-ms, `+lsn.flush.timeout.ms+`>>
+|30000 (30 seconds)
+|The maximum time, in milliseconds, that the connector waits for an LSN flush operation to complete.
+If the operation does not complete within the specified interval, the connector takes the action configured in the xref:postgresql-property-lsn-flush-timeout-action[`lsn.flush.timeout.action`] property.
+
 |[[postgresql-property-retriable-restart-connector-wait-ms]]<<postgresql-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>>
 |10000 (10 seconds)
 |The number of milliseconds to wait before restarting a connector after a retriable error occurs.


### PR DESCRIPTION
(cherry picked from commit e975a0341ed3d1560f30b90e6b712f3b7a4120cd)

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes [DBZ-10036](https://redhat.atlassian.net/browse/DBZ-10036)

## Description
Creates entries in the PostgreSQL connector Advanced configuration properties table for `lsn.flush.timeout.action` and `lsn.flush.timeout.ms` which was omitted in the documentation for earlier releases.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `3.6`
