### PR TITLE
debezium/dbz#2604 Fix incremental snapshot recovery after schema mismatches in MySQL and MariaDB

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -21,6 +21,7 @@ import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
 import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -165,12 +166,29 @@ public abstract class BinlogReadOnlyIncrementalSnapshotChangeEventSource<P exten
         return (BinlogReadOnlyIncrementalSnapshotContext<TableId>) context;
     }
 
+    @Override
+    protected boolean supportsSchemaMismatchRecovery() {
+        return true;
+    }
+
+    @Override
+    protected void postReadChunk(IncrementalSnapshotContext<TableId> context) {
+        // Binlog snapshot queries must not retain metadata locks between chunks, even if
+        // a watermark method returns without ending the transaction or a chunk exits early.
+        rollbackChunkTransaction(null);
+        super.postReadChunk(context);
+    }
+
     private void readUntilGtidChange(P partition, OffsetContext offsetContext) throws InterruptedException {
         String currentGtid = getContext().getCurrentGtid(offsetContext);
         while (getContext().snapshotRunning() && getContext().reachedHighWatermark(currentGtid)) {
             getContext().closeWindow();
             sendWindowEvents(partition, offsetContext);
             readChunk(partition, offsetContext);
+            if (isSchemaMismatchRetryPending()) {
+                // Yield to streaming so that a pending DDL event can refresh the table model.
+                return;
+            }
             if (currentGtid == null && getContext().watermarksChanged()) {
                 return;
             }

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
@@ -44,6 +45,19 @@ public class BinlogSignalBasedIncrementalSnapshotChangeEventSource<P extends Bin
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.schema = databaseSchema;
         this.binlogConnectorConnection = jdbcConnection;
+    }
+
+    @Override
+    protected boolean supportsSchemaMismatchRecovery() {
+        return true;
+    }
+
+    @Override
+    protected void postReadChunk(IncrementalSnapshotContext<TableId> context) {
+        // Binlog snapshot queries must not retain metadata locks between chunks, even if
+        // a watermark method returns without ending the transaction or a chunk exits early.
+        rollbackChunkTransaction(null);
+        super.postReadChunk(context);
     }
 
     @Override

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogIncrementalSnapshotRecoveryIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogIncrementalSnapshotRecoveryIT.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.binlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
+import io.debezium.connector.binlog.util.BinlogTestConnection;
+import io.debezium.connector.binlog.util.TestHelper;
+import io.debezium.connector.binlog.util.UniqueDatabase;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.common.DebeziumHeaderProducer;
+import io.debezium.converters.custom.CustomConverterServiceProvider;
+import io.debezium.doc.FixFor;
+import io.debezium.document.DocumentReader;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.signal.SignalProcessor;
+import io.debezium.pipeline.signal.SignalRecord;
+import io.debezium.pipeline.signal.actions.snapshotting.CloseIncrementalSnapshotWindow;
+import io.debezium.pipeline.signal.actions.snapshotting.OpenIncrementalSnapshotWindow;
+import io.debezium.pipeline.signal.actions.snapshotting.ResumeIncrementalSnapshot;
+import io.debezium.pipeline.signal.channels.SourceSignalChannel;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaFactory;
+import io.debezium.util.Clock;
+import io.debezium.util.LoggingContext;
+
+/**
+ * Exercises schema-cache races deterministically with real JDBC queries and snapshot records.
+ * Watermark callbacks and the timing of cached schema updates are controlled by the test.
+ */
+@Timeout(30)
+public abstract class BinlogIncrementalSnapshotRecoveryIT<C extends SourceConnector, P extends BinlogPartition, O extends BinlogOffsetContext<?>>
+        implements BinlogConnectorTest<C> {
+
+    protected final UniqueDatabase database = TestHelper.getUniqueDatabase("recovery", "incremental_recovery");
+    protected BinlogConnectorConfig config;
+    protected BinlogConnectorConnection jdbc;
+    protected BinlogDatabaseSchema<P, O, ?, ?> schema;
+    protected P partition;
+    protected O offset;
+    protected EventDispatcher<P, TableId> dispatcher;
+    protected NotificationService<P, O> notifications;
+    private BinlogTestConnection observer;
+    private ChangeEventQueue<DataChangeEvent> queue;
+    private AbstractIncrementalSnapshotChangeEventSource<P, TableId> source;
+    private IncrementalSnapshotContext<TableId> context;
+    private boolean readOnly;
+    private SignalProcessor<P, O> signalProcessor;
+    private SourceSignalChannel signalChannel;
+    private ErrorHandler errorHandler;
+
+    protected abstract BinlogConnectorConfig createConfig(Configuration configuration);
+
+    protected abstract BinlogConnectorConnection createConnection(Configuration configuration);
+
+    protected abstract CdcSourceTaskContext<?> createTaskContext(Configuration configuration);
+
+    protected abstract BinlogDatabaseSchema<P, O, ?, ?> createSchema(CdcSourceTaskContext<?> taskContext);
+
+    protected abstract P createPartition();
+
+    protected abstract O createOffset();
+
+    protected abstract AbstractIncrementalSnapshotChangeEventSource<P, TableId> createReadOnlySource();
+
+    @BeforeEach
+    void createTables() throws SQLException {
+        database.create();
+        observer = getTestDatabaseConnection(database.getDatabaseName());
+        observer.execute("CREATE TABLE a(pk INT PRIMARY KEY, aa INT, c INT)",
+                "INSERT INTO a VALUES (1,10,101),(2,20,102),(3,30,103),(4,40,104),(5,50,105)",
+                "CREATE TABLE b(pk INT PRIMARY KEY, aa INT, c INT)",
+                "INSERT INTO b VALUES (11,110,111),(12,120,112),(13,130,113)",
+                "CREATE TABLE signal_table(id VARCHAR(100) PRIMARY KEY, type VARCHAR(100), data VARCHAR(2000))",
+                "CREATE TABLE ticks(id INT AUTO_INCREMENT PRIMARY KEY)",
+                "SET SESSION lock_wait_timeout=2");
+    }
+
+    @AfterEach
+    void closeResources() throws Exception {
+        try {
+            if (signalProcessor != null) {
+                signalProcessor.stop();
+            }
+            if (jdbc != null) {
+                jdbc.close();
+            }
+        }
+        finally {
+            if (dispatcher != null) {
+                dispatcher.close();
+            }
+            if (queue != null) {
+                queue.close();
+            }
+            if (schema != null) {
+                schema.close();
+            }
+            if (observer != null) {
+                observer.close();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @FixFor("debezium/dbz#2604")
+    @ValueSource(strings = { "read-only", "insert_insert", "insert_delete" })
+    void shouldRecoverFirstChunkAndCompleteNextTable(String mode) throws Exception {
+        initialize(mode, true);
+        schema.refresh(table("a", false));
+        context.maximumKey(new Object[]{ 5 });
+        seedVerifiedSchema();
+
+        source.init(partition, offset);
+
+        assertRetryPreservesTableAndReleasesLock();
+        schema.refresh(table("a", true));
+        assertAllRows(completeSnapshot());
+    }
+
+    @ParameterizedTest
+    @FixFor("debezium/dbz#2604")
+    @ValueSource(strings = { "read-only", "insert_insert", "insert_delete" })
+    void shouldRecoverMaximumKeyQuery(String mode) throws Exception {
+        initialize(mode, true);
+        schema.refresh(table("a", false));
+        seedVerifiedSchema();
+
+        source.init(partition, offset);
+
+        assertThat(context.maximumKey()).isEmpty();
+        assertRetryPreservesTableAndReleasesLock();
+        schema.refresh(table("a", true));
+        assertAllRows(completeSnapshot());
+    }
+
+    @ParameterizedTest
+    @FixFor("debezium/dbz#2604")
+    @ValueSource(strings = { "read-only", "insert_insert", "insert_delete" })
+    void shouldRetryFromLastEmittedKey(String mode) throws Exception {
+        initialize(mode, true);
+        // Model a resumed snapshot whose first chunk (keys 1 and 2) was already emitted.
+        context.sendEvent(new Object[]{ 2 });
+        context.nextChunkPosition(new Object[]{ 2 });
+        context.maximumKey(new Object[]{ 5 });
+        schema.refresh(table("a", false));
+        seedVerifiedSchema();
+
+        source.init(partition, offset);
+
+        assertRetryPreservesTableAndReleasesLock();
+        assertThat(context.chunkEndPosititon()).containsExactly(2);
+        schema.refresh(table("a", true));
+        final var records = completeSnapshot();
+        assertRows(records, List.of(3, 4, 5, 11, 12, 13));
+    }
+
+    @ParameterizedTest
+    @FixFor("debezium/dbz#2604")
+    @ValueSource(strings = { "read-only", "insert_insert", "insert_delete" })
+    void shouldPreserveNormalSnapshotBehavior(String mode) throws Exception {
+        initialize(mode, true);
+        source.init(partition, offset);
+        assertAllRows(completeSnapshot());
+    }
+
+    @ParameterizedTest
+    @FixFor("debezium/dbz#2604")
+    @ValueSource(strings = { "read-only", "insert_insert", "insert_delete" })
+    void shouldReleaseFailedReadTransactionWhenRecoveryIsDisabled(String mode) throws Exception {
+        initialize(mode, false);
+        schema.refresh(table("a", false));
+        context.maximumKey(new Object[]{ 5 });
+
+        source.init(partition, offset);
+
+        assertThat(context.currentDataCollectionId().getId()).isEqualTo(tableId("b"));
+        assertThat(queue.poll()).isEmpty();
+        assertDdlIsNotBlocked();
+    }
+
+    @ParameterizedTest
+    @FixFor("debezium/dbz#2604")
+    @ValueSource(strings = { "read-only", "insert_insert", "insert_delete" })
+    void shouldKeepRetryingPersistentMismatchWithoutSkippingTables(String mode) throws Exception {
+        initialize(mode, true);
+        schema.refresh(table("a", false));
+        context.maximumKey(new Object[]{ 5 });
+        seedVerifiedSchema();
+        source.init(partition, offset);
+
+        for (int i = 0; i < 5; i++) {
+            advanceWatermark();
+            assertRetryPreservesTableAndReleasesLock();
+            assertThat(errorHandler.getProducerThrowable()).isNull();
+        }
+
+        schema.refresh(table("a", true));
+        assertAllRows(completeSnapshot());
+    }
+
+    @ParameterizedTest
+    @FixFor("debezium/dbz#2604")
+    @ValueSource(strings = { "insert_insert", "insert_delete" })
+    void shouldReportRecoveryWindowFailureThroughSignalProcessor(String mode) throws Exception {
+        initialize(mode, true);
+        source.setErrorHandler(errorHandler);
+        schema.refresh(table("a", false));
+        context.maximumKey(new Object[]{ 5 });
+        seedVerifiedSchema();
+        if (mode.equals("insert_insert")) {
+            observer.execute("CREATE TRIGGER fail_close BEFORE INSERT ON signal_table FOR EACH ROW "
+                    + "BEGIN IF NEW.type = 'snapshot-window-close' THEN "
+                    + "SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT='Injected window close failure'; END IF; END");
+        }
+        else {
+            observer.execute("CREATE TRIGGER fail_close BEFORE DELETE ON signal_table FOR EACH ROW "
+                    + "SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT='Injected window close failure'");
+        }
+        context.pauseSnapshot();
+        source.init(partition, offset);
+
+        // SignalProcessor catches action exceptions; the task must still see the recovery failure.
+        processSignal("resume", ResumeIncrementalSnapshot.NAME);
+
+        assertThat(context.snapshotRunning()).isTrue();
+        assertThat(context.currentDataCollectionId().getId()).isEqualTo(tableId("a"));
+        assertThat(errorHandler.getProducerThrowable()).hasMessageContaining("Could not close incremental snapshot window");
+        assertThatThrownBy(() -> queue.poll()).isInstanceOf(ConnectException.class);
+        assertDdlIsNotBlocked();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void initialize(String mode, boolean schemaChanges) throws Exception {
+        readOnly = mode.equals("read-only");
+        final var configuration = database.defaultConfig()
+                .with(BinlogConnectorConfig.USER, "mysqluser")
+                .with(BinlogConnectorConfig.PASSWORD, "mysqlpw")
+                .with(BinlogConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
+                .with(BinlogConnectorConfig.READ_ONLY_CONNECTION, readOnly)
+                .with(BinlogConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 2)
+                .with(BinlogConnectorConfig.INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES, schemaChanges)
+                .with(BinlogConnectorConfig.SIGNAL_DATA_COLLECTION, database.qualifiedTableName("signal_table"))
+                .with(BinlogConnectorConfig.SIGNAL_EMIT_FAILURE_MAX_RETRIES, 0)
+                .with(BinlogConnectorConfig.INCREMENTAL_SNAPSHOT_WATERMARKING_STRATEGY, readOnly ? "insert_insert" : mode)
+                .with("schema.history.internal", "io.debezium.relational.history.MemorySchemaHistory")
+                .build();
+        config = createConfig(configuration);
+        config.getServiceRegistry().registerServiceProvider(new CustomConverterServiceProvider());
+        jdbc = createConnection(configuration);
+        jdbc.connect();
+        assumeTrue(!readOnly || jdbc.isGtidModeEnabled(), "Read-only incremental snapshots require GTID mode");
+        final var taskContext = createTaskContext(configuration);
+        schema = createSchema(taskContext);
+        schema.refresh(table("a", true));
+        schema.refresh(table("b", true));
+        partition = createPartition();
+        offset = createOffset();
+        context = (IncrementalSnapshotContext<TableId>) offset.getIncrementalSnapshotContext();
+        context.addDataCollectionNamesToSnapshot("recovery", List.of(database.qualifiedTableName("a"), database.qualifiedTableName("b")), List.of(), "");
+        queue = new ChangeEventQueue.Builder<DataChangeEvent>()
+                .maxBatchSize(100).maxQueueSize(1000).pollInterval(Duration.ofMillis(10))
+                .loggingContextSupplier(() -> LoggingContext.forConnector(getConnectorName(), "recovery", "test"))
+                .build();
+        dispatcher = new EventDispatcher<>(config, config.getTopicNamingStrategy(BinlogConnectorConfig.TOPIC_NAMING_STRATEGY),
+                schema, queue, config.getTableFilters().dataCollectionFilter(), DataChangeEvent::new,
+                new BinlogEventMetadataProvider(), Heartbeat.ScheduledHeartbeat.NOOP_HEARTBEAT,
+                config.schemaNameAdjuster(), new DebeziumHeaderProducer(taskContext));
+        notifications = new NotificationService<>(List.of(), config, SchemaFactory.get(), record -> {
+        });
+        source = readOnly ? createReadOnlySource()
+                : new BinlogSignalBasedIncrementalSnapshotChangeEventSource<>(config, jdbc, dispatcher, schema,
+                        Clock.system(), SnapshotProgressListener.NO_OP(), DataChangeEventListener.NO_OP(), notifications);
+        errorHandler = new ErrorHandler(getConnectorClass(), config, queue, null);
+        dispatcher.setIncrementalSnapshotChangeEventSource(java.util.Optional.of(source));
+        signalChannel = new SourceSignalChannel();
+        signalProcessor = new SignalProcessor<>(getConnectorClass(), config,
+                Map.of(OpenIncrementalSnapshotWindow.NAME, new OpenIncrementalSnapshotWindow<>(),
+                        CloseIncrementalSnapshotWindow.NAME, new CloseIncrementalSnapshotWindow<>(dispatcher),
+                        ResumeIncrementalSnapshot.NAME, new ResumeIncrementalSnapshot<>(dispatcher)),
+                List.of(signalChannel), DocumentReader.defaultReader(), Offsets.of(partition, offset));
+    }
+
+    private void seedVerifiedSchema() throws SQLException {
+        // Schema verification compares JDBC metadata across windows, not with the binlog model.
+        // Keep that metadata current while deliberately leaving the cached table definition stale.
+        jdbc.query("SELECT * FROM " + tableId("a").toQuotedString('`') + " LIMIT 0", rows -> {
+            final var metadata = rows.getMetaData();
+            List<Column> columns = new ArrayList<>();
+            for (int i = 1; i <= metadata.getColumnCount(); i++) {
+                columns.add(Column.editor().name(metadata.getColumnName(i)).jdbcType(metadata.getColumnType(i))
+                        .type(metadata.getColumnTypeName(i)).optional(metadata.isNullable(i) > 0)
+                        .length(metadata.getPrecision(i)).scale(metadata.getScale(i)).create());
+            }
+            Collections.sort(columns);
+            context.setSchema(Table.editor().tableId(tableId("a")).addColumns(columns).create());
+        });
+        context.setSchemaVerificationPassed(true);
+    }
+
+    private void assertRetryPreservesTableAndReleasesLock() throws Exception {
+        assertThat(context.snapshotRunning()).isTrue();
+        assertThat(context.currentDataCollectionId().getId()).isEqualTo(tableId("a"));
+        assertThat(queue.poll()).isEmpty();
+        assertDdlIsNotBlocked();
+    }
+
+    private void assertDdlIsNotBlocked() throws SQLException {
+        // A closed ResultSet is insufficient: a retained read transaction blocks this DDL.
+        observer.execute("ALTER TABLE a COMMENT='chunk transaction released'");
+    }
+
+    private List<SourceRecord> completeSnapshot() throws Exception {
+        List<SourceRecord> records = new ArrayList<>();
+        for (int i = 0; i < 30 && context.snapshotRunning(); i++) {
+            advanceWatermark();
+            queue.poll().forEach(event -> records.add(event.getRecord()));
+        }
+        assertThat(context.snapshotRunning()).as("both tables must complete").isFalse();
+        queue.poll().forEach(event -> records.add(event.getRecord()));
+        return records;
+    }
+
+    private void advanceWatermark() throws Exception {
+        if (readOnly) {
+            observer.execute("INSERT INTO ticks VALUES (NULL)");
+            final String gtidSet = jdbc.knownGtidSet().toString();
+            jdbc.commit();
+            final String gtid;
+            if (isMariaDb()) {
+                final String serverId = observer.queryAndMap("SELECT @@SESSION.gtid_domain_id, @@server_id", rows -> {
+                    rows.next();
+                    return rows.getString(1) + "-" + rows.getString(2) + "-";
+                });
+                gtid = Arrays.stream(gtidSet.split(",")).map(String::trim)
+                        .filter(value -> value.startsWith(serverId)).findFirst().orElseThrow();
+            }
+            else {
+                final String serverId = observer.queryAndMap("SELECT @@server_uuid", rows -> {
+                    rows.next();
+                    return rows.getString(1);
+                });
+                final String serverSet = Arrays.stream(gtidSet.split(",")).map(String::trim)
+                        .filter(value -> value.startsWith(serverId + ":")).findFirst().orElseThrow();
+                final String interval = serverSet.substring(serverSet.lastIndexOf(':') + 1);
+                gtid = serverId + ":" + interval.substring(interval.lastIndexOf('-') + 1);
+            }
+            offset.startGtid(gtid, gtidSet);
+            source.processTransactionCommittedEvent(partition, offset);
+        }
+        else {
+            final String chunkId = context.currentChunkId();
+            processSignal(chunkId + "-open", OpenIncrementalSnapshotWindow.NAME);
+            processSignal(chunkId + "-close", CloseIncrementalSnapshotWindow.NAME);
+        }
+    }
+
+    private void processSignal(String id, String type) {
+        signalChannel.signals.add(new SignalRecord(id, type, "{}", Map.of()));
+        signalProcessor.processSourceSignal(partition);
+    }
+
+    private void assertAllRows(List<SourceRecord> records) {
+        assertRows(records, List.of(1, 2, 3, 4, 5, 11, 12, 13));
+    }
+
+    private void assertRows(List<SourceRecord> records, List<Integer> expectedKeys) {
+        List<Integer> keys = new ArrayList<>();
+        for (final var record : records) {
+            final var envelope = (Struct) record.value();
+            assertThat(envelope.getString("op")).isEqualTo("r");
+            final var row = envelope.getStruct("after");
+            final int key = row.getInt32("pk");
+            keys.add(key);
+            assertThat(row.getInt32("c")).isEqualTo(100 + key);
+            assertThat(record.topic()).isEqualTo(database.topicForTable(key < 10 ? "a" : "b"));
+        }
+        assertThat(keys).containsExactlyElementsOf(expectedKeys);
+    }
+
+    private TableId tableId(String name) {
+        return new TableId(database.getDatabaseName(), null, name);
+    }
+
+    private Table table(String name, boolean includeNewColumn) {
+        final var editor = Table.editor().tableId(tableId(name))
+                .addColumns(Column.editor().name("pk").jdbcType(Types.INTEGER).type("INT").optional(false).create(),
+                        Column.editor().name("aa").jdbcType(Types.INTEGER).type("INT").optional(true).create());
+        if (includeNewColumn) {
+            editor.addColumn(Column.editor().name("c").jdbcType(Types.INTEGER).type("INT").optional(true).create());
+        }
+        return editor.setPrimaryKeyNames("pk").create();
+    }
+}

--- a/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-common/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -37,6 +37,7 @@ import io.debezium.annotation.NotThreadSafe;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.ValueWrapper;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.IncrementalSnapshotNotificationService.TableScanCompletionStatus;
 import io.debezium.pipeline.notification.NotificationService;
@@ -73,6 +74,9 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         implements IncrementalSnapshotChangeEventSource<P, T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractIncrementalSnapshotChangeEventSource.class);
+
+    private boolean schemaMismatchRetryPending;
+    private ErrorHandler errorHandler;
 
     protected final RelationalDatabaseConnectorConfig connectorConfig;
     private final Clock clock;
@@ -316,6 +320,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
                 try {
                     if (createDataEventsForTable(partition)) {
+                        schemaMismatchRetryPending = false;
 
                         if (!context.snapshotRunning()) { // A stop signal has been processed and window cleared.
                             return;
@@ -354,10 +359,23 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             emitWindowClose(partition, offsetContext);
             LOGGER.trace("Window close emitted");
         }
+        catch (ColumnUtils.SchemaMismatchException e) {
+            rollbackChunkTransaction(e);
+            if (supportsSchemaMismatchRecovery() && connectorConfig.isIncrementalSnapshotSchemaChangesEnabled()) {
+                retryChunkAfterSchemaMismatch(partition, offsetContext, e);
+            }
+            else {
+                warnAndSkip(partition, offsetContext, SQL_EXCEPTION,
+                        "Schema mismatch while executing incremental snapshot for table '%s', skipping and continuing streaming"
+                                .formatted(context.currentDataCollectionId().getId()),
+                        e);
+            }
+        }
         catch (SQLException e) {
             if (e instanceof SQLNonTransientConnectionException) {
                 closeJdbcConnection();
             }
+            rollbackChunkTransaction(e);
             warnAndSkip(partition, offsetContext,
                     SQL_EXCEPTION,
                     "SQL error while executing incremental snapshot for table '%s', skipping and continuing streaming"
@@ -365,6 +383,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                     e);
         }
         catch (Exception e) {
+            rollbackChunkTransaction(e);
             warnAndSkip(partition, offsetContext,
                     SQL_EXCEPTION,
                     "Error while executing incremental snapshot for table '%s', skipping and continuing streaming".formatted(context.currentDataCollectionId().getId()),
@@ -376,6 +395,67 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                 postIncrementalSnapshotCompleted();
             }
         }
+    }
+
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    protected boolean supportsSchemaMismatchRecovery() {
+        return false;
+    }
+
+    protected boolean isSchemaMismatchRetryPending() {
+        return schemaMismatchRetryPending;
+    }
+
+    private void retryChunkAfterSchemaMismatch(P partition, OffsetContext offsetContext, ColumnUtils.SchemaMismatchException cause)
+            throws InterruptedException {
+        // Do not publish a partially read chunk or advance to the next table. Streaming must
+        // process the intervening DDL before the next window attempts the same chunk again.
+        window.clear();
+        context.revertChunk();
+        context.setSchemaVerificationPassed(false);
+        schemaMismatchRetryPending = true;
+        LOGGER.warn("Retrying incremental snapshot chunk for table {} in the next watermark window after a schema mismatch",
+                context.currentDataCollectionId().getId(), cause);
+        try {
+            // The failed read transaction has already been rolled back. Close the empty window
+            // so streaming can process the DDL before the next attempt reads the same chunk.
+            emitWindowClose(partition, offsetContext);
+        }
+        catch (InterruptedException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            e.addSuppressed(cause);
+            throw reportFailure("Could not close incremental snapshot window after a schema mismatch", e);
+        }
+    }
+
+    protected void rollbackChunkTransaction(Throwable chunkFailure) {
+        try {
+            // A failed read can bypass the window-close transaction boundary and retain
+            // metadata locks. rollback() does not reconnect an already closed connection.
+            jdbcConnection.rollback();
+        }
+        catch (SQLException e) {
+            closeJdbcConnection();
+            if (chunkFailure != null) {
+                e.addSuppressed(chunkFailure);
+            }
+            throw reportFailure("Could not roll back the incremental snapshot chunk", e);
+        }
+    }
+
+    private DebeziumException reportFailure(String message, Throwable cause) {
+        final var failure = new DebeziumException(message, cause);
+        // SignalProcessor catches action exceptions. Also report a fatal recovery failure to
+        // the task's queue so it cannot continue streaming with an incomplete snapshot window.
+        if (errorHandler != null) {
+            errorHandler.setProducerThrowable(failure);
+        }
+        return failure;
     }
 
     private boolean isTableInvalid(P partition, OffsetContext offsetContext) {
@@ -487,6 +567,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
     }
 
     private void nextDataCollection(P partition, OffsetContext offsetContext) {
+        schemaMismatchRetryPending = false;
         context.nextDataCollection();
         if (!context.snapshotRunning()) {
             progressListener.snapshotCompleted(partition);
@@ -521,6 +602,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         validateSignalTableConfiguration(newDataCollectionIds);
 
         if (shouldReadChunk) {
+            schemaMismatchRetryPending = false;
 
             List<T> monitoredDataCollections = newDataCollectionIds.stream()
                     .map(DataCollection::getId).collect(Collectors.toList());

--- a/debezium-connector-common/src/main/java/io/debezium/util/ColumnUtils.java
+++ b/debezium-connector-common/src/main/java/io/debezium/util/ColumnUtils.java
@@ -47,7 +47,7 @@ public class ColumnUtils {
                 for (int j = 0; j < metaData.getColumnCount(); j++) {
                     resultSetColumns[j] = metaData.getColumnName(j + 1);
                 }
-                throw new IllegalArgumentException("Column '"
+                throw new SchemaMismatchException("Column '"
                         + columnName
                         + "' not found in result set '"
                         + String.join(", ", resultSetColumns)
@@ -60,6 +60,16 @@ public class ColumnUtils {
             greatestColumnPosition = Math.max(greatestColumnPosition, columns[i].position());
         }
         return new ColumnArray(columns, greatestColumnPosition);
+    }
+
+    /**
+     * A result-set column is missing from the cached table definition.
+     */
+    public static class SchemaMismatchException extends IllegalArgumentException {
+
+        public SchemaMismatchException(String message) {
+            super(message);
+        }
     }
 
     public static class MappedColumns {

--- a/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSourceTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSourceTest.java
@@ -5,6 +5,10 @@
  */
 package io.debezium.pipeline.source.snapshot.incremental;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -14,9 +18,13 @@ import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,15 +33,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.Column;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.RelationalDatabaseSchema;
+import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
+import io.debezium.util.LoggingContext;
 
 /**
  * Verifies how {@link AbstractIncrementalSnapshotChangeEventSource#readChunk} reacts when reading a
@@ -94,6 +109,79 @@ public class AbstractIncrementalSnapshotChangeEventSourceTest {
         source.readChunk(null, offsetContext);
 
         verify(jdbcConnection, never()).close();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2604")
+    @SuppressWarnings("unchecked")
+    public void shouldEndChunkTransactionWhenChunkReadFailsWithNonSqlError() throws Exception {
+        // A schema change racing with the chunk query surfaces as a runtime exception from result-set
+        // processing ("Column 'c' not found in result set ...", see DBZ-4350). readChunk skips the
+        // table and lets streaming continue, but the transaction the chunk queries run in must still
+        // be ended: on connections with autocommit disabled it holds the chunk table's shared
+        // metadata lock until this connection ends the transaction. Ending it here must not
+        // depend on a later window or connector-specific streaming loop cleaning it up.
+        RelationalDatabaseSchema schema = mock(RelationalDatabaseSchema.class);
+        Table table = mock(Table.class);
+        when(schema.tableFor(any(TableId.class))).thenReturn(table);
+
+        ChunkQueryBuilder<TableId> chunkQueryBuilder = mock(ChunkQueryBuilder.class);
+        doReturn(chunkQueryBuilder).when(jdbcConnection).chunkQueryBuilder(any());
+        when(chunkQueryBuilder.prepareTable(any(), any())).thenReturn(table);
+        when(chunkQueryBuilder.getQueryColumns(any(), any())).thenReturn(List.of(mock(Column.class)));
+        when(chunkQueryBuilder.buildMaxPrimaryKeyQuery(any(), any(), any())).thenReturn("SELECT max(pk) FROM a");
+
+        source = new SignalBasedIncrementalSnapshotChangeEventSource<>(config(), jdbcConnection, null, schema, null, progressListener, null,
+                notificationService);
+
+        final AtomicBoolean chunkReadFailed = new AtomicBoolean();
+        final AtomicBoolean transactionEndedAfterFailure = new AtomicBoolean();
+        when(jdbcConnection.queryAndMap(anyString(), any(JdbcConnection.ResultSetMapper.class))).thenAnswer(invocation -> {
+            chunkReadFailed.set(true);
+            throw new IllegalArgumentException("Column 'c' not found in result set 'pk, aa, c'");
+        });
+        when(jdbcConnection.rollback()).thenAnswer(invocation -> {
+            if (chunkReadFailed.get()) {
+                transactionEndedAfterFailure.set(true);
+            }
+            return jdbcConnection;
+        });
+
+        source.readChunk(null, offsetContext);
+
+        assertThat(transactionEndedAfterFailure)
+                .as("the transaction the failed chunk read ran in must be ended before readChunk returns")
+                .isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2604")
+    public void shouldCloseConnectionAndReportRollbackFailure() throws Exception {
+        final var readFailure = new SQLException("chunk failed");
+        final var rollbackFailure = new SQLException("rollback failed");
+        when(jdbcConnection.commit()).thenThrow(readFailure);
+        when(jdbcConnection.rollback()).thenThrow(rollbackFailure);
+        final var queue = new ChangeEventQueue.Builder<DataChangeEvent>()
+                .maxBatchSize(10).maxQueueSize(20).pollInterval(Duration.ofMillis(10))
+                .loggingContextSupplier(() -> LoggingContext.forConnector("test", "recovery", "test"))
+                .build();
+        try {
+            final var errorHandler = new ErrorHandler(SourceConnector.class, config(), queue, null);
+            source.setErrorHandler(errorHandler);
+
+            assertThatThrownBy(() -> source.readChunk(null, offsetContext))
+                    .hasMessageContaining("Could not roll back")
+                    .hasCause(rollbackFailure);
+
+            verify(jdbcConnection).close();
+            verify(progressListener, never()).snapshotCompleted(null);
+            assertThat(rollbackFailure.getSuppressed()).containsExactly(readFailure);
+            assertThat(errorHandler.getProducerThrowable()).hasCause(rollbackFailure);
+            assertThatThrownBy(queue::poll).isInstanceOf(ConnectException.class);
+        }
+        finally {
+            queue.close();
+        }
     }
 
     private RelationalDatabaseConnectorConfig config() {

--- a/debezium-connector-common/src/test/java/io/debezium/util/ColumnUtilsTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/util/ColumnUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+import java.sql.Types;
+
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetMetaDataImpl;
+import javax.sql.rowset.RowSetProvider;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+class ColumnUtilsTest {
+
+    @Test
+    @FixFor("debezium/dbz#2604")
+    void shouldIdentifyMissingCachedColumnAsSchemaMismatch() throws SQLException {
+        final var table = Table.editor().tableId(new TableId("test", null, "a"))
+                .addColumn(column("pk", 1)).setPrimaryKeyNames("pk").create();
+
+        try (var rows = resultSet("pk", "c")) {
+            assertThatThrownBy(() -> ColumnUtils.toArray(rows, table))
+                    .isInstanceOf(ColumnUtils.SchemaMismatchException.class)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Column 'c'")
+                    .hasMessageContaining("test.a");
+        }
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2604")
+    void shouldRetainResultSetOrderWhenAllColumnsExist() throws SQLException {
+        final var primaryKey = column("pk", 1);
+        final var value = column("c", 2);
+        final var table = Table.editor().tableId(new TableId("test", null, "a"))
+                .addColumns(primaryKey, value).setPrimaryKeyNames("pk").create();
+
+        try (var rows = resultSet("c", "pk")) {
+            final var mapped = ColumnUtils.toArray(rows, table);
+            assertThat(mapped.getColumns()).containsExactly(table.columnWithName("c"), table.columnWithName("pk"));
+            assertThat(mapped.getGreatestColumnPosition()).isEqualTo(2);
+        }
+    }
+
+    private static Column column(String name, int position) {
+        return Column.editor().name(name).position(position).jdbcType(Types.INTEGER).type("INT").create();
+    }
+
+    private static CachedRowSet resultSet(String... columns) throws SQLException {
+        final var metadata = new RowSetMetaDataImpl();
+        metadata.setColumnCount(columns.length);
+        for (int i = 0; i < columns.length; ++i) {
+            metadata.setColumnName(i + 1, columns[i]);
+            metadata.setColumnType(i + 1, Types.INTEGER);
+        }
+        final var rows = RowSetProvider.newFactory().createCachedRowSet();
+        rows.setMetaData(metadata);
+        return rows;
+    }
+}

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbChangeEventSourceFactory.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbChangeEventSourceFactory.java
@@ -120,7 +120,7 @@ public class MariaDbChangeEventSourceFactory implements ChangeEventSourceFactory
                                                                                                                                                 NotificationService<MariaDbPartition, MariaDbOffsetContext> notificationService) {
         if (configuration.isReadOnlyConnection()) {
             if (connectionFactory.mainConnection().isGtidModeEnabled()) {
-                return Optional.of(new MariaDbReadOnlyIncrementalSnapshotChangeEventSource(
+                final var source = new MariaDbReadOnlyIncrementalSnapshotChangeEventSource(
                         configuration,
                         connectionFactory.mainConnection(),
                         dispatcher,
@@ -128,7 +128,9 @@ public class MariaDbChangeEventSourceFactory implements ChangeEventSourceFactory
                         clock,
                         snapshotProgressListener,
                         dataChangeEventListener,
-                        notificationService));
+                        notificationService);
+                source.setErrorHandler(errorHandler);
+                return Optional.of(source);
             }
             throw new UnsupportedOperationException("Read only connection requires GTID_MODE to be ON");
         }
@@ -138,7 +140,7 @@ public class MariaDbChangeEventSourceFactory implements ChangeEventSourceFactory
             return Optional.empty();
         }
 
-        return Optional.of(new BinlogSignalBasedIncrementalSnapshotChangeEventSource<>(
+        final var source = new BinlogSignalBasedIncrementalSnapshotChangeEventSource<MariaDbPartition>(
                 configuration,
                 connectionFactory.mainConnection(),
                 dispatcher,
@@ -146,7 +148,9 @@ public class MariaDbChangeEventSourceFactory implements ChangeEventSourceFactory
                 clock,
                 snapshotProgressListener,
                 dataChangeEventListener,
-                notificationService));
+                notificationService);
+        source.setErrorHandler(errorHandler);
+        return Optional.of(source);
     }
 
     private void preSnapshot() {

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/IncrementalSnapshotRecoveryIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/IncrementalSnapshotRecoveryIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mariadb;
+
+import java.util.List;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
+import io.debezium.connector.binlog.BinlogIncrementalSnapshotRecoveryIT;
+import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.mariadb.jdbc.MariaDbConnection;
+import io.debezium.connector.mariadb.jdbc.MariaDbConnectionConfiguration;
+import io.debezium.connector.mariadb.jdbc.MariaDbFieldReader;
+import io.debezium.connector.mariadb.jdbc.MariaDbValueConverters;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.CustomConverterRegistry;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+class IncrementalSnapshotRecoveryIT
+        extends BinlogIncrementalSnapshotRecoveryIT<MariaDbConnector, MariaDbPartition, MariaDbOffsetContext>
+        implements MariaDbCommon {
+
+    @Override
+    protected MariaDbConnectorConfig createConfig(Configuration configuration) {
+        return new MariaDbConnectorConfig(configuration);
+    }
+
+    @Override
+    protected BinlogConnectorConnection createConnection(Configuration configuration) {
+        return new MariaDbConnection(new MariaDbConnectionConfiguration(configuration),
+                new MariaDbFieldReader((MariaDbConnectorConfig) config));
+    }
+
+    @Override
+    protected MariaDbTaskContext createTaskContext(Configuration configuration) {
+        return new MariaDbTaskContext(configuration, (MariaDbConnectorConfig) config);
+    }
+
+    @Override
+    protected MariaDbDatabaseSchema createSchema(CdcSourceTaskContext<?> taskContext) {
+        return new MariaDbDatabaseSchema((MariaDbConnectorConfig) config,
+                new MariaDbValueConverters(config.getDecimalMode(), config.getTemporalPrecisionMode(),
+                        config.getBigIntUnsignedHandlingMode().asBigIntUnsignedMode(), config.binaryHandlingMode(),
+                        MariaDbValueConverters::adjustTemporal, config.getEventConvertingFailureHandlingMode(), config.getServiceRegistry()),
+                config.getTopicNamingStrategy(BinlogConnectorConfig.TOPIC_NAMING_STRATEGY), config.schemaNameAdjuster(), false,
+                new CustomConverterRegistry(List.of()), taskContext);
+    }
+
+    @Override
+    protected MariaDbPartition createPartition() {
+        return new MariaDbPartition(database.getServerName(), database.getDatabaseName());
+    }
+
+    @Override
+    protected MariaDbOffsetContext createOffset() {
+        return MariaDbOffsetContext.initial((MariaDbConnectorConfig) config);
+    }
+
+    @Override
+    protected AbstractIncrementalSnapshotChangeEventSource<MariaDbPartition, TableId> createReadOnlySource() {
+        return new MariaDbReadOnlyIncrementalSnapshotChangeEventSource((MariaDbConnectorConfig) config, jdbc, dispatcher,
+                (MariaDbDatabaseSchema) schema, Clock.system(), SnapshotProgressListener.NO_OP(), DataChangeEventListener.NO_OP(), notifications);
+    }
+}

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ReadOnlyIncrementalSnapshotIT.java
@@ -5,11 +5,8 @@
  */
 package io.debezium.connector.mariadb;
 
-import org.junit.jupiter.api.Test;
-
 import io.debezium.connector.binlog.BinlogReadOnlyIncrementalSnapshotIT;
 import io.debezium.connector.mariadb.jdbc.MariaDbFieldReader;
-import io.debezium.junit.Flaky;
 
 /**
  * @author Chris Cranford
@@ -18,17 +15,5 @@ public class ReadOnlyIncrementalSnapshotIT extends BinlogReadOnlyIncrementalSnap
     @Override
     protected Class<?> getFieldReader() {
         return MariaDbFieldReader.class;
-    }
-
-    /**
-     * The DDL loop competes for the table metadata lock with the in-flight incremental snapshot chunk
-     * reads; on a slow CI runner an ALTER can stay blocked past the 600s query timeout that MariaDB
-     * Connector/J enforces via {@code SET STATEMENT max_statement_time}, killing the statement.
-     */
-    @Override
-    @Test
-    @Flaky("debezium/dbz#2604")
-    public void schemaChanges() throws Exception {
-        super.schemaChanges();
     }
 }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/ReadOnlyIncrementalSnapshotIT.java
@@ -5,8 +5,11 @@
  */
 package io.debezium.connector.mariadb;
 
+import org.junit.jupiter.api.Test;
+
 import io.debezium.connector.binlog.BinlogReadOnlyIncrementalSnapshotIT;
 import io.debezium.connector.mariadb.jdbc.MariaDbFieldReader;
+import io.debezium.junit.Flaky;
 
 /**
  * @author Chris Cranford
@@ -15,5 +18,17 @@ public class ReadOnlyIncrementalSnapshotIT extends BinlogReadOnlyIncrementalSnap
     @Override
     protected Class<?> getFieldReader() {
         return MariaDbFieldReader.class;
+    }
+
+    /**
+     * The DDL loop competes for the table metadata lock with the in-flight incremental snapshot chunk
+     * reads; on a slow CI runner an ALTER can stay blocked past the 600s query timeout that MariaDB
+     * Connector/J enforces via {@code SET STATEMENT max_statement_time}, killing the statement.
+     */
+    @Override
+    @Test
+    @Flaky("debezium/dbz#2604")
+    public void schemaChanges() throws Exception {
+        super.schemaChanges();
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -120,7 +120,7 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
 
         if (configuration.isReadOnlyConnection()) {
             if (connectionFactory.mainConnection().isGtidModeEnabled()) {
-                return Optional.of(new MySqlReadOnlyIncrementalSnapshotChangeEventSource(
+                final var source = new MySqlReadOnlyIncrementalSnapshotChangeEventSource(
                         configuration,
                         connectionFactory.mainConnection(),
                         dispatcher,
@@ -128,7 +128,9 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
                         clock,
                         snapshotProgressListener,
                         dataChangeEventListener,
-                        notificationService));
+                        notificationService);
+                source.setErrorHandler(errorHandler);
+                return Optional.of(source);
             }
             throw new UnsupportedOperationException("Read only connection requires GTID_MODE to be ON");
         }
@@ -137,13 +139,15 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
         if (configuration.getSignalingDataCollectionIds().isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(new BinlogSignalBasedIncrementalSnapshotChangeEventSource<>(
+        final var source = new BinlogSignalBasedIncrementalSnapshotChangeEventSource<MySqlPartition>(
                 configuration,
                 connectionFactory.mainConnection(),
                 dispatcher,
                 schema,
                 clock,
                 snapshotProgressListener,
-                dataChangeEventListener, notificationService));
+                dataChangeEventListener, notificationService);
+        source.setErrorHandler(errorHandler);
+        return Optional.of(source);
     }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotRecoveryIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotRecoveryIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.util.List;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
+import io.debezium.connector.binlog.BinlogIncrementalSnapshotRecoveryIT;
+import io.debezium.connector.binlog.jdbc.BinlogConnectorConnection;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.mysql.jdbc.MySqlConnection;
+import io.debezium.connector.mysql.jdbc.MySqlConnectionConfiguration;
+import io.debezium.connector.mysql.jdbc.MySqlFieldReaderResolver;
+import io.debezium.connector.mysql.jdbc.MySqlValueConverters;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.CustomConverterRegistry;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+class IncrementalSnapshotRecoveryIT
+        extends BinlogIncrementalSnapshotRecoveryIT<MySqlConnector, MySqlPartition, MySqlOffsetContext>
+        implements MySqlCommon {
+
+    @Override
+    protected MySqlConnectorConfig createConfig(Configuration configuration) {
+        return new MySqlConnectorConfig(configuration);
+    }
+
+    @Override
+    protected BinlogConnectorConnection createConnection(Configuration configuration) {
+        return new MySqlConnection(new MySqlConnectionConfiguration(configuration),
+                MySqlFieldReaderResolver.resolve((MySqlConnectorConfig) config));
+    }
+
+    @Override
+    protected MySqlTaskContext createTaskContext(Configuration configuration) {
+        return new MySqlTaskContext(configuration, (MySqlConnectorConfig) config);
+    }
+
+    @Override
+    protected MySqlDatabaseSchema createSchema(CdcSourceTaskContext<?> taskContext) {
+        return new MySqlDatabaseSchema((MySqlConnectorConfig) config,
+                new MySqlValueConverters(config.getDecimalMode(), config.getTemporalPrecisionMode(),
+                        config.getBigIntUnsignedHandlingMode().asBigIntUnsignedMode(), config.binaryHandlingMode(),
+                        MySqlValueConverters::adjustTemporal, config.getEventConvertingFailureHandlingMode(), config.getServiceRegistry(),
+                        config.getUnavailableValuePlaceholder()),
+                config.getTopicNamingStrategy(BinlogConnectorConfig.TOPIC_NAMING_STRATEGY), config.schemaNameAdjuster(), false,
+                new CustomConverterRegistry(List.of()), taskContext);
+    }
+
+    @Override
+    protected MySqlPartition createPartition() {
+        return new MySqlPartition(database.getServerName(), database.getDatabaseName());
+    }
+
+    @Override
+    protected MySqlOffsetContext createOffset() {
+        return MySqlOffsetContext.initial((MySqlConnectorConfig) config);
+    }
+
+    @Override
+    protected AbstractIncrementalSnapshotChangeEventSource<MySqlPartition, TableId> createReadOnlySource() {
+        return new MySqlReadOnlyIncrementalSnapshotChangeEventSource((MySqlConnectorConfig) config, jdbc, dispatcher,
+                (MySqlDatabaseSchema) schema, Clock.system(), SnapshotProgressListener.NO_OP(), DataChangeEventListener.NO_OP(), notifications);
+    }
+}

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-mariadb-mysql-adv-connector-cfg-props.adoc
@@ -394,6 +394,12 @@ Description:::
 Specifies whether the connector allows schema changes during an incremental snapshot.
 When the value is set to `true`, the connector detects schema change during an incremental snapshot, and re-select a current chunk to avoid locking DDLs.
 +
+If a query result contains a column that is absent from the connector's cached table definition, the connector discards the current chunk and retries it after closing the watermark window.
+The retry retains the current table and the last emitted snapshot key, allowing streaming to process the pending schema change before reading the chunk again.
+This behavior applies to both signal-table and read-only incremental snapshots.
+As with schema verification, a persistent mismatch is logged and retried in subsequent watermark windows instead of skipping the table.
+The connector does not report the snapshot as complete while the table is waiting for its schema to catch up.
++
 Changes to a primary key are not supported.
 Changing the primary during an incremental snapshot, can lead to incorrect results.
 A further limitation is that if a schema change affects only the default values of columns, then the change is not detected until the DDL is processed from the binlog stream.


### PR DESCRIPTION
Fixes debezium/dbz#2604

## Problem

During incremental snapshots, concurrent schema changes can leave query results out of sync with the connector's cached schema. In MySQL and MariaDB, a missing-column mismatch can cause the current table to be skipped and leave a read transaction open, blocking subsequent DDL.

## Changes

With schema-change support enabled, retry the affected chunk in a subsequent watermark window instead of abandoning the table. Preserve snapshot progress and allow streaming to process pending schema changes before retrying.

Release chunk transactions on failure and propagate recovery failures through the connector's existing error-handling path.

This recovery behavior applies to MySQL and MariaDB read-only and signal-based incremental snapshots.

AI assistance: Codex assisted with the investigation, implementation, and testing.
