### PR TITLE
Fix Map key tag and bounds checking in ConnectValueSerde debezium/dbz#2609

### DIFF
--- a/debezium-connector-common/src/main/java/io/debezium/serde/ConnectValueSerde.java
+++ b/debezium-connector-common/src/main/java/io/debezium/serde/ConnectValueSerde.java
@@ -123,6 +123,7 @@ public final class ConnectValueSerde {
     private static final byte KEY_TAG_DATE = 12;
     private static final byte KEY_TAG_STRUCT = 13;
     private static final byte KEY_TAG_LIST = 14;
+    private static final byte KEY_TAG_MAP = 15;
 
     private final JsonConverter structConverter;
 
@@ -391,6 +392,11 @@ public final class ConnectValueSerde {
     }
 
     private static void describeSchema(DataOutputStream dos, Schema schema) throws IOException {
+        if (schema == null) {
+            dos.writeBoolean(false);
+            return;
+        }
+        dos.writeBoolean(true);
         writeNullableString(dos, schema.name());
         dos.writeByte(schema.type().ordinal());
         dos.writeBoolean(schema.isOptional());
@@ -398,10 +404,12 @@ public final class ConnectValueSerde {
         dos.writeInt(version != null ? version : 0);
         switch (schema.type()) {
             case STRUCT:
-                dos.writeInt(schema.fields().size());
-                for (org.apache.kafka.connect.data.Field field : schema.fields()) {
-                    dos.writeUTF(field.name());
-                    describeSchema(dos, field.schema());
+                dos.writeInt(schema.fields() != null ? schema.fields().size() : 0);
+                if (schema.fields() != null) {
+                    for (org.apache.kafka.connect.data.Field field : schema.fields()) {
+                        dos.writeUTF(field.name());
+                        describeSchema(dos, field.schema());
+                    }
                 }
                 break;
             case ARRAY:
@@ -495,7 +503,7 @@ public final class ConnectValueSerde {
         else if (value instanceof Map<?, ?> map) {
             // Maps have no deterministic iteration order; entries are sorted by their encoded bytes so the
             // same logical map always produces the same key bytes.
-            dos.writeByte(KEY_TAG_LIST);
+            dos.writeByte(KEY_TAG_MAP);
             final List<byte[]> encodedEntries = new ArrayList<>(map.size());
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 try (ByteArrayOutputStream entryBaos = new ByteArrayOutputStream();
@@ -595,7 +603,11 @@ public final class ConnectValueSerde {
     }
 
     private static byte[] readBytes(DataInputStream dis) throws IOException {
-        final byte[] bytes = new byte[dis.readInt()];
+        final int length = dis.readInt();
+        if (length < 0) {
+            throw new DebeziumException("Invalid negative byte array length: " + length);
+        }
+        final byte[] bytes = new byte[length];
         dis.readFully(bytes);
         return bytes;
     }

--- a/debezium-connector-common/src/main/java/io/debezium/serde/ConnectValueSerde.java
+++ b/debezium-connector-common/src/main/java/io/debezium/serde/ConnectValueSerde.java
@@ -393,10 +393,8 @@ public final class ConnectValueSerde {
 
     private static void describeSchema(DataOutputStream dos, Schema schema) throws IOException {
         if (schema == null) {
-            dos.writeBoolean(false);
             return;
         }
-        dos.writeBoolean(true);
         writeNullableString(dos, schema.name());
         dos.writeByte(schema.type().ordinal());
         dos.writeBoolean(schema.isOptional());
@@ -404,12 +402,10 @@ public final class ConnectValueSerde {
         dos.writeInt(version != null ? version : 0);
         switch (schema.type()) {
             case STRUCT:
-                dos.writeInt(schema.fields() != null ? schema.fields().size() : 0);
-                if (schema.fields() != null) {
-                    for (org.apache.kafka.connect.data.Field field : schema.fields()) {
-                        dos.writeUTF(field.name());
-                        describeSchema(dos, field.schema());
-                    }
+                dos.writeInt(schema.fields().size());
+                for (org.apache.kafka.connect.data.Field field : schema.fields()) {
+                    dos.writeUTF(field.name());
+                    describeSchema(dos, field.schema());
                 }
                 break;
             case ARRAY:
@@ -606,6 +602,9 @@ public final class ConnectValueSerde {
         final int length = dis.readInt();
         if (length < 0) {
             throw new DebeziumException("Invalid negative byte array length: " + length);
+        }
+        if (length > dis.available()) {
+            throw new DebeziumException("Invalid byte array length: " + length);
         }
         final byte[] bytes = new byte[length];
         dis.readFully(bytes);

--- a/debezium-connector-common/src/test/java/io/debezium/serde/ConnectValueSerdeTest.java
+++ b/debezium-connector-common/src/test/java/io/debezium/serde/ConnectValueSerdeTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.DebeziumException;
 import io.debezium.data.VariableScaleDecimal;
+import io.debezium.doc.FixFor;
 
 /**
  * Unit tests for {@link ConnectValueSerde}, exercising exact-runtime-type round-trips for every
@@ -225,5 +226,54 @@ public class ConnectValueSerdeTest {
         final byte[] truncated = new byte[bytes.length - 5];
         System.arraycopy(bytes, 0, truncated, 0, truncated.length);
         assertThatThrownBy(() -> serde.deserialize(truncated)).isInstanceOf(DebeziumException.class);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2609")
+    public void mapInKeyStructUsesDistinctKeyTagFromList() {
+        final Schema mapSchema = SchemaBuilder.struct()
+                .field("f1", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+                .build();
+        final Schema listSchema = SchemaBuilder.struct()
+                .field("f1", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+                .build();
+
+        final Struct mapStruct = new Struct(mapSchema).put("f1", Map.of("k", "v"));
+        final Struct listStruct = new Struct(listSchema).put("f1", List.of("k", "v"));
+
+        final byte[] mapBytes = serde.serializeStructIdentity(mapStruct);
+        final byte[] listBytes = serde.serializeStructIdentity(listStruct);
+
+        assertThat(mapBytes).isNotEqualTo(listBytes);
+        // The first 16 bytes are the schema fingerprint; the 17th byte is the field value tag.
+        final byte mapTag = mapBytes[16];
+        final byte listTag = listBytes[16];
+        assertThat(mapTag).isEqualTo((byte) 15);
+        assertThat(listTag).isEqualTo((byte) 14);
+        assertThat(mapTag).isNotEqualTo(listTag);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2609")
+    public void corruptedNegativeLengthThrowsDebeziumException() {
+        // Construct bytes with DBZ magic, format version 1, timestamp 0, TAG_STRING (1), and negative length (-1).
+        final byte[] corrupted = new byte[]{
+                'D', 'B', 'Z', 1,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                1,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThatThrownBy(() -> serde.deserialize(corrupted))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("Invalid negative byte array length");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2609")
+    public void emptyStructIdentityHandledSafely() {
+        final Schema schema = SchemaBuilder.struct().build();
+        final Struct struct = new Struct(schema);
+        final byte[] bytes = serde.serializeStructIdentity(struct);
+        assertThat(bytes).isNotNull();
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2609

## Description

In `ConnectValueSerde`:
* `Map` values serialized via `writeKeyValue` for message key identity bytes were previously tagged with `KEY_TAG_LIST` (14) due to missing `KEY_TAG_MAP`. Added `KEY_TAG_MAP = 15` and tagged Map key values accordingly to maintain distinct and unambiguous identity serialization.
* In `readBytes(DataInputStream)`, validated that the array length prefix is non-negative, throwing `DebeziumException` on corrupted/negative lengths rather than allowing an unhandled `NegativeArraySizeException`.
* In `describeSchema`, added null safety check before accessing schema attributes.
* Added unit regression tests in `ConnectValueSerdeTest`.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
