### PR TITLE
debezium/dbz#2610 Support readable MongoDB start timestamps

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/BsonTimestampParser.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/BsonTimestampParser.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Pattern;
+
+import org.bson.BsonTimestamp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+/**
+ * Parses a change stream start time without losing timestamp precision or overflowing BSON timestamp components.
+ */
+final class BsonTimestampParser {
+
+    private static final long MAX_UNSIGNED_INT = 0xffff_ffffL;
+    private static final Pattern UNIX_SECONDS = Pattern.compile("[+-]?[0-9]+");
+    private static final String FORMAT_DESCRIPTION = "Expected integer Unix seconds, an ISO-8601 timestamp with a UTC offset "
+            + "and whole-second precision, or an Extended JSON timestamp such as {\"$timestamp\":{\"t\":30,\"i\":0}}";
+    private static final ObjectReader JSON_READER = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+            .build().reader();
+
+    private BsonTimestampParser() {
+    }
+
+    static BsonTimestamp parse(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(FORMAT_DESCRIPTION);
+        }
+        final var timestamp = value.trim();
+        try {
+            if (UNIX_SECONDS.matcher(timestamp).matches()) {
+                return new BsonTimestamp(unsignedInt(Long.parseLong(timestamp), "Unix seconds"), 0);
+            }
+            if (timestamp.startsWith("{")) {
+                return parseExtendedJson(timestamp);
+            }
+            final var instant = OffsetDateTime.parse(timestamp).toInstant();
+            if (instant.getNano() != 0) {
+                throw new IllegalArgumentException("Sub-second precision is not supported; specify a whole-second timestamp");
+            }
+            return new BsonTimestamp(unsignedInt(instant.getEpochSecond(), "Unix seconds"), 0);
+        }
+        catch (NumberFormatException | DateTimeParseException | JsonProcessingException e) {
+            throw new IllegalArgumentException(FORMAT_DESCRIPTION, e);
+        }
+    }
+
+    private static BsonTimestamp parseExtendedJson(String value) throws JsonProcessingException {
+        final JsonNode root = JSON_READER.readTree(value);
+        final var timestamp = root.get("$timestamp");
+        if (root.size() != 1 || timestamp == null || !timestamp.isObject() || timestamp.size() != 2
+                || !timestamp.has("t") || !timestamp.has("i")) {
+            throw new IllegalArgumentException(FORMAT_DESCRIPTION);
+        }
+        return new BsonTimestamp(unsignedInt(timestamp.get("t"), "t"), unsignedInt(timestamp.get("i"), "i"));
+    }
+
+    private static int unsignedInt(JsonNode value, String component) {
+        if (!value.isIntegralNumber() || !value.canConvertToLong()) {
+            throw new IllegalArgumentException("Timestamp component '" + component + "' must be an integer between 0 and " + MAX_UNSIGNED_INT);
+        }
+        return unsignedInt(value.longValue(), component);
+    }
+
+    private static int unsignedInt(long value, String component) {
+        if (value < 0 || value > MAX_UNSIGNED_INT) {
+            throw new IllegalArgumentException("Timestamp component '" + component + "' must be between 0 and " + MAX_UNSIGNED_INT);
+        }
+        // BSON uses unsigned 32-bit components, represented as signed ints by the Java driver.
+        return (int) value;
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/BsonTimestampParser.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/BsonTimestampParser.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
+import io.debezium.util.Strings;
+
 /**
  * Parses a change stream start time without losing timestamp precision or overflowing BSON timestamp components.
  */
@@ -35,7 +37,7 @@ final class BsonTimestampParser {
     }
 
     static BsonTimestamp parse(String value) {
-        if (value == null || value.isBlank()) {
+        if (Strings.isNullOrBlank(value)) {
             throw new IllegalArgumentException(FORMAT_DESCRIPTION);
         }
         final var timestamp = value.trim();

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
@@ -110,8 +110,8 @@ public class MongoDbConnector extends BaseSourceConnector implements ConfigDescr
         Map<String, ConfigValue> validation = validateAllFields(config);
         ConfigValue csValidation = validation.get(MongoDbConnectorConfig.CONNECTION_STRING.name());
 
-        // Validate connection when connection string is otherwise valid
-        if (csValidation.errorMessages().isEmpty()) {
+        // Construct the connection configuration only after all field validation has succeeded.
+        if (validation.values().stream().allMatch(configValue -> configValue.errorMessages().isEmpty())) {
             validateConnection(config, csValidation);
         }
         return new Config(new ArrayList<>(validation.values()));

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
@@ -110,8 +110,9 @@ public class MongoDbConnector extends BaseSourceConnector implements ConfigDescr
         Map<String, ConfigValue> validation = validateAllFields(config);
         ConfigValue csValidation = validation.get(MongoDbConnectorConfig.CONNECTION_STRING.name());
 
-        // Construct the connection configuration only after all field validation has succeeded.
-        if (validation.values().stream().allMatch(configValue -> configValue.errorMessages().isEmpty())) {
+        // Validate connection when the connection string and start timestamp are otherwise valid.
+        if (csValidation.errorMessages().isEmpty()
+                && validation.get(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP.name()).errorMessages().isEmpty()) {
             validateConnection(config, csValidation);
         }
         return new Config(new ArrayList<>(validation.values()));

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -19,6 +19,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Struct;
 import org.bson.BsonTimestamp;
 import org.bson.Document;
@@ -974,8 +975,20 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDefault(-1L)
-            .withDescription("If no existing offset is detected,  "
-                    + "Debezium will start streaming from given timestamp");
+            .withDescription("If no existing offset is detected, Debezium will start streaming from the given packed BSON timestamp. "
+                    + "Cannot be used with capture.start.timestamp unless set to -1 (disabled).");
+
+    public static final Field CAPTURE_START_TIMESTAMP = Field.create("capture.start.timestamp")
+            .withDisplayName("Capture from timestamp")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(Width.LONG)
+            .withImportance(Importance.LOW)
+            .withValidation(MongoDbConnectorConfig::validateStartTimestamp)
+            .withDescription("If no existing offset is detected, Debezium will start streaming from this timestamp. "
+                    + "Accepts integer Unix seconds, ISO-8601 with a UTC offset and whole-second precision, "
+                    + "or a BSON timestamp in Extended JSON format. "
+                    + "Cannot be used with capture.start.op.time unless that property is set to -1 (disabled).");
 
     public static final Field CAPTURE_SCOPE = Field.create("capture.scope")
             .withDisplayName("Capture scope")
@@ -1102,7 +1115,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
             .group(Field.Group.FILTERS, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, COLLECTION_INCLUDE_LIST, COLLECTION_EXCLUDE_LIST, FIELD_EXCLUDE_LIST, FIELD_RENAMES,
                     SNAPSHOT_FILTER_QUERY_BY_COLLECTION)
             .group(Field.Group.CONNECTOR, TOPIC_PREFIX, SNAPSHOT_MODE, CAPTURE_MODE, CAPTURE_SCOPE, CAPTURE_TARGET, JSON_SERIALIZATION_MODE, SCHEMA_NAME_ADJUSTMENT_MODE,
-                    SOURCE_INFO_STRUCT_MAKER)
+                    SOURCE_INFO_STRUCT_MAKER, CAPTURE_START_OP_TIME, CAPTURE_START_TIMESTAMP)
             .create();
 
     /**
@@ -1115,7 +1128,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
     }
 
     private final SnapshotMode snapshotMode;
-    private final Long startOperationTime;
+    private final BsonTimestamp startOperationTime;
     private final CaptureMode captureMode;
     private final JsonSerializationMode jsonSerializationMode;
     private final FullUpdateType captureModeFullUpdateType;
@@ -1173,7 +1186,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         String snapshotModeValue = config.getString(MongoDbConnectorConfig.SNAPSHOT_MODE);
         this.snapshotMode = SnapshotMode.parse(snapshotModeValue, MongoDbConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());
 
-        this.startOperationTime = config.getLong(CAPTURE_START_OP_TIME);
+        this.startOperationTime = resolveStartOperationTime(config);
 
         String captureModeValue = config.getString(MongoDbConnectorConfig.CAPTURE_MODE);
         this.captureMode = CaptureMode.parse(captureModeValue, MongoDbConnectorConfig.CAPTURE_MODE.defaultValueAsString());
@@ -1284,6 +1297,36 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         return ConnectorConfigValidationHelper.validateExcludeField(config, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, problems);
     }
 
+    private static int validateStartTimestamp(Configuration config, Field field, ValidationOutput problems) {
+        try {
+            resolveStartOperationTime(config);
+            return 0;
+        }
+        catch (ConfigException e) {
+            problems.accept(field, config.getString(field), e.getMessage());
+            return 1;
+        }
+    }
+
+    private static BsonTimestamp resolveStartOperationTime(Configuration config) {
+        final var value = config.getString(CAPTURE_START_TIMESTAMP);
+        final var operationTime = config.getLong(CAPTURE_START_OP_TIME);
+        final var hasOperationTime = !CAPTURE_START_OP_TIME.defaultValue().equals(operationTime);
+        if (value != null) {
+            if (hasOperationTime) {
+                throw new ConfigException(CAPTURE_START_TIMESTAMP.name(), value,
+                        "Cannot be configured together with '" + CAPTURE_START_OP_TIME.name() + "'");
+            }
+            try {
+                return BsonTimestampParser.parse(value);
+            }
+            catch (IllegalArgumentException e) {
+                throw new ConfigException(CAPTURE_START_TIMESTAMP.name(), value, e.getMessage());
+            }
+        }
+        return hasOperationTime ? new BsonTimestamp(operationTime) : null;
+    }
+
     private static int validateCaptureTarget(Configuration config, Field field, ValidationOutput problems) {
         var value = config.getString(field);
         var scope = CaptureScope.parse(config.getString(CAPTURE_SCOPE), CAPTURE_SCOPE.defaultValueAsString());
@@ -1340,10 +1383,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
     }
 
     public Optional<BsonTimestamp> startAtOperationTime() {
-        if (CAPTURE_START_OP_TIME.defaultValue().equals(startOperationTime)) {
-            return Optional.empty();
-        }
-        return Optional.of(new BsonTimestamp(startOperationTime));
+        return Optional.ofNullable(startOperationTime);
     }
 
     public FullUpdateType getCaptureModeFullUpdateType() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -975,6 +975,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withDefault(-1L)
+            .withValidation(MongoDbConnectorConfig::validateStartOpTime)
             .withDescription("If no existing offset is detected, Debezium will start streaming from the given packed BSON timestamp. "
                     + "Cannot be used with capture.start.timestamp unless set to -1 (disabled).");
 
@@ -1302,6 +1303,14 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         return ConnectorConfigValidationHelper.validateExcludeField(config, DATABASE_INCLUDE_LIST, DATABASE_EXCLUDE_LIST, problems);
     }
 
+    private static int validateStartOpTime(Configuration config, Field field, ValidationOutput problems) {
+        if (hasConflictingStartTimes(config)) {
+            problems.accept(field, config.getString(field), "Cannot be configured together with '" + CAPTURE_START_TIMESTAMP.name() + "'");
+            return 1;
+        }
+        return 0;
+    }
+
     private static int validateStartTimestamp(Configuration config, Field field, ValidationOutput problems) {
         try {
             resolveStartOperationTime(config);
@@ -1313,17 +1322,21 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         }
     }
 
+    private static boolean hasConflictingStartTimes(Configuration config) {
+        return config.getString(CAPTURE_START_TIMESTAMP) != null
+                && !CAPTURE_START_OP_TIME.defaultValue().equals(config.getLong(CAPTURE_START_OP_TIME));
+    }
+
     private static BsonTimestamp resolveStartOperationTime(Configuration config) {
+        if (hasConflictingStartTimes(config)) {
+            throw new IllegalArgumentException("Cannot be configured together with '" + CAPTURE_START_OP_TIME.name() + "'");
+        }
         final var value = config.getString(CAPTURE_START_TIMESTAMP);
-        final var operationTime = config.getLong(CAPTURE_START_OP_TIME);
-        final var hasOperationTime = !CAPTURE_START_OP_TIME.defaultValue().equals(operationTime);
         if (value != null) {
-            if (hasOperationTime) {
-                throw new IllegalArgumentException("Cannot be configured together with '" + CAPTURE_START_OP_TIME.name() + "'");
-            }
             return BsonTimestampParser.parse(value);
         }
-        return hasOperationTime ? new BsonTimestamp(operationTime) : null;
+        final var operationTime = config.getLong(CAPTURE_START_OP_TIME);
+        return !CAPTURE_START_OP_TIME.defaultValue().equals(operationTime) ? new BsonTimestamp(operationTime) : null;
     }
 
     private static int validateCaptureTarget(Configuration config, Field field, ValidationOutput problems) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -1186,7 +1186,12 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         String snapshotModeValue = config.getString(MongoDbConnectorConfig.SNAPSHOT_MODE);
         this.snapshotMode = SnapshotMode.parse(snapshotModeValue, MongoDbConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());
 
-        this.startOperationTime = resolveStartOperationTime(config);
+        try {
+            this.startOperationTime = resolveStartOperationTime(config);
+        }
+        catch (IllegalArgumentException e) {
+            throw new ConfigException(CAPTURE_START_TIMESTAMP.name(), config.getString(CAPTURE_START_TIMESTAMP), e.getMessage());
+        }
 
         String captureModeValue = config.getString(MongoDbConnectorConfig.CAPTURE_MODE);
         this.captureMode = CaptureMode.parse(captureModeValue, MongoDbConnectorConfig.CAPTURE_MODE.defaultValueAsString());
@@ -1302,7 +1307,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
             resolveStartOperationTime(config);
             return 0;
         }
-        catch (ConfigException e) {
+        catch (IllegalArgumentException e) {
             problems.accept(field, config.getString(field), e.getMessage());
             return 1;
         }
@@ -1314,15 +1319,9 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         final var hasOperationTime = !CAPTURE_START_OP_TIME.defaultValue().equals(operationTime);
         if (value != null) {
             if (hasOperationTime) {
-                throw new ConfigException(CAPTURE_START_TIMESTAMP.name(), value,
-                        "Cannot be configured together with '" + CAPTURE_START_OP_TIME.name() + "'");
+                throw new IllegalArgumentException("Cannot be configured together with '" + CAPTURE_START_OP_TIME.name() + "'");
             }
-            try {
-                return BsonTimestampParser.parse(value);
-            }
-            catch (IllegalArgumentException e) {
-                throw new ConfigException(CAPTURE_START_TIMESTAMP.name(), value, e.getMessage());
-            }
+            return BsonTimestampParser.parse(value);
         }
         return hasOperationTime ? new BsonTimestamp(operationTime) : null;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -227,8 +227,9 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
             stream.startAtOperationTime(offsetContext.lastTimestamp());
         }
         else if (connectorConfig.startAtOperationTime().isPresent()) {
-            LOGGER.info("Resuming streaming from explicit operation time '{}'", offsetContext.lastTimestamp());
-            stream.startAtOperationTime(connectorConfig.startAtOperationTime().get());
+            final var startTimestamp = connectorConfig.startAtOperationTime().get();
+            LOGGER.info("Resuming streaming from explicit operation time '{}'", startTimestamp);
+            stream.startAtOperationTime(startTimestamp);
         }
 
         if (connectorConfig.getCursorMaxAwaitTime() > 0) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/BsonTimestampParserTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/BsonTimestampParserTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+
+import org.bson.BsonTimestamp;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BsonTimestampParserTest {
+
+    @ParameterizedTest
+    @MethodSource("validTimestamps")
+    void shouldParseTimestamp(String value, long seconds, long increment) {
+        assertThat(BsonTimestampParser.parse(value)).isEqualTo(new BsonTimestamp((int) seconds, (int) increment));
+    }
+
+    static Stream<Arguments> validTimestamps() {
+        return Stream.of(
+                Arguments.of("0", 0L, 0L),
+                Arguments.of("30", 30L, 0L),
+                Arguments.of(" 30 ", 30L, 0L),
+                Arguments.of("1789084800", 1789084800L, 0L),
+                Arguments.of("2147483647", 2147483647L, 0L),
+                Arguments.of("2147483648", 2147483648L, 0L),
+                Arguments.of("4294967295", 4294967295L, 0L),
+                Arguments.of("1970-01-01T00:00:00Z", 0L, 0L),
+                Arguments.of("1970-01-01T00:00:30.000Z", 30L, 0L),
+                Arguments.of("2026-09-11T00:00:00Z", 1789084800L, 0L),
+                Arguments.of("2026-09-11T09:00:00+09:00", 1789084800L, 0L),
+                Arguments.of("2026-09-10T19:00:00-05:00", 1789084800L, 0L),
+                Arguments.of("2038-01-19T03:14:08Z", 2147483648L, 0L),
+                Arguments.of("2106-02-07T06:28:15Z", 4294967295L, 0L),
+                Arguments.of("{\"$timestamp\":{\"t\":30,\"i\":7}}", 30L, 7L),
+                Arguments.of(" {\"$timestamp\": {\"i\": 7, \"t\": 30}} ", 30L, 7L),
+                Arguments.of("{\"$timestamp\":{\"t\":0,\"i\":0}}", 0L, 0L),
+                Arguments.of("{\"$timestamp\":{\"t\":2147483648,\"i\":2147483648}}", 2147483648L, 2147483648L),
+                Arguments.of("{\"$timestamp\":{\"t\":4294967295,\"i\":4294967295}}", 4294967295L, 4294967295L));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+            " ", "not-a-timestamp", "-1", "4294967296", "1789084800000", "9223372036854775808", "30.5", "3e1",
+            "1969-12-31T23:59:59Z", "2106-02-07T06:28:16Z", "2026-09-11", "2026-09-11T00:00:00",
+            "2026-09-11T00:00:00.001Z", "2026-09-11T00:00:00.000000001Z", "2026-02-29T00:00:00Z",
+            "{}", "[]", "null", "{\"$date\":\"2026-09-11T00:00:00Z\"}", "Timestamp(30, 0)",
+            "{\"$timestamp\":null}", "{\"$timestamp\":{\"t\":30}}", "{\"$timestamp\":{\"i\":0}}",
+            "{\"$timestamp\":{\"other\":30,\"i\":0}}", "{\"$timestamp\":{\"t\":30,\"other\":0}}",
+            "{\"$timestamp\":{\"t\":30,\"i\":0,\"extra\":1}}", "{\"$timestamp\":{\"t\":30,\"i\":0},\"extra\":1}",
+            "{\"$timestamp\":{\"t\":-1,\"i\":0}}", "{\"$timestamp\":{\"t\":30,\"i\":-1}}",
+            "{\"$timestamp\":{\"t\":4294967296,\"i\":0}}", "{\"$timestamp\":{\"t\":30,\"i\":4294967296}}",
+            "{\"$timestamp\":{\"t\":9223372036854775808,\"i\":0}}", "{\"$timestamp\":{\"t\":30,\"i\":9223372036854775808}}",
+            "{\"$timestamp\":{\"t\":30.5,\"i\":0}}", "{\"$timestamp\":{\"t\":30,\"i\":0.5}}",
+            "{\"$timestamp\":{\"t\":\"30\",\"i\":0}}", "{\"$timestamp\":{\"t\":30,\"i\":null}}",
+            "{\"$timestamp\":{\"t\":30,\"i\":0,\"t\":31}}",
+            "{\"$timestamp\":{\"t\":30,\"i\":0},\"$timestamp\":{\"t\":31,\"i\":0}}",
+            "{\"$timestamp\":{\"t\":30,\"i\":0}} {}", "{\"$timestamp\":{\"t\":30,\"i\":0}} trailing",
+            "{\"$timestamp\":{\"t\":30,\"i\":0}"
+    })
+    void shouldRejectInvalidTimestamp(String value) {
+        assertThatThrownBy(() -> BsonTimestampParser.parse(value)).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
@@ -6,18 +6,24 @@
 package io.debezium.connector.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.bson.BsonTimestamp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import io.debezium.config.Configuration;
@@ -25,6 +31,86 @@ import io.debezium.config.Field;
 import io.debezium.data.Envelope;
 
 public class MongoDbConnectorConfigTest {
+
+    @Test
+    void shouldExposeCaptureStartFields() {
+        final var configDef = new MongoDbConnector().config();
+        for (var field : new Field[]{ MongoDbConnectorConfig.CAPTURE_START_OP_TIME, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP }) {
+            assertThat(MongoDbConnectorConfig.ALL_FIELDS.fieldWithName(field.name())).isNotNull();
+            assertThat(configDef.configKeys()).containsKey(field.name());
+        }
+    }
+
+    @Test
+    void shouldLeaveStartTimeUnspecifiedByDefault() {
+        assertThat(new MongoDbConnectorConfig(TestHelper.getConfiguration()).startAtOperationTime()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { 30L, 7684060705770700807L, Long.MIN_VALUE })
+    void shouldPreservePackedOperationTime(long value) {
+        final var config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, value)
+                .build();
+        assertThat(new MongoDbConnectorConfig(config).startAtOperationTime()).contains(new BsonTimestamp(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "1789084800", "2026-09-11T09:00:00+09:00", "{\"$timestamp\":{\"t\":1789084800,\"i\":0}}" })
+    void shouldUseReadableStartTimestamp(String value) {
+        final var config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value)
+                .build();
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP.name()).errorMessages()).isEmpty();
+        assertThat(new MongoDbConnectorConfig(config).startAtOperationTime()).contains(new BsonTimestamp(1789084800, 0));
+    }
+
+    @Test
+    void shouldAllowDisabledLegacyStartTimeWithReadableTimestamp() {
+        final var config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, -1L)
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "30")
+                .build();
+        assertThat(new MongoDbConnectorConfig(config).startAtOperationTime()).contains(new BsonTimestamp(30, 0));
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP.name()).errorMessages()).isEmpty();
+    }
+
+    @Test
+    void shouldRejectConflictingStartTimes() {
+        final var config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, new BsonTimestamp(30, 0).getValue())
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "30")
+                .build();
+        assertThat(connectorValidationErrors(config, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
+                .singleElement().asString().contains("Cannot be configured together with 'capture.start.op.time'");
+        assertThatThrownBy(() -> new MongoDbConnectorConfig(config))
+                .isInstanceOf(ConfigException.class).hasMessageContaining("capture.start.op.time");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "invalid", "30.5", "4294967296", "2026-09-11T00:00:00.001Z", "{\"$timestamp\":{\"t\":30,\"i\":-1}}" })
+    void shouldReportInvalidStartTimestampAsConfigurationError(String value) {
+        final var config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value)
+                .build();
+        assertThat(connectorValidationErrors(config, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).hasSize(1);
+        assertThatThrownBy(() -> new MongoDbConnectorConfig(config))
+                .isInstanceOf(ConfigException.class).hasMessageContaining("capture.start.timestamp");
+    }
+
+    @Test
+    void shouldValidateLegacyStartTimeType() {
+        final var config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, "invalid")
+                .build();
+        assertThat(connectorValidationErrors(config, MongoDbConnectorConfig.CAPTURE_START_OP_TIME)).hasSize(1);
+    }
+
+    private static List<String> connectorValidationErrors(Configuration config, Field field) {
+        return new MongoDbConnector().validate(config.asMap()).configValues().stream()
+                .filter(value -> value.name().equals(field.name()))
+                .findFirst().orElseThrow().errorMessages();
+    }
 
     @Test
     void parseSignallingMessage() {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
@@ -15,7 +15,9 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -23,11 +25,13 @@ import org.bson.BsonTimestamp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.connector.mongodb.connection.MongoDbConnectionContext;
 import io.debezium.data.Envelope;
 
 public class MongoDbConnectorConfigTest {
@@ -81,7 +85,11 @@ public class MongoDbConnectorConfigTest {
                 .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, new BsonTimestamp(30, 0).getValue())
                 .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "30")
                 .build();
-        assertThat(connectorValidationErrors(config, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
+        final var connector = new ConnectionValidationConnector();
+        final var validation = connector.validate(config.asMap());
+        assertThat(connector.connectionConfig).isNull();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING)).isEmpty();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
                 .singleElement().asString().contains("Cannot be configured together with 'capture.start.op.time'");
         assertThatThrownBy(() -> new MongoDbConnectorConfig(config))
                 .isInstanceOf(ConfigException.class).hasMessageContaining("capture.start.op.time");
@@ -93,7 +101,11 @@ public class MongoDbConnectorConfigTest {
         final var config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value)
                 .build();
-        assertThat(connectorValidationErrors(config, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).hasSize(1);
+        final var connector = new ConnectionValidationConnector();
+        final var validation = connector.validate(config.asMap());
+        assertThat(connector.connectionConfig).isNull();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING)).isEmpty();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).hasSize(1);
         assertThatThrownBy(() -> new MongoDbConnectorConfig(config))
                 .isInstanceOf(ConfigException.class).hasMessageContaining("capture.start.timestamp");
     }
@@ -103,13 +115,82 @@ public class MongoDbConnectorConfigTest {
         final var config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, "invalid")
                 .build();
-        assertThat(connectorValidationErrors(config, MongoDbConnectorConfig.CAPTURE_START_OP_TIME)).hasSize(1);
+        final var connector = new ConnectionValidationConnector();
+        final var validation = connector.validate(config.asMap());
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_OP_TIME)).hasSize(1);
+        assertThat(connector.connectionConfig).isNotNull();
+        assertThat(connector.connectionConfig.startAtOperationTime()).isEmpty();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING))
+                .containsExactly(ConnectionValidationConnector.CONNECTION_ERROR);
     }
 
-    private static List<String> connectorValidationErrors(Configuration config, Field field) {
-        return new MongoDbConnector().validate(config.asMap()).configValues().stream()
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "30")
+    void shouldValidateConnectionWithValidStartTimestamp(String value) {
+        final var builder = TestHelper.getConfiguration().edit();
+        if (value != null) {
+            builder.with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value);
+        }
+        final var config = builder.build();
+        final var connector = new ConnectionValidationConnector();
+        final var validation = connector.validate(config.asMap());
+        assertThat(connector.connectionConfig).isNotNull();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).isEmpty();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING))
+                .containsExactly(ConnectionValidationConnector.CONNECTION_ERROR);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "30")
+    void shouldValidateConnectionWithUnrelatedFieldError(String value) {
+        final var builder = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, "invalid");
+        if (value != null) {
+            builder.with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value);
+        }
+        final var config = builder.build();
+        final var connector = new ConnectionValidationConnector();
+        final var validation = connector.validate(config.asMap());
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.SNAPSHOT_MODE)).hasSize(1);
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).isEmpty();
+        assertThat(connector.connectionConfig).isNotNull();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING))
+                .containsExactly(ConnectionValidationConnector.CONNECTION_ERROR);
+    }
+
+    @Test
+    void shouldSkipConnectionValidationWithInvalidConnectionString() {
+        final var config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CONNECTION_STRING, "invalid")
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "30")
+                .build();
+        final var connector = new ConnectionValidationConnector();
+        final var validation = connector.validate(config.asMap());
+        assertThat(connector.connectionConfig).isNull();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING))
+                .isNotEmpty().doesNotContain(ConnectionValidationConnector.CONNECTION_ERROR);
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).isEmpty();
+    }
+
+    private static List<String> validationErrors(Config validation, Field field) {
+        return validation.configValues().stream()
                 .filter(value -> value.name().equals(field.name()))
                 .findFirst().orElseThrow().errorMessages();
+    }
+
+    private static class ConnectionValidationConnector extends MongoDbConnector {
+        private static final String CONNECTION_ERROR = "Unable to connect: test connection failure";
+
+        private MongoDbConnectorConfig connectionConfig;
+
+        @Override
+        public void validateConnection(Configuration config, ConfigValue connectionStringValidation) {
+            // Exercise configuration construction without opening a MongoDB connection.
+            connectionConfig = new MongoDbConnectionContext(config).getConnectorConfig();
+            connectionStringValidation.addErrorMessage(CONNECTION_ERROR);
+        }
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
@@ -90,9 +90,10 @@ public class MongoDbConnectorConfigTest {
         assertThat(connector.connectionConfig).isNull();
         assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING)).isEmpty();
         assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
-                .singleElement().asString().contains("Cannot be configured together with 'capture.start.op.time'");
+                .containsExactly("The 'capture.start.timestamp' value is invalid: Cannot be configured together with 'capture.start.op.time'");
         assertThatThrownBy(() -> new MongoDbConnectorConfig(config))
-                .isInstanceOf(ConfigException.class).hasMessageContaining("capture.start.op.time");
+                .isInstanceOf(ConfigException.class)
+                .hasMessage("Invalid value 30 for configuration capture.start.timestamp: Cannot be configured together with 'capture.start.op.time'");
     }
 
     @ParameterizedTest
@@ -105,9 +106,13 @@ public class MongoDbConnectorConfigTest {
         final var validation = connector.validate(config.asMap());
         assertThat(connector.connectionConfig).isNull();
         assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING)).isEmpty();
-        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).hasSize(1);
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
+                .singleElement().asString()
+                .startsWith("The 'capture.start.timestamp' value is invalid: ")
+                .doesNotContain("Invalid value", "for configuration");
         assertThatThrownBy(() -> new MongoDbConnectorConfig(config))
-                .isInstanceOf(ConfigException.class).hasMessageContaining("capture.start.timestamp");
+                .isInstanceOf(ConfigException.class)
+                .hasMessageStartingWith("Invalid value " + value + " for configuration capture.start.timestamp: ");
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
@@ -47,16 +47,21 @@ public class MongoDbConnectorConfigTest {
 
     @Test
     void shouldLeaveStartTimeUnspecifiedByDefault() {
-        assertThat(new MongoDbConnectorConfig(TestHelper.getConfiguration()).startAtOperationTime()).isEmpty();
+        final var config = TestHelper.getConfiguration();
+        assertThat(new MongoDbConnectorConfig(config).startAtOperationTime()).isEmpty();
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_OP_TIME.name()).errorMessages()).isEmpty();
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP.name()).errorMessages()).isEmpty();
     }
 
     @ParameterizedTest
-    @ValueSource(longs = { 30L, 7684060705770700807L, Long.MIN_VALUE })
+    @ValueSource(longs = { 0L, 30L, 7684060705770700807L, Long.MIN_VALUE, Long.MAX_VALUE })
     void shouldPreservePackedOperationTime(long value) {
         final var config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, value)
                 .build();
         assertThat(new MongoDbConnectorConfig(config).startAtOperationTime()).contains(new BsonTimestamp(value));
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_OP_TIME.name()).errorMessages()).isEmpty();
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP.name()).errorMessages()).isEmpty();
     }
 
     @ParameterizedTest
@@ -66,6 +71,7 @@ public class MongoDbConnectorConfigTest {
                 .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value)
                 .build();
         assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP.name()).errorMessages()).isEmpty();
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_OP_TIME.name()).errorMessages()).isEmpty();
         assertThat(new MongoDbConnectorConfig(config).startAtOperationTime()).contains(new BsonTimestamp(1789084800, 0));
     }
 
@@ -77,13 +83,15 @@ public class MongoDbConnectorConfigTest {
                 .build();
         assertThat(new MongoDbConnectorConfig(config).startAtOperationTime()).contains(new BsonTimestamp(30, 0));
         assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP.name()).errorMessages()).isEmpty();
+        assertThat(config.validate(MongoDbConnectorConfig.ALL_FIELDS).get(MongoDbConnectorConfig.CAPTURE_START_OP_TIME.name()).errorMessages()).isEmpty();
     }
 
-    @Test
-    void shouldRejectConflictingStartTimes() {
+    @ParameterizedTest
+    @ValueSource(strings = { "30", "", "invalid" })
+    void shouldRejectConflictingStartTimes(String value) {
         final var config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, new BsonTimestamp(30, 0).getValue())
-                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "30")
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value)
                 .build();
         final var connector = new ConnectionValidationConnector();
         final var validation = connector.validate(config.asMap());
@@ -91,9 +99,11 @@ public class MongoDbConnectorConfigTest {
         assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING)).isEmpty();
         assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
                 .containsExactly("The 'capture.start.timestamp' value is invalid: Cannot be configured together with 'capture.start.op.time'");
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_OP_TIME))
+                .containsExactly("The 'capture.start.op.time' value is invalid: Cannot be configured together with 'capture.start.timestamp'");
         assertThatThrownBy(() -> new MongoDbConnectorConfig(config))
                 .isInstanceOf(ConfigException.class)
-                .hasMessage("Invalid value 30 for configuration capture.start.timestamp: Cannot be configured together with 'capture.start.op.time'");
+                .hasMessage("Invalid value " + value + " for configuration capture.start.timestamp: Cannot be configured together with 'capture.start.op.time'");
     }
 
     @ParameterizedTest
@@ -106,6 +116,7 @@ public class MongoDbConnectorConfigTest {
         final var validation = connector.validate(config.asMap());
         assertThat(connector.connectionConfig).isNull();
         assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING)).isEmpty();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_OP_TIME)).isEmpty();
         assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
                 .singleElement().asString()
                 .startsWith("The 'capture.start.timestamp' value is invalid: ")
@@ -115,18 +126,42 @@ public class MongoDbConnectorConfigTest {
                 .hasMessageStartingWith("Invalid value " + value + " for configuration capture.start.timestamp: ");
     }
 
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "30")
+    void shouldValidateLegacyStartTimeType(String value) {
+        final var builder = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, "invalid");
+        if (value != null) {
+            builder.with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, value);
+        }
+        final var config = builder.build();
+        final var connector = new ConnectionValidationConnector();
+        final var validation = connector.validate(config.asMap());
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_OP_TIME))
+                .containsExactly("The 'capture.start.op.time' value is invalid: A long value is expected");
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP)).isEmpty();
+        assertThat(connector.connectionConfig).isNotNull();
+        assertThat(connector.connectionConfig.startAtOperationTime())
+                .isEqualTo(value == null ? Optional.empty() : Optional.of(new BsonTimestamp(30, 0)));
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING))
+                .containsExactly(ConnectionValidationConnector.CONNECTION_ERROR);
+    }
+
     @Test
-    void shouldValidateLegacyStartTimeType() {
+    void shouldReportMalformedStartTimesOnTheirOwnFields() {
         final var config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, "invalid")
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "invalid")
                 .build();
         final var connector = new ConnectionValidationConnector();
         final var validation = connector.validate(config.asMap());
-        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_OP_TIME)).hasSize(1);
-        assertThat(connector.connectionConfig).isNotNull();
-        assertThat(connector.connectionConfig.startAtOperationTime()).isEmpty();
-        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING))
-                .containsExactly(ConnectionValidationConnector.CONNECTION_ERROR);
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_OP_TIME))
+                .containsExactly("The 'capture.start.op.time' value is invalid: A long value is expected");
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP))
+                .singleElement().asString().startsWith("The 'capture.start.timestamp' value is invalid: Expected integer Unix seconds");
+        assertThat(connector.connectionConfig).isNull();
+        assertThat(validationErrors(validation, MongoDbConnectorConfig.CONNECTION_STRING)).isEmpty();
     }
 
     @ParameterizedTest

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -38,11 +40,14 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.awaitility.Awaitility;
 import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.mongodb.DBRef;
 import com.mongodb.client.ClientSession;
@@ -872,40 +877,46 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         assertThat(deleteId).isEqualTo(id.get());
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = { "packed", "unix", "iso", "extended" })
     /*
      * Verifies that streaming starts from the specified timestamp.
      *
      * The following procedure is used:
-     * 1) Two documents are inserted,
+     * 1) Two documents are inserted (in different seconds for Unix and ISO inputs),
      * 2) Capture timestamp is retrieved (insert of the second doc)
      * 3) Insert additional document
      *
      * Connector should capture only second and third insert
      */
-    public void shouldConsumeEventsFromTimestamp() throws InterruptedException, IOException {
+    public void shouldConsumeEventsFromTimestamp(String format) throws InterruptedException {
         // Cleanup database
         TestHelper.cleanDatabase(mongo, "dbit");
 
         // insert some data
-        long startOpTime = -1;
+        final BsonTimestamp startOpTime;
         var expectedDocs = List.of(
                 Document.parse("{\"_id\": 0}"),
                 Document.parse("{\"_id\": 1}"),
                 Document.parse("{\"_id\": 2}"));
-        try (var client = connect()) {
+        try (var client = connect(); var session = client.startSession()) {
             var db = client.getDatabase("dbit");
-            // insert two documents
-            db.getCollection("test").insertOne(expectedDocs.get(0));
-            db.getCollection("test").insertOne(expectedDocs.get(1));
+            db.getCollection("test").insertOne(session, expectedDocs.get(0));
+            final var firstInsertSecond = Integer.toUnsignedLong(session.getOperationTime().getTime());
 
-            // get capture start timestamps
-            var serverStatus = db.runCommand(new Document("serverStatus", 1), BsonDocument.class);
-            startOpTime = serverStatus.getTimestamp("operationTime").getValue();
+            // Unix and ISO timestamps start at the beginning of a second, so keep the excluded insert in an earlier second.
+            if ("unix".equals(format) || "iso".equals(format)) {
+                Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> db.runCommand(new Document("serverStatus", 1))
+                        .getDate("localTime").toInstant().getEpochSecond() > firstInsertSecond);
+            }
+            db.getCollection("test").insertOne(session, expectedDocs.get(1));
+            startOpTime = session.getOperationTime();
 
             // insert additional document
             db.getCollection("test").insertOne(expectedDocs.get(2));
         }
+
+        final var startTimeValue = formatStartTimestamp(format, startOpTime);
 
         // Use the DB configuration to define the connector's configuration ...
         config = TestHelper.getConfiguration(mongo).edit()
@@ -913,7 +924,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
                 .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NO_DATA)
-                .with(MongoDbConnectorConfig.CAPTURE_START_OP_TIME, startOpTime)
+                .with("packed".equals(format) ? MongoDbConnectorConfig.CAPTURE_START_OP_TIME : MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, startTimeValue)
                 .build();
 
         // Set up the replication context for connections ...
@@ -924,7 +935,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         waitForStreamingRunning("mongodb", "mongo");
 
         // Check consumed records
-        final SourceRecords records = consumeAvailableRecordsByTopic();
+        final SourceRecords records = consumeRecordsByTopic(2);
         assertThat(records.allRecordsInOrder().size()).isEqualTo(2);
         assertNoRecordsToConsume();
 
@@ -935,6 +946,140 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
                 .toList();
         assertThat(actualDocs.get(0)).isEqualTo(expectedDocs.get(1));
         assertThat(actualDocs.get(1)).isEqualTo(expectedDocs.get(2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "packed", "unix", "iso", "extended" })
+    void shouldRespectTimestampIncrementWithinSameSecond(String format) throws InterruptedException {
+        record TimestampedInserts(String collectionName, List<BsonTimestamp> timestamps) {
+        }
+        final List<Document> documents = List.of(
+                new Document("_id", "earlier"),
+                new Document("_id", "boundary"),
+                new Document("_id", "after"));
+        final TimestampedInserts inserts;
+        try (var client = connect(); var session = client.startSession()) {
+            final var database = client.getDatabase("dbit");
+            final var attempt = new AtomicInteger();
+            // Retry only data preparation if the inserts cross a second boundary. Each attempt uses an isolated namespace.
+            inserts = Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> {
+                final var collectionName = "timestamp" + attempt.getAndIncrement();
+                final var collection = database.getCollection(collectionName);
+                final List<BsonTimestamp> timestamps = new ArrayList<>();
+                for (var document : documents) {
+                    collection.insertOne(session, document);
+                    timestamps.add(session.getOperationTime());
+                }
+                return new TimestampedInserts(collectionName, timestamps);
+            }, candidate -> candidate.timestamps().stream()
+                    .allMatch(timestamp -> timestamp.getTime() == candidate.timestamps().get(0).getTime()));
+        }
+
+        final var timestamps = inserts.timestamps();
+        final var startTimestamp = timestamps.get(1);
+        assertThat(timestamps).extracting(BsonTimestamp::getTime).containsOnly(startTimestamp.getTime());
+        assertThat(Integer.toUnsignedLong(timestamps.get(0).getInc())).isLessThan(Integer.toUnsignedLong(startTimestamp.getInc()));
+        assertThat(Integer.toUnsignedLong(timestamps.get(2).getInc())).isGreaterThan(Integer.toUnsignedLong(startTimestamp.getInc()));
+
+        config = TestHelper.getConfiguration(mongo).edit()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit\\." + inserts.collectionName())
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NO_DATA)
+                .with("packed".equals(format) ? MongoDbConnectorConfig.CAPTURE_START_OP_TIME : MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP,
+                        formatStartTimestamp(format, startTimestamp))
+                .build();
+
+        start(MongoDbConnector.class, config);
+        waitForStreamingRunning("mongodb", "mongo");
+
+        // Whole-second inputs include the earlier insert; precise BSON timestamps include the boundary and later insert only.
+        final var expectedDocuments = "unix".equals(format) || "iso".equals(format) ? documents : documents.subList(1, 3);
+        final var records = consumeRecordsByTopic(expectedDocuments.size());
+        final var actualDocuments = records.allRecordsInOrder().stream()
+                .map(record -> Document.parse(((Struct) record.value()).getString("after")))
+                .toList();
+        assertThat(actualDocuments).containsExactlyElementsOf(expectedDocuments);
+        assertNoRecordsToConsume();
+    }
+
+    private static String formatStartTimestamp(String format, BsonTimestamp timestamp) {
+        return switch (format) {
+            case "packed" -> Long.toString(timestamp.getValue());
+            case "unix" -> Integer.toUnsignedString(timestamp.getTime());
+            case "iso" -> Instant.ofEpochSecond(Integer.toUnsignedLong(timestamp.getTime())).toString();
+            case "extended" -> "{\"$timestamp\":{\"t\":%s,\"i\":%s}}".formatted(
+                    Integer.toUnsignedString(timestamp.getTime()), Integer.toUnsignedString(timestamp.getInc()));
+            default -> throw new IllegalArgumentException("Unknown timestamp format: " + format);
+        };
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldResumeFromOffsetBeforeConfiguredTimestamp(boolean hasResumeToken) throws InterruptedException {
+        final BsonDocument resumeToken;
+        final BsonTimestamp operationTime;
+        try (var client = connect()) {
+            final var collection = client.getDatabase("dbit").getCollection("test");
+            collection.insertOne(new Document("_id", 0));
+            try (var cursor = collection.watch().cursor()) {
+                collection.insertOne(new Document("_id", 1));
+                final var event = cursor.next();
+                resumeToken = event.getResumeToken();
+                operationTime = event.getClusterTime();
+            }
+            collection.insertOne(new Document("_id", 2));
+        }
+        config = TestHelper.getConfiguration(mongo).edit()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.test")
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NO_DATA)
+                // Startup log position validation requires a resume token; exercise timestamp-only streaming separately.
+                .with(CommonConnectorConfig.LOG_POSITION_CHECK_ENABLED, hasResumeToken)
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "2106-02-07T06:28:15Z")
+                .build();
+        final Map<String, Object> offset = new HashMap<>(Map.of(
+                SourceInfo.TIMESTAMP, operationTime.getTime(),
+                SourceInfo.ORDER, operationTime.getInc()));
+        if (hasResumeToken) {
+            offset.put(SourceInfo.RESUME_TOKEN, ResumeTokens.toBase64(resumeToken));
+        }
+        storeOffsets(config, Map.of(Map.of("server_id", "mongo"), offset));
+
+        start(MongoDbConnector.class, config);
+        waitForStreamingRunning("mongodb", "mongo");
+
+        final var records = consumeRecordsByTopic(hasResumeToken ? 1 : 2);
+        final var documents = records.allRecordsInOrder().stream()
+                .map(record -> Document.parse(((Struct) record.value()).getString("after")))
+                .toList();
+        // Timestamp-based resumption is inclusive; resumeAfter excludes the already processed event.
+        assertThat(documents).containsExactlyElementsOf(hasResumeToken
+                ? List.of(new Document("_id", 2))
+                : List.of(new Document("_id", 1), new Document("_id", 2)));
+        assertNoRecordsToConsume();
+    }
+
+    @Test
+    void shouldSnapshotBeforeStreamingWithConfiguredTimestamp() throws InterruptedException {
+        insertDocuments("dbit", "test", new Document("_id", 0));
+        config = TestHelper.getConfiguration(mongo).edit()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.test")
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.INITIAL)
+                .with(MongoDbConnectorConfig.CAPTURE_START_TIMESTAMP, "2106-02-07T06:28:15Z")
+                .build();
+
+        start(MongoDbConnector.class, config);
+        final var snapshotRecords = consumeRecordsByTopic(1);
+        assertThat(((Struct) snapshotRecords.allRecordsInOrder().get(0).value()).getString("op")).isEqualTo("r");
+        waitForStreamingRunning("mongodb", "mongo");
+
+        insertDocuments("dbit", "test", new Document("_id", 1));
+        final var streamingRecords = consumeRecordsByTopic(1);
+        final var value = (Struct) streamingRecords.allRecordsInOrder().get(0).value();
+        assertThat(value.getString("op")).isEqualTo("c");
+        assertThat(Document.parse(value.getString("after"))).isEqualTo(new Document("_id", 1));
+        assertNoRecordsToConsume();
     }
 
     @Test

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1619,13 +1619,17 @@ For the complete list of BSON type representations, see the MongoDB documentatio
 This setting does not affect the representation of document identifiers in change event keys.
 
 |[[mongodb-property-capture-start-op-time]]<<mongodb-property-capture-start-op-time, `+capture.start.op.time+`>>
-|No default value
+|`-1` (disabled)
 |Specifies the https://www.mongodb.com/docs/manual/changeStreams/#ref-start-time-id1[startAtOperationTime] change stream parameter.
-Set the value to be a long representation of the BSON timestamp.
+Set the value to the packed 64-bit long representation of a BSON timestamp, which contains both seconds and the operation increment.
+This value is not a Unix timestamp in seconds or milliseconds.
+The connector uses it only if no offset is available when streaming starts.
+For readable timestamp formats, use xref:mongodb-property-capture-start-timestamp[`capture.start.timestamp`].
+You cannot configure both properties unless `capture.start.op.time` is `-1` (disabled).
 
 [IMPORTANT]
 ====
-The ability to set the `capture.start.op.time`` property to override the normal offset-based behavior and begin streaming from a specific timestamp is a Technology Preview feature.
+The ability to set the `capture.start.op.time` property to begin streaming from a specific timestamp when no offset is available is a Technology Preview feature.
 Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete.
 Red{nbsp}Hat does not recommend using them in production.
 These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
@@ -1633,6 +1637,45 @@ These features provide early access to upcoming product features, enabling custo
 For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 
 ====
+
+|[[mongodb-property-capture-start-timestamp]]<<mongodb-property-capture-start-timestamp, `+capture.start.timestamp+`>>
+|No default value
+|Specifies the starting position for a change stream when no offset is available.
+This property is an alternative to xref:mongodb-property-capture-start-op-time[`capture.start.op.time`] and has the same Technology Preview status.
+Set the value to a string in one of the following formats:
+
+* Integer Unix seconds, for example, `1789084800`.
+* ISO-8601 with `Z` or an explicit UTC offset, for example, `2026-09-11T00:00:00Z` or `2026-09-11T09:00:00+09:00`.
+* A BSON timestamp in Extended JSON v2 format, for example, `{"$timestamp":{"t":1789084800,"i":7}}`.
+
+Unix seconds and ISO-8601 values use an operation increment of `0`, so capture starts at the beginning of the specified second.
+Extended JSON preserves the `i` value, which is an operation increment within a second, not a fractional second.
+Events at the specified BSON timestamp are included.
+
+Seconds and the Extended JSON `i` value must be integers in the range `0` through `4294967295`.
+For ISO-8601 values, the corresponding UTC instant must be between `1970-01-01T00:00:00Z` and `2106-02-07T06:28:15Z`, inclusive.
+Nonzero fractional seconds, timestamps without a UTC offset, and out-of-range values cause configuration errors.
+Numeric values are always interpreted as seconds; Unix milliseconds are not supported.
+An ISO-8601 fractional part containing only zeros, such as `.000`, is accepted.
+You cannot configure this property together with `capture.start.op.time` unless that property is `-1` (disabled).
+
+To start streaming from the configured timestamp without an initial snapshot, set xref:mongodb-property-snapshot-mode[`snapshot.mode`] to `no_data` and use a connector with no stored offset.
+For example:
+
+[source,json]
+----
+{
+  "snapshot.mode": "no_data",
+  "capture.start.timestamp": "2026-09-11T00:00:00Z"
+}
+----
+
+A stored resume token or offset timestamp takes precedence over this property.
+Changing the property does not rewind an existing connector.
+If the connector performs a snapshot, streaming uses the position established by the snapshot.
+This setting does not create a historical snapshot.
+MongoDB must still retain the requested starting position in the oplog; configuring a timestamp does not restore expired oplog history.
+
 |[[mongodb-property-capture-scope]]<<mongodb-property-capture-scope, `+capture.scope+`>>
 |`deployment`
 |Specifies the https://www.mongodb.com/docs/manual/changeStreams/#watch-a-collection--database--or-deployment[scope of the change streams] that the connector opens.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1658,6 +1658,7 @@ Nonzero fractional seconds, timestamps without a UTC offset, and out-of-range va
 Numeric values are always interpreted as seconds; Unix milliseconds are not supported.
 An ISO-8601 fractional part containing only zeros, such as `.000`, is accepted.
 You cannot configure this property together with `capture.start.op.time` unless that property is `-1` (disabled).
+Configuration validation reports conflicting settings as errors on both properties.
 
 To start streaming from the configured timestamp without an initial snapshot, set xref:mongodb-property-snapshot-mode[`snapshot.mode`] to `no_data` and use a connector with no stored offset.
 For example:


### PR DESCRIPTION
Fixes debezium/dbz#2610

## Description

The MongoDB connector's existing `capture.start.op.time` setting requires a packed BSON timestamp. Add `capture.start.timestamp` so users can instead specify integer Unix seconds, ISO-8601 with a UTC offset, or BSON Timestamp Extended JSON v2.

For example, a new connector can start without an initial snapshot using:

```json
{
  "snapshot.mode": "no_data",
  "capture.start.timestamp": "2026-09-11T00:00:00Z"
}
```

Unix seconds and ISO-8601 start at the beginning of the specified second; Extended JSON preserves the operation increment. Preserve the existing packed setting, stored-offset precedence, and snapshot-established streaming position. Reject conflicting settings, nonzero fractional seconds, malformed input, and unsigned 32-bit overflow during configuration validation.

Register both starting-position settings in the connector's configuration definition and avoid connection validation when field validation has already failed, so invalid timestamp settings return configuration errors. Document the formats, boundaries, and existing Technology Preview status.

## Validation

* JDK 21 / MongoDB 8.0: MongoDB module and dependencies built with `clean install -Passembly`, with 85 selected unit tests and 13 integration test cases passing.
* Integration tests verify all four input representations, inclusive boundaries within the same second, stored-offset precedence, and snapshot-established starting positions.
* JaCoCo: the timestamp parser has 100% line and branch coverage (30/30 lines, 30/30 branches); the starting-position resolver covers 11/11 lines and 8/8 branches.
* A Kafka Connect Docker run passed 21 checks, including actual Kafka records, worker restart with stored offsets, snapshots, and REST configuration validation.

The full-reactor `./mvnw clean install` was stopped after MySQL integration tests reported `Access denied for user 'mysqluser'@'localhost'`. The selected MongoDB reactor build above subsequently passed on the rebased branch. Remaining full-suite validation is left to PR CI.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

AI assistance: Codex assisted with investigation, implementation, testing, and PR preparation.
