### PR TITLE
debezium/dbz#2611 Do not pass a null throwable to super.isRetriable

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -514,6 +514,7 @@ Mathijs van den Worm
 Matt Bayley
 Matt Beary
 Matt Hejnas
+Matt Langley
 Matt Vance
 Matteo Capitanio
 Matthias Crauwels

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbErrorHandler.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbErrorHandler.java
@@ -37,13 +37,12 @@ public class MariaDbErrorHandler extends ErrorHandler {
 
     @Override
     protected boolean isRetriable(Throwable throwable) {
-        while (throwable != null) {
-            if (throwable instanceof SQLException sqlException) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof SQLException sqlException) {
                 if (NON_RETRIABLE_ERROR_CODES.contains(sqlException.getErrorCode())) {
                     return false;
                 }
             }
-            throwable = throwable.getCause();
         }
         return super.isRetriable(throwable);
     }

--- a/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbErrorHandlerTest.java
+++ b/debezium-connector-mariadb/src/test/java/io/debezium/connector/mariadb/MariaDbErrorHandlerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mariadb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.DataChangeEvent;
+
+public class MariaDbErrorHandlerTest {
+
+    private static final int ER_MASTER_FATAL_ERROR_READING_BINLOG = 1236;
+
+    private final MariaDbErrorHandler errorHandler = new MariaDbErrorHandler(
+            new MariaDbConnectorConfig(Configuration.create()
+                    .with(MariaDbConnectorConfig.HOSTNAME, "localhost")
+                    .with(MariaDbConnectorConfig.PORT, 3306)
+                    .with(MariaDbConnectorConfig.USER, "mariadbuser")
+                    .with(MariaDbConnectorConfig.PASSWORD, "mariadbpw")
+                    .with(MariaDbConnectorConfig.SERVER_ID, 18765)
+                    .with(MariaDbConnectorConfig.TOPIC_PREFIX, "mariadb-server")
+                    .build()),
+            new ChangeEventQueue.Builder<DataChangeEvent>().build(), null);
+
+    @Test
+    @FixFor("debezium/dbz#2611")
+    void ioExceptionIsRetriable() {
+        assertThat(errorHandler.isRetriable(new IOException("connection reset"))).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2611")
+    void wrappedEofExceptionIsRetriable() {
+        final Throwable throwable = new DebeziumException(new EOFException("Failed to read next byte from position 1"));
+        assertThat(errorHandler.isRetriable(throwable)).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2611")
+    void sqlExceptionWithoutNonRetriableCodeIsRetriable() {
+        assertThat(errorHandler.isRetriable(new SQLException("communications link failure", "08S01", 0))).isTrue();
+    }
+
+    @Test
+    void binlogReadErrorIsNotRetriable() {
+        final SQLException sqlException = new SQLException("could not find next log", "HY000", ER_MASTER_FATAL_ERROR_READING_BINLOG);
+        assertThat(errorHandler.isRetriable(sqlException)).isFalse();
+    }
+
+    @Test
+    void wrappedBinlogReadErrorIsNotRetriable() {
+        final SQLException sqlException = new SQLException("could not find next log", "HY000", ER_MASTER_FATAL_ERROR_READING_BINLOG);
+        assertThat(errorHandler.isRetriable(new DebeziumException(sqlException))).isFalse();
+    }
+
+    @Test
+    void unrelatedExceptionIsNotRetriable() {
+        assertThat(errorHandler.isRetriable(new NullPointerException())).isFalse();
+    }
+
+    @Test
+    void nullThrowableIsNotRetriable() {
+        assertThat(errorHandler.isRetriable(null)).isFalse();
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
@@ -37,13 +37,12 @@ public class MySqlErrorHandler extends ErrorHandler {
 
     @Override
     protected boolean isRetriable(Throwable throwable) {
-        while (throwable != null) {
-            if (throwable instanceof SQLException sqlException) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof SQLException sqlException) {
                 if (NON_RETRIABLE_ERROR_CODES.contains(sqlException.getErrorCode())) {
                     return false;
                 }
             }
-            throwable = throwable.getCause();
         }
         return super.isRetriable(throwable);
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlErrorHandlerTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlErrorHandlerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.DataChangeEvent;
+
+public class MySqlErrorHandlerTest {
+
+    private static final int ER_MASTER_FATAL_ERROR_READING_BINLOG = 1236;
+
+    private final MySqlErrorHandler errorHandler = new MySqlErrorHandler(
+            new MySqlConnectorConfig(Configuration.create()
+                    .with(MySqlConnectorConfig.HOSTNAME, "localhost")
+                    .with(MySqlConnectorConfig.PORT, 3306)
+                    .with(MySqlConnectorConfig.USER, "mysqluser")
+                    .with(MySqlConnectorConfig.PASSWORD, "mysqlpw")
+                    .with(MySqlConnectorConfig.SERVER_ID, 18765)
+                    .with(MySqlConnectorConfig.TOPIC_PREFIX, "mysql-server")
+                    .build()),
+            new ChangeEventQueue.Builder<DataChangeEvent>().build(), null);
+
+    @Test
+    @FixFor("debezium/dbz#2611")
+    void ioExceptionIsRetriable() {
+        assertThat(errorHandler.isRetriable(new IOException("connection reset"))).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2611")
+    void wrappedEofExceptionIsRetriable() {
+        final Throwable throwable = new DebeziumException(new EOFException("Failed to read next byte from position 1"));
+        assertThat(errorHandler.isRetriable(throwable)).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2611")
+    void sqlExceptionWithoutNonRetriableCodeIsRetriable() {
+        assertThat(errorHandler.isRetriable(new SQLException("communications link failure", "08S01", 0))).isTrue();
+    }
+
+    @Test
+    void binlogReadErrorIsNotRetriable() {
+        final SQLException sqlException = new SQLException("could not find next log", "HY000", ER_MASTER_FATAL_ERROR_READING_BINLOG);
+        assertThat(errorHandler.isRetriable(sqlException)).isFalse();
+    }
+
+    @Test
+    void wrappedBinlogReadErrorIsNotRetriable() {
+        final SQLException sqlException = new SQLException("could not find next log", "HY000", ER_MASTER_FATAL_ERROR_READING_BINLOG);
+        assertThat(errorHandler.isRetriable(new DebeziumException(sqlException))).isFalse();
+    }
+
+    @Test
+    void unrelatedExceptionIsNotRetriable() {
+        assertThat(errorHandler.isRetriable(new NullPointerException())).isFalse();
+    }
+
+    @Test
+    void nullThrowableIsNotRetriable() {
+        assertThat(errorHandler.isRetriable(null)).isFalse();
+    }
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -354,6 +354,7 @@ surya-dl,Surya Dhaneshwar
 suryadanny,Surya Dhaneshwar
 SyedMuhammadSufyian,Syed Muhammad Sufyian
 SylvainMarty,Sylvain Marty
+tarqu1n,Matt Langley
 Tayler,Tayler Dunn
 taylor-rolison,Taylor Rolison
 TechIsCool,David Beck


### PR DESCRIPTION
Fixes debezium/dbz#2611

`MySqlErrorHandler.isRetriable` and `MariaDbErrorHandler.isRetriable` reused the method
parameter as the cursor for the cause-chain walk. The loop exits only when the cursor is
`null`, so `super.isRetriable(throwable)` always received `null`, and
`ErrorHandler.isRetriable` returns `false` on `null`.

The effect: the `communicationExceptions()` override in both connectors was dead code, and
every error was treated as non-retriable. A dropped binlog connection stopped the task
instead of restarting it.

This restores a separate local cursor, as `PostgresErrorHandler.isPermanentError` already
does. The scan for error code 1236 keeps its own loop, because the base class only walks the
cause chain for the `communicationExceptions()` test.

Regressed in 464d8cf6 (DBZ-8786), first released in 3.1.0.CR1.

New unit tests, one class per connector, cover both directions: an `IOException`, a wrapped
`EOFException` and a plain `SQLException` are retriable; error code 1236, wrapped or not, is
still non-retriable.
