### PR TITLE
debezium/dbz#1957 Allow passwordless JDBC storage

### DIFF
--- a/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
+++ b/debezium-storage/debezium-storage-jdbc/src/main/java/io/debezium/storage/jdbc/JdbcCommonConfig.java
@@ -41,7 +41,6 @@ public class JdbcCommonConfig {
 
     public static final Field PROP_PASSWORD = Field.create(CONFIGURATION_FIELD_CONNECTION_GROUP + "password")
             .withDescription("Password of the database which will be used to access the database storage")
-            .withValidation(Field::isRequired)
             .withDeprecatedAliases(CONFIGURATION_FIELD_PREFIX_STRING + "password");
 
     private static final long DEFAULT_WAIT_RETRY_DELAY = 3000L;

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreTest.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/JdbcOffsetBackingStoreTest.java
@@ -44,7 +44,6 @@ public class JdbcOffsetBackingStoreTest {
         props = new HashMap<>();
         props.put("offset.storage.jdbc.url", "jdbc:sqlite:" + dbFile.getAbsolutePath());
         props.put("offset.storage.jdbc.user", "user");
-        props.put("offset.storage.jdbc.password", "pass");
         props.put("offset.storage.jdbc.offset.table.name", "offsets_jdbc");
         props.put("offset.storage.jdbc.offset.table.ddl", "CREATE TABLE %s (id VARCHAR(36) NOT NULL, " +
                 "offset_key VARCHAR(1255), offset_val VARCHAR(1255)," +

--- a/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryTest.java
+++ b/debezium-storage/debezium-storage-jdbc/src/test/java/io/debezium/storage/jdbc/history/JdbcSchemaHistoryTest.java
@@ -148,7 +148,6 @@ public class JdbcSchemaHistoryTest {
         history.configure(Configuration.create()
                 .with(SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING + JdbcSchemaHistoryConfig.PROP_JDBC_URL.name(), "jdbc:sqlite:" + dbFile)
                 .with(SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING + JdbcSchemaHistoryConfig.PROP_USER.name(), "user")
-                .with(SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING + JdbcSchemaHistoryConfig.PROP_PASSWORD.name(), "pass")
                 .build(), null, SchemaHistoryMetrics.NOOP, true);
         history.start();
     }
@@ -181,6 +180,12 @@ public class JdbcSchemaHistoryTest {
         history.initializeStorage();
         assertTrue(history.storageExists());
         assertFalse(history.exists());
+    }
+
+    @Test
+    public void shouldInitializeStorageWithoutPassword() {
+        history.initializeStorage();
+        assertTrue(history.storageExists());
     }
 
     @Test


### PR DESCRIPTION
Fixes debezium/dbz#1957 

## Description
This PR removes an unnecessary validation that blocks passwordless authentication with JDBC storage for offsets and schema history. Also adjusts the corresponding tests accordingly.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
